### PR TITLE
Support conditional compilation of modules

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		220432AF274E7BF800BAE645 /* SharedTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220432AE274E7BF800BAE645 /* SharedTypes.swift */; };
 		220432EA2753092C00BAE645 /* RustFnUsesOpaqueSwiftType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220432E92753092C00BAE645 /* RustFnUsesOpaqueSwiftType.swift */; };
 		220432EC27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220432EB27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift */; };
+		221E16B42786233600F94AC0 /* ConditionalCompilationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221E16B32786233600F94AC0 /* ConditionalCompilationTests.swift */; };
 		228FE5D52740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228FE5D42740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift */; };
 		228FE5D72740DB6A00805D9E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228FE5D62740DB6A00805D9E /* ContentView.swift */; };
 		228FE5D92740DB6D00805D9E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 228FE5D82740DB6D00805D9E /* Assets.xcassets */; };
@@ -52,6 +53,7 @@
 		220432AE274E7BF800BAE645 /* SharedTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTypes.swift; sourceTree = "<group>"; };
 		220432E92753092C00BAE645 /* RustFnUsesOpaqueSwiftType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustFnUsesOpaqueSwiftType.swift; sourceTree = "<group>"; };
 		220432EB27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustFnUsesOpaqueSwiftTypeTests.swift; sourceTree = "<group>"; };
+		221E16B32786233600F94AC0 /* ConditionalCompilationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalCompilationTests.swift; sourceTree = "<group>"; };
 		228FE5D12740DB6A00805D9E /* SwiftRustIntegrationTestRunner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftRustIntegrationTestRunner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		228FE5D42740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftRustIntegrationTestRunnerApp.swift; sourceTree = "<group>"; };
 		228FE5D62740DB6A00805D9E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -156,6 +158,7 @@
 				220432AE274E7BF800BAE645 /* SharedTypes.swift */,
 				220432EB27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift */,
 				22FD1C552753CB3F00F64281 /* SwiftFnUsesOpaqueRustTypeTests.swift */,
+				221E16B32786233600F94AC0 /* ConditionalCompilationTests.swift */,
 			);
 			path = SwiftRustIntegrationTestRunnerTests;
 			sourceTree = "<group>";
@@ -332,6 +335,7 @@
 				220432AF274E7BF800BAE645 /* SharedTypes.swift in Sources */,
 				220432EC27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift in Sources */,
 				228FE6502749C43100805D9E /* BooleanTests.swift in Sources */,
+				221E16B42786233600F94AC0 /* ConditionalCompilationTests.swift in Sources */,
 				22043295274ADA7A00BAE645 /* OptionTests.swift in Sources */,
 				228FE5E72740DB6D00805D9E /* StringTests.swift in Sources */,
 				228FE61227428A8D00805D9E /* OpaqueSwiftStructTests.swift in Sources */,
@@ -486,8 +490,10 @@
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../target/debug";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.0;
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.xcode.SwiftRustIntegrationTestRunner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG FOO";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/Headers/BridgingHeader.h";
 				SWIFT_VERSION = 5.0;

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/xcshareddata/xcschemes/SwiftRustIntegrationTestRunner.xcscheme
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/xcshareddata/xcschemes/SwiftRustIntegrationTestRunner.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "228FE5D02740DB6A00805D9E"
+               BuildableName = "SwiftRustIntegrationTestRunner.app"
+               BlueprintName = "SwiftRustIntegrationTestRunner"
+               ReferencedContainer = "container:SwiftRustIntegrationTestRunner.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "228FE5E12740DB6D00805D9E"
+               BuildableName = "SwiftRustIntegrationTestRunnerTests.xctest"
+               BlueprintName = "SwiftRustIntegrationTestRunnerTests"
+               ReferencedContainer = "container:SwiftRustIntegrationTestRunner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "228FE5D02740DB6A00805D9E"
+            BuildableName = "SwiftRustIntegrationTestRunner.app"
+            BlueprintName = "SwiftRustIntegrationTestRunner"
+            ReferencedContainer = "container:SwiftRustIntegrationTestRunner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "228FE5D02740DB6A00805D9E"
+            BuildableName = "SwiftRustIntegrationTestRunner.app"
+            BlueprintName = "SwiftRustIntegrationTestRunner"
+            ReferencedContainer = "container:SwiftRustIntegrationTestRunner.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/ASwiftStack.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/ASwiftStack.swift
@@ -30,15 +30,3 @@ public class ASwiftStack {
         UnsafeBufferPointer(start: self.as_ptr(), count: Int(self.len()))
     }
 }
-
-import SwiftUI
-struct SomeStruct {
-    @State private var reRender = 1
-}
-extension SomeStruct: View {
-    
-    var body: some View {
-        Text("Hi")
-    }
-    
-}

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ConditionalCompilationTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ConditionalCompilationTests.swift
@@ -1,0 +1,28 @@
+//
+//  SwiftFnUsesOpaqueRustTypeTests.swift
+//  SwiftRustIntegrationTestRunnerTests
+//
+//  Created by Frankie Nwafili on 11/28/21.
+//
+
+import XCTest
+@testable import SwiftRustIntegrationTestRunner
+
+
+class ConditionalCompilationTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    /// Call a function from a bridge module that is only exposed when the
+    /// "this_is_enabled" feature is enabled for the Rust crate.
+    /// We have that feature enabled by default, so we should be able to call the function.
+    func testConditionalCompilation() throws {
+        XCTAssertEqual(conditionally_exposed_fn(), 123)
+    }
+}

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
@@ -42,6 +42,3 @@ class OptionTests: XCTestCase {
         run_option_tests()
     }
 }
-
-
-

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [The Bridge Module](./bridge-module/README.md)
   - [Shared Structs](./bridge-module/structs/README.md)
   - [extern "Rust"](./bridge-module/extern-rust/README.md)
+  - [Conditional Compilation](./bridge-module/conditional-compilation/README.md)
 
 - [Built In Types](./built-in/README.md)
   - [Option<T> <---> Optional<T>](./built-in/option/README.md)

--- a/book/src/bridge-module/conditional-compilation/README.md
+++ b/book/src/bridge-module/conditional-compilation/README.md
@@ -1,0 +1,134 @@
+# Conditional Compilation
+
+You can use [the cfg attribute](https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute)
+in order to conditionally generate bindings.
+
+Here's an example of only generating some bindings when a "dev-utils" feature is enabled for the Rust crate.
+
+```rust
+struct App {
+    users: HashMap<u8, Userg>
+}
+
+struct User {
+    is_logged_in: bool
+}
+
+impl App {
+	fn new() -> Self {
+		App {
+		    users: HashMap::new()
+		}
+	}
+
+	#[cfg(feature = "dev-utils")]
+	fn create_logged_in_user(&mut self, user_id: u8);
+}
+
+mod ffi {
+	extern "Rust" {
+	    type App;
+
+        #[swift_bridge(init)]
+	    fn new() -> App;
+
+		fn create_logged_in_user(&mut self, user_id: u8)  {
+			let user = User {
+			    is_logged_in: true
+			};
+		    self.users.insert(user_id, user)
+		}
+	}
+}
+
+// This example module contains methods that are useful
+// during testing and in SwiftUI previews.
+// It is only available when the Rust crate is compiled with the "dev-utils" feature.
+#[swift_bridge::bridge]
+#[cfg(feature = "dev-utils")]
+mod ffi_dev_utils {
+	extern "Rust" {
+	    #[swift_bridge(import)]
+        type App;
+
+        fn create_logged_in_user(&mut self, user_id: u8);
+	}
+}
+```
+
+## Supported Conditions
+
+Here are the conditions that are currently supported.
+
+If you need a condition that isn't yet supported, please open an issue.
+
+#### #[cfg(feature = "some-feature")]
+
+```rust
+#[swift_bridge]
+mod ffi {
+    // The code generator will only generate the corresponding
+    // Swift and C code if the "extra-utils" feature is enabled.
+    #[cfg(feature = "extra-utils")]
+	extern "Rust" {
+        // ....
+    }
+}
+```
+
+## Locations
+
+Here are the different things that you can conditionally compile.
+
+#### Bridge module
+
+The bridge module can use the `cfg` attribute.
+
+At build time the `swift_bridge_build` library determines whether or not a module will be compiled.
+
+If not, we won't generate any of the corresponding C or Swift code for that module.
+
+```rust
+#[swift_bridge::bridge]
+// This module's bindings will only be available when the Rust crate is compiled with
+// the `ffi-extras` feature
+#[cfg(feature = "ffi-extras")]
+mod ffi_extras {
+  // ...
+}
+```
+
+#### extern "Rust" blocks
+
+<em>...This hasn't been implemented yet but should be easy...</em>
+
+Functions can methods can use the `#[cfg]` attribute.
+
+```rust
+#[swift_bridge::bridge]
+mod ffi {
+    #[cfg(all(unix, target_pointer_width = "32"))]
+	extern "Rust" {
+        // ...
+    }
+}
+```
+
+
+#### Rust functions amd methods
+
+<em>...This hasn't been implemented yet but should be easy...</em>
+
+Functions and methods can use the `#[cfg]` attribute.
+
+```rust
+#[swift_bridge::bridge]
+mod ffi {
+	extern "Rust" {
+	    // This function's will only be available when
+        // the Rust crate is compiled targetting Windows.
+        #[cfg(target_os = "windows")]
+	    fn play_solitaire();
+    }
+}
+```

--- a/crates/swift-bridge-ir/src/bridge_macro_attributes.rs
+++ b/crates/swift-bridge-ir/src/bridge_macro_attributes.rs
@@ -1,0 +1,48 @@
+use proc_macro2::Ident;
+use syn::parse::{Parse, ParseStream};
+use syn::{Path, Token};
+
+/// The `...` in
+/// `#\[swift_bridge::bridge(...)\]`
+pub struct SwiftBridgeModuleAttrs {
+    #[allow(missing_docs)]
+    pub attributes: Vec<SwiftBridgeModuleAttr>,
+}
+
+/// An attribute within a `#\[swift_bridge::bridge(...)\]`
+pub enum SwiftBridgeModuleAttr {
+    /// Sets the path for the actual swift bridge crate that contains different helpers such
+    /// as `RustString`.
+    /// `#\[swift_bridge::bridge(swift_bridge_path = swift_bridge)\]`
+    SwiftBridgePath(Path),
+}
+
+impl Parse for SwiftBridgeModuleAttrs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.is_empty() {
+            return Ok(SwiftBridgeModuleAttrs { attributes: vec![] });
+        }
+
+        let opts = syn::punctuated::Punctuated::<_, Token![,]>::parse_terminated(input)?;
+
+        Ok(SwiftBridgeModuleAttrs {
+            attributes: opts.into_iter().collect(),
+        })
+    }
+}
+
+impl Parse for SwiftBridgeModuleAttr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let key: Ident = input.parse()?;
+        let _equals = input.parse::<Token![=]>()?;
+
+        let attr = match key.to_string().as_str() {
+            "swift_bridge_path" => SwiftBridgeModuleAttr::SwiftBridgePath(input.parse()?),
+            _ => {
+                return Err(syn::Error::new(input.span(), "Unknown attribute."));
+            }
+        };
+
+        Ok(attr)
+    }
+}

--- a/crates/swift-bridge-ir/src/bridge_module_attributes.rs
+++ b/crates/swift-bridge-ir/src/bridge_module_attributes.rs
@@ -1,0 +1,36 @@
+use proc_macro2::Ident;
+use syn::parse::{Parse, ParseStream};
+use syn::LitStr;
+use syn::Token;
+
+/// A `cfg` attribute on a bridge module.
+///
+/// ```no_run
+/// #[swift_bridge::bridge]
+/// // This is a cfg attribute.
+/// #[cfg(feature = "some-feature")]
+/// mod ffi {
+/// }
+/// ```
+pub enum CfgAttr {
+    /// #\[cfg(feature = "...")\]
+    Feature(LitStr),
+}
+
+impl Parse for CfgAttr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let content;
+        syn::parenthesized!(content in input);
+        let ident: Ident = content.parse()?;
+
+        if &ident == "feature" {
+            content.parse::<Token![=]>()?;
+
+            let feature_name = content.parse::<LitStr>()?;
+
+            Ok(CfgAttr::Feature(feature_name))
+        } else {
+            todo!("Return an unsupported cfg kind error")
+        }
+    }
+}

--- a/crates/swift-bridge-ir/src/codegen.rs
+++ b/crates/swift-bridge-ir/src/codegen.rs
@@ -1,6 +1,61 @@
+use crate::bridge_module_attributes::CfgAttr;
+use crate::SwiftBridgeModule;
+
 mod generate_c_header;
 mod generate_rust_tokens;
 mod generate_swift;
 
 #[cfg(test)]
 mod codegen_tests;
+
+/// The corresponding Swift code and C header for a bridge module.
+pub struct SwiftCodeAndCHeader {
+    /// The generated Swift code.
+    pub swift: String,
+    /// The generated C header.
+    pub c_header: String,
+}
+
+/// Configuration for how we will generate our Swift code.
+pub struct CodegenConfig {
+    /// Look up whether or not a feature is enabled for the crate that holds the bridge module.
+    /// This helps us decide whether or not to generate code for parts of the module
+    /// that are annotated with `#[cfg(feature = "some-feature")]`
+    pub crate_feature_lookup: Box<dyn Fn(&str) -> bool>,
+}
+
+#[cfg(test)]
+impl CodegenConfig {
+    pub(crate) fn no_features_enabled() -> Self {
+        CodegenConfig {
+            crate_feature_lookup: Box::new(|_| false),
+        }
+    }
+}
+
+impl SwiftBridgeModule {
+    /// Generate the corresponding Swift code and C header for a bridge module.
+    pub fn generate_swift_code_and_c_header(&self, config: CodegenConfig) -> SwiftCodeAndCHeader {
+        SwiftCodeAndCHeader {
+            swift: self.generate_swift(&config),
+            c_header: self.generate_c_header(&config),
+        }
+    }
+
+    /// Whether or not the module's conditional compilation flags willl lead it to being included
+    /// in the final binary.
+    /// If not, when we won't generate any C or Swift code for it.
+    fn module_will_be_compiled(&self, config: &CodegenConfig) -> bool {
+        for cfg_attr in &self.cfg_attrs {
+            match cfg_attr {
+                CfgAttr::Feature(feature_name) => {
+                    if !(config.crate_feature_lookup)(&feature_name.value()) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        true
+    }
+}

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/conditional_compilation_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/conditional_compilation_codegen_tests.rs
@@ -1,0 +1,122 @@
+use super::{CodegenTest, ExpectedCHeader, ExpectedRustTokens, ExpectedSwiftCode};
+use quote::quote;
+
+/// Verify that we properly handle a `#[cfg(feature = "foo")]` for a bridge module when the
+/// feature is enabled.
+mod cfg_feature_bridge_module_feature_enabled {
+    use super::*;
+    use crate::codegen::codegen_tests::BridgeModule;
+
+    fn bridge_module() -> BridgeModule {
+        let tokens = quote! {
+            #[swift_bridge::bridge]
+            #[cfg(feature = "some-feature")]
+            mod ffi {
+                extern "Rust" {
+                    fn some_function();
+                }
+            }
+        };
+        BridgeModule {
+            tokens,
+            enabled_crate_features: vec!["some-feature"],
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::Contains(quote! {
+            #[cfg(feature = "some-feature")]
+            mod ffi {
+                #[export_name = "__swift_bridge__$some_function"]
+                pub extern "C" fn __swift_bridge__some_function() {
+                    super::some_function()
+                }
+            }
+        })
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(
+            r#"
+func some_function()
+"#,
+        )
+    }
+
+    const EXPECTED_C_HEADER: ExpectedCHeader = ExpectedCHeader::ExactAfterTrim(
+        r#"
+void __swift_bridge__$some_function(void);
+    "#,
+    );
+
+    #[test]
+    fn cfg_feature_bridge_module_feature_enabled() {
+        CodegenTest {
+            bridge_module: bridge_module(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: EXPECTED_C_HEADER,
+        }
+        .test();
+    }
+}
+
+/// Verify that we properly handle add `#[cfg(feature = "foo")]` for a bridge module when the
+/// feature is enabled.
+mod cfg_feature_bridge_module_feature_disabled {
+    use super::*;
+    use crate::codegen::codegen_tests::BridgeModule;
+
+    fn bridge_module() -> BridgeModule {
+        let tokens = quote! {
+            #[swift_bridge::bridge]
+            #[cfg(feature = "some-feature")]
+            mod ffi {
+                extern "Rust" {
+                    fn some_function();
+                }
+            }
+        };
+        BridgeModule {
+            tokens,
+            enabled_crate_features: vec![],
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::Contains(quote! {
+            #[cfg(feature = "some-feature")]
+            mod ffi {
+                #[export_name = "__swift_bridge__$some_function"]
+                pub extern "C" fn __swift_bridge__some_function() {
+                    super::some_function()
+                }
+            }
+        })
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::DoesNotContainAfterTrim(
+            r#"
+func some_function
+"#,
+        )
+    }
+
+    const EXPECTED_C_HEADER: ExpectedCHeader = ExpectedCHeader::DoesNotContainAfterTrim(
+        r#"
+some_function
+    "#,
+    );
+
+    #[test]
+    fn cfg_feature_bridge_module_feature_disabled() {
+        CodegenTest {
+            bridge_module: bridge_module(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: EXPECTED_C_HEADER,
+        }
+        .test();
+    }
+}

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/extern_rust_method_swift_class_placement_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/extern_rust_method_swift_class_placement_codegen_tests.rs
@@ -100,7 +100,7 @@ public class SomeTypeRef {
     #[test]
     fn extern_rust_fn_return_option_string() {
         CodegenTest {
-            bridge_module_tokens: bridge_module_tokens(),
+            bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),
             expected_swift_code: expected_swift_code(),
             expected_c_header: expected_c_header(),

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/extern_rust_opaque_type_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/extern_rust_opaque_type_codegen_tests.rs
@@ -76,7 +76,7 @@ void __swift_bridge__$SomeType$_free(void* self);
     #[test]
     fn extern_rust_fn_return_option_string() {
         CodegenTest {
-            bridge_module_tokens: bridge_module_tokens(),
+            bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),
             expected_swift_code: expected_swift_code(),
             expected_c_header: EXPECTED_C_HEADER,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/option_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/option_codegen_tests.rs
@@ -50,7 +50,7 @@ void* __swift_bridge__$some_function(void);
     #[test]
     fn extern_rust_fn_return_option_string() {
         CodegenTest {
-            bridge_module_tokens: bridge_module_tokens(),
+            bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),
             expected_swift_code: expected_swift_code(),
             expected_c_header: EXPECTED_C_HEADER,
@@ -124,7 +124,7 @@ struct RustStr __swift_bridge__$another_function(void);
     #[test]
     fn extern_rust_fn_return_option_str() {
         CodegenTest {
-            bridge_module_tokens: bridge_module_tokens(),
+            bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),
             expected_swift_code: expected_swift_code(),
             expected_c_header: EXPECTED_C_HEADER,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/string_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/string_codegen_tests.rs
@@ -48,7 +48,7 @@ void __swift_bridge__$some_function(void* arg);
     #[test]
     fn extern_rust_fn_with_owned_string_argument() {
         CodegenTest {
-            bridge_module_tokens: bridge_module_tokens(),
+            bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),
             expected_swift_code: expected_swift_code(),
             expected_c_header: expected_c_header(),
@@ -105,7 +105,7 @@ void __swift_bridge__$some_function(struct RustStr arg);
     #[test]
     fn extern_rust_fn_with_str_argument() {
         CodegenTest {
-            bridge_module_tokens: bridge_module_tokens(),
+            bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),
             expected_swift_code: expected_swift_code(),
             expected_c_header: expected_c_header(),
@@ -154,7 +154,7 @@ void* __swift_bridge__$some_function(void);
     #[test]
     fn extern_rust_fn_returns_string() {
         CodegenTest {
-            bridge_module_tokens: bridge_module_tokens(),
+            bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),
             expected_swift_code: EXPECTED_SWIFT_CODE,
             expected_c_header: EXPECTED_C_HEADER,
@@ -207,7 +207,7 @@ struct RustStr __swift_bridge__$some_function(void);
     #[test]
     fn extern_rust_fn_return_str() {
         CodegenTest {
-            bridge_module_tokens: bridge_module_tokens(),
+            bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),
             expected_swift_code: expected_swift_code(),
             expected_c_header: expected_c_header(),

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
@@ -4,6 +4,7 @@ use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use quote::ToTokens;
 
+use crate::bridge_module_attributes::CfgAttr;
 use crate::bridged_type::FieldsFormat;
 use crate::codegen::generate_rust_tokens::vec::generate_vec_of_opaque_rust_type_functions;
 use crate::parse::{HostLang, SharedTypeDeclaration, TypeDeclaration};
@@ -182,6 +183,19 @@ impl ToTokens for SwiftBridgeModule {
             quote! {}
         };
 
+        let mut module_attributes = vec![];
+
+        for cfg in &self.cfg_attrs {
+            match cfg {
+                CfgAttr::Feature(feature_name) => {
+                    //
+                    module_attributes.push(quote! {
+                        #[cfg(feature = #feature_name)]
+                    });
+                }
+            };
+        }
+
         let module_inner = quote! {
             #(#shared_struct_definitions)*
 
@@ -196,6 +210,7 @@ impl ToTokens for SwiftBridgeModule {
 
         let t = quote! {
             #[allow(non_snake_case)]
+            #(#module_attributes)*
             mod #mod_name {
                 #module_inner
             }

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/option.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/option.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod tests {
+    use crate::codegen::generate_swift::CodegenConfig;
     use crate::test_utils::{assert_trimmed_generated_contains_trimmed_expected, parse_ok};
     use quote::quote;
 
@@ -15,7 +16,7 @@ mod tests {
             }
         };
         let module = parse_ok(tokens);
-        let generated = module.generate_swift();
+        let generated = module.generate_swift(&CodegenConfig::no_features_enabled());
 
         let expected = r#"
 @_cdecl("__swift_bridge__$foo")
@@ -39,7 +40,7 @@ func __swift_bridge__foo () -> UInt8 {
             }
         };
         let module = parse_ok(tokens);
-        let generated = module.generate_swift();
+        let generated = module.generate_swift(&CodegenConfig::no_features_enabled());
 
         let expected = r#"
 func foo() -> Optional<UInt8> {

--- a/crates/swift-bridge-ir/src/lib.rs
+++ b/crates/swift-bridge-ir/src/lib.rs
@@ -7,16 +7,20 @@
 
 #![deny(missing_docs)]
 
+use crate::bridge_module_attributes::CfgAttr;
 use crate::parse::TypeDeclarations;
 use proc_macro2::Ident;
-use syn::parse::{Parse, ParseStream};
-use syn::{Path, Token};
+use syn::Path;
 
+pub use self::bridge_macro_attributes::{SwiftBridgeModuleAttr, SwiftBridgeModuleAttrs};
+pub use self::codegen::CodegenConfig;
 use crate::parsed_extern_fn::ParsedExternFn;
 
 mod errors;
 mod parse;
 
+mod bridge_macro_attributes;
+mod bridge_module_attributes;
 mod bridged_type;
 mod parsed_extern_fn;
 
@@ -56,6 +60,7 @@ pub struct SwiftBridgeModule {
     types: TypeDeclarations,
     functions: Vec<ParsedExternFn>,
     swift_bridge_path: Path,
+    cfg_attrs: Vec<CfgAttr>,
 }
 
 impl SwiftBridgeModule {
@@ -63,49 +68,6 @@ impl SwiftBridgeModule {
     /// We set this to `crate` when we're inside of the `swift_bridge` crate.
     pub fn set_swift_bridge_path(&mut self, path: Path) {
         self.swift_bridge_path = path;
-    }
-}
-
-/// `#\[swift_bridge::bridge(swift_bridge_path = swift_bridge\]`
-pub struct SwiftBridgeModuleAttrs {
-    #[allow(missing_docs)]
-    pub attributes: Vec<SwiftBridgeModuleAttr>,
-}
-
-/// `#\[swift_bridge::bridge(swift_bridge_path = swift_bridge\]`
-pub enum SwiftBridgeModuleAttr {
-    /// Sets the path for the actual swift bridge crate that contains different helpers such
-    /// as `RustString`.
-    SwiftBridgePath(Path),
-}
-
-impl Parse for SwiftBridgeModuleAttrs {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        if input.is_empty() {
-            return Ok(SwiftBridgeModuleAttrs { attributes: vec![] });
-        }
-
-        let opts = syn::punctuated::Punctuated::<_, Token![,]>::parse_terminated(input)?;
-
-        Ok(SwiftBridgeModuleAttrs {
-            attributes: opts.into_iter().collect(),
-        })
-    }
-}
-
-impl Parse for SwiftBridgeModuleAttr {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let key: Ident = input.parse()?;
-        let _equals = input.parse::<Token![=]>()?;
-
-        let attr = match key.to_string().as_str() {
-            "swift_bridge_path" => SwiftBridgeModuleAttr::SwiftBridgePath(input.parse()?),
-            _ => {
-                return Err(syn::Error::new(input.span(), "Unknown attribute."));
-            }
-        };
-
-        Ok(attr)
     }
 }
 

--- a/crates/swift-bridge-ir/src/test_utils.rs
+++ b/crates/swift-bridge-ir/src/test_utils.rs
@@ -75,6 +75,20 @@ Expected:
     );
 }
 
+/// Trims both generated and expected.
+pub fn assert_trimmed_generated_does_not_contain_trimmed_expected(generated: &str, expected: &str) {
+    assert!(
+        !generated.trim().contains(&expected.trim()),
+        r#"Expected was contained by generated.
+Generated:
+{}
+Expected:
+{}"#,
+        generated.trim(),
+        expected.trim()
+    );
+}
+
 pub(crate) fn parse_ok(tokens: TokenStream) -> SwiftBridgeModule {
     let module_and_errors: SwiftBridgeModuleAndErrors = syn::parse2(tokens).unwrap();
     module_and_errors.module

--- a/crates/swift-integration-tests/Cargo.toml
+++ b/crates/swift-integration-tests/Cargo.toml
@@ -6,6 +6,12 @@ publish = []
 
 build = "build.rs"
 
+[features]
+# Feature flags are for our conditional compilation tests.
+default = ["this_is_enabled"]
+this_is_enabled = []
+this_is_not_enabled = []
+
 [lib]
 crate-type = ["staticlib"]
 

--- a/crates/swift-integration-tests/build.rs
+++ b/crates/swift-integration-tests/build.rs
@@ -16,6 +16,7 @@ fn main() {
         "src/vec.rs",
         "src/rust_function_uses_opaque_swift_type.rs",
         "src/swift_function_uses_opaque_rust_type.rs",
+        "src/conditional_compilation.rs",
     ];
     for path in &bridges {
         println!("cargo:rerun-if-changed={}", path);

--- a/crates/swift-integration-tests/src/conditional_compilation.rs
+++ b/crates/swift-integration-tests/src/conditional_compilation.rs
@@ -1,0 +1,23 @@
+#[swift_bridge::bridge]
+#[cfg(feature = "this_is_enabled")]
+mod enabled {
+    extern "Rust" {
+        // This function will be exposed since this "this_is_enabled" feature is on by default.
+        fn conditionally_exposed_fn() -> u8;
+    }
+}
+
+#[swift_bridge::bridge]
+#[cfg(feature = "this_is_not_enabled")]
+mod not_enabled {
+    extern "Rust" {
+        // This function isn't actually defined at `super::undefined_fn`, but it doesn't matter
+        // since this entire bridge module won't be compiled.
+        fn undefined_fn();
+    }
+}
+
+#[cfg(feature = "this_is_enabled")]
+fn conditionally_exposed_fn() -> u8 {
+    123
+}

--- a/crates/swift-integration-tests/src/lib.rs
+++ b/crates/swift-integration-tests/src/lib.rs
@@ -2,6 +2,7 @@ mod expose_opaque_rust_struct;
 mod import_opaque_swift_class;
 
 mod bool;
+mod conditional_compilation;
 mod option;
 mod pointer;
 mod rust_function_uses_opaque_swift_type;


### PR DESCRIPTION
So far we support `#[cfg(feature = "...")]`. We can add support for more conditions in the future.

```rust
#[cfg(feature = "some-enabled-feature")]
mod ffi {
    extern "Rust" {
        fn bindings_will_be_emitted();
    }
}

#[cfg(feature = "some-disabled-feature")]
mod ffi_extras {
    extern "Rust" {
        fn bindings_will_be_not_emitted();
    }
}
```