### PR TITLE
Add #[swift_bridge(already_declared)] attribute

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		220432EA2753092C00BAE645 /* RustFnUsesOpaqueSwiftType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220432E92753092C00BAE645 /* RustFnUsesOpaqueSwiftType.swift */; };
 		220432EC27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220432EB27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift */; };
 		221E16B42786233600F94AC0 /* ConditionalCompilationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221E16B32786233600F94AC0 /* ConditionalCompilationTests.swift */; };
+		221E16B62786F9FF00F94AC0 /* OpaqueTypeAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221E16B52786F9FF00F94AC0 /* OpaqueTypeAttributeTests.swift */; };
 		228FE5D52740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228FE5D42740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift */; };
 		228FE5D72740DB6A00805D9E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228FE5D62740DB6A00805D9E /* ContentView.swift */; };
 		228FE5D92740DB6D00805D9E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 228FE5D82740DB6D00805D9E /* Assets.xcassets */; };
@@ -54,6 +55,7 @@
 		220432E92753092C00BAE645 /* RustFnUsesOpaqueSwiftType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustFnUsesOpaqueSwiftType.swift; sourceTree = "<group>"; };
 		220432EB27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustFnUsesOpaqueSwiftTypeTests.swift; sourceTree = "<group>"; };
 		221E16B32786233600F94AC0 /* ConditionalCompilationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalCompilationTests.swift; sourceTree = "<group>"; };
+		221E16B52786F9FF00F94AC0 /* OpaqueTypeAttributeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpaqueTypeAttributeTests.swift; sourceTree = "<group>"; };
 		228FE5D12740DB6A00805D9E /* SwiftRustIntegrationTestRunner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftRustIntegrationTestRunner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		228FE5D42740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftRustIntegrationTestRunnerApp.swift; sourceTree = "<group>"; };
 		228FE5D62740DB6A00805D9E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -159,6 +161,7 @@
 				220432EB27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift */,
 				22FD1C552753CB3F00F64281 /* SwiftFnUsesOpaqueRustTypeTests.swift */,
 				221E16B32786233600F94AC0 /* ConditionalCompilationTests.swift */,
+				221E16B52786F9FF00F94AC0 /* OpaqueTypeAttributeTests.swift */,
 			);
 			path = SwiftRustIntegrationTestRunnerTests;
 			sourceTree = "<group>";
@@ -331,6 +334,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				22043293274A8FDF00BAE645 /* VecTests.swift in Sources */,
+				221E16B62786F9FF00F94AC0 /* OpaqueTypeAttributeTests.swift in Sources */,
 				220432A7274C953E00BAE645 /* PointerTests.swift in Sources */,
 				220432AF274E7BF800BAE645 /* SharedTypes.swift in Sources */,
 				220432EC27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift in Sources */,

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OpaqueTypeAttributeTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OpaqueTypeAttributeTests.swift
@@ -1,0 +1,44 @@
+//
+//  OpaqueTypeAttributeTests.swift
+//  SwiftRustIntegrationTestRunnerTests
+//
+//  Created by Frankie Nwafili on 1/6/22.
+//
+
+import XCTest
+@testable import SwiftRustIntegrationTestRunner
+
+/// Tests for attributes on opaque types.
+class OpaqueTypeAttributeTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    /// Verify that we can call an initializers, methods and associated functions that were declared in a different module from
+    /// where the opaque Rust type was defined.
+    /// This ensures that our code generation properly generates Swift convenience initializers inside of class extensions.
+    /// See crates/swift-integration-tests/src/type_attributes/already_declared.rs
+    func testExternRustAlreadyDeclaredCallInitializer() throws {
+        let val = AlreadyDeclaredTypeTest()
+        
+        XCTAssert(val.a_ref_method())
+        XCTAssert(val.a_ref_mut_method())
+        XCTAssert(val.an_owned_method())
+        
+        XCTAssert(AlreadyDeclaredTypeTest.an_associated_function())
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}
+

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [The Bridge Module](./bridge-module/README.md)
   - [Shared Structs](./bridge-module/structs/README.md)
   - [extern "Rust"](./bridge-module/extern-rust/README.md)
+  - [extern "Swift"](./bridge-module/extern-swift/README.md)
   - [Conditional Compilation](./bridge-module/conditional-compilation/README.md)
 
 - [Built In Types](./built-in/README.md)

--- a/book/src/bridge-module/conditional-compilation/README.md
+++ b/book/src/bridge-module/conditional-compilation/README.md
@@ -48,7 +48,7 @@ mod ffi {
 #[cfg(feature = "dev-utils")]
 mod ffi_dev_utils {
 	extern "Rust" {
-	    #[swift_bridge(import)]
+	    #[swift_bridge(already_declared)]
         type App;
 
         fn create_logged_in_user(&mut self, user_id: u8);

--- a/book/src/bridge-module/extern-rust/README.md
+++ b/book/src/bridge-module/extern-rust/README.md
@@ -127,6 +127,38 @@ func useSomeType(someType: SomeTypeRef) {
 }
 ```
 
+## Opaque Type Attributes
+
+#### #[swift_bridge(already_declared)]
+
+The `already_declared` attribute allows you to use the same type in multiple bridge modules.
+
+```rust
+use some_crate::App;
+
+mod ffi {
+	extern "Rust" {
+	    type App;
+
+        #[swift_bridge(init)]
+	    fn new() -> App;
+	}
+}
+
+#[swift_bridge::bridge]
+#[cfg(feature = "dev-utils")]
+mod ffi_dev_utils {
+	extern "Rust" {
+        // We won't emit Swift and C type definitions for this type
+        // since we've already declared it elsewhere.
+	    #[swift_bridge(already_declared)]
+        type App;
+
+        fn create_logged_in_user(&mut self, user_id: u8);
+	}
+}
+```
+
 ## Function Attributes
 
 #### #[swift_bridge(associated_to = SomeType)]

--- a/book/src/bridge-module/extern-swift/README.md
+++ b/book/src/bridge-module/extern-swift/README.md
@@ -1,0 +1,3 @@
+# extern "Swift"
+
+work in progress ...

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests.rs
@@ -22,11 +22,13 @@ use quote::ToTokens;
 use std::collections::HashSet;
 
 use crate::test_utils::{
-    assert_tokens_contain, assert_tokens_eq, assert_trimmed_generated_contains_trimmed_expected,
+    assert_tokens_contain, assert_tokens_do_not_contain, assert_tokens_eq,
+    assert_trimmed_generated_contains_trimmed_expected,
     assert_trimmed_generated_does_not_contain_trimmed_expected,
     assert_trimmed_generated_equals_trimmed_expected, parse_ok,
 };
 
+mod already_declared_attribute_codegen_tests;
 mod conditional_compilation_codegen_tests;
 mod extern_rust_function_opaque_rust_type_argument_codegen_tests;
 mod extern_rust_function_opaque_rust_type_return_codegen_tests;
@@ -368,6 +370,8 @@ enum ExpectedRustTokens {
     Exact(TokenStream),
     /// The generated Rust tokens stream contains the provided stream.
     Contains(TokenStream),
+    /// The generated Rust tokens stream does not contain the provided stream.
+    DoesNotContain(TokenStream),
     /// The generated Rust tokens stream contains the provided stream.
     ContainsMany(Vec<TokenStream>),
     /// Skip testing Rust tokens
@@ -410,6 +414,9 @@ impl CodegenTest {
             }
             ExpectedRustTokens::Contains(expected_contained_tokens) => {
                 assert_tokens_contain(&generated_tokens, &expected_contained_tokens);
+            }
+            ExpectedRustTokens::DoesNotContain(expected_not_contained_tokens) => {
+                assert_tokens_do_not_contain(&generated_tokens, &expected_not_contained_tokens);
             }
             ExpectedRustTokens::ContainsMany(expected_contained_tokens) => {
                 for tokens in expected_contained_tokens {

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/already_declared_attribute_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/already_declared_attribute_codegen_tests.rs
@@ -1,0 +1,96 @@
+use super::{CodegenTest, ExpectedCHeader, ExpectedRustTokens, ExpectedSwiftCode};
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Verify that we properly handle a `#[swift_bridge(already_declared)]` attribute on an opaque
+/// Rust type.
+mod extern_rust_already_declared_type_attribute {
+    use super::*;
+
+    fn bridge_module() -> TokenStream {
+        quote! {
+            #[swift_bridge::bridge]
+            mod ffi {
+                extern "Rust" {
+                    #[swift_bridge(already_declared)]
+                    type SomeType;
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::DoesNotContain(quote! {
+            SomeType
+        })
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::DoesNotContainAfterTrim(
+            r#"
+SomeType
+"#,
+        )
+    }
+
+    const EXPECTED_C_HEADER: ExpectedCHeader = ExpectedCHeader::DoesNotContainAfterTrim(
+        r#"
+SomeType
+    "#,
+    );
+
+    #[test]
+    fn extern_rust_already_declared_type_attribute() {
+        CodegenTest {
+            bridge_module: bridge_module().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: EXPECTED_C_HEADER,
+        }
+        .test();
+    }
+}
+
+/// Verify that we generate associated functions and methods for already declared types.
+mod extern_rust_already_declared_type_still_generates_methods {
+    use super::*;
+
+    fn bridge_module() -> TokenStream {
+        quote! {
+            #[swift_bridge::bridge]
+            mod ffi {
+                extern "Rust" {
+                    #[swift_bridge(already_declared)]
+                    type SomeType;
+
+                    fn some_function(self);
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::Contains(quote! {
+            fn __swift_bridge__SomeType_some_function
+        })
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(r#"func some_function"#)
+    }
+
+    const EXPECTED_C_HEADER: ExpectedCHeader = ExpectedCHeader::ContainsAfterTrim(
+        r#"void __swift_bridge__$SomeType$some_function(void* self);"#,
+    );
+
+    #[test]
+    fn extern_rust_already_declared_type_still_generates_methods() {
+        CodegenTest {
+            bridge_module: bridge_module().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: EXPECTED_C_HEADER,
+        }
+        .test();
+    }
+}

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/extern_rust_method_swift_class_placement_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/extern_rust_method_swift_class_placement_codegen_tests.rs
@@ -39,10 +39,6 @@ mod extern_rust_method_swift_class_placement {
 public class SomeType: SomeTypeRefMut {
     var isOwned: Bool = true
 
-    init() {
-        fatalError("No #[swift_bridge(constructor)] was defined in the extern Rust module.")
-    }
-
     override init(ptr: UnsafeMutableRawPointer) {
         super.init(ptr: ptr)
     }
@@ -52,7 +48,8 @@ public class SomeType: SomeTypeRefMut {
             __swift_bridge__$SomeType$_free(ptr)
         }
     }
-
+}
+extension SomeType {
     func a() {
         __swift_bridge__$SomeType$a({isOwned = false; return ptr;}())
     }
@@ -65,7 +62,8 @@ public class SomeTypeRefMut: SomeTypeRef {
     override init(ptr: UnsafeMutableRawPointer) {
         super.init(ptr: ptr)
     }
-
+}
+extension SomeTypeRefMut {
     func e() {
         __swift_bridge__$SomeType$e(ptr)
     }
@@ -80,7 +78,8 @@ public class SomeTypeRef {
     init(ptr: UnsafeMutableRawPointer) {
         self.ptr = ptr
     }
-
+}
+extension SomeTypeRef {
     func c() {
         __swift_bridge__$SomeType$c(ptr)
     }

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/extern_rust_opaque_type_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/extern_rust_opaque_type_codegen_tests.rs
@@ -36,10 +36,6 @@ mod extern_rust_type {
 public class SomeType: SomeTypeRefMut {
     var isOwned: Bool = true
 
-    init() {
-        fatalError("No #[swift_bridge(constructor)] was defined in the extern Rust module.")
-    }
-
     override init(ptr: UnsafeMutableRawPointer) {
         super.init(ptr: ptr)
     }

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -88,6 +88,10 @@ impl SwiftBridgeModule {
                         continue;
                     }
 
+                    if ty.already_declared {
+                        continue;
+                    }
+
                     let ty_name = ty.ident.to_string();
 
                     let ty_decl = format!("typedef struct {ty_name} {ty_name};", ty_name = ty_name);

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
@@ -129,8 +129,10 @@ impl ToTokens for SwiftBridgeModule {
                                 &self.swift_bridge_path,
                             );
 
-                            extern_rust_fn_tokens.push(free);
-                            extern_rust_fn_tokens.push(vec_functions);
+                            if !ty.already_declared {
+                                extern_rust_fn_tokens.push(free);
+                                extern_rust_fn_tokens.push(vec_functions);
+                            }
                         }
                         HostLang::Swift => {
                             let ty_name = &ty.ident;

--- a/crates/swift-bridge-ir/src/lib.rs
+++ b/crates/swift-bridge-ir/src/lib.rs
@@ -7,14 +7,15 @@
 
 #![deny(missing_docs)]
 
-use crate::bridge_module_attributes::CfgAttr;
-use crate::parse::TypeDeclarations;
 use proc_macro2::Ident;
 use syn::Path;
 
+use crate::bridge_module_attributes::CfgAttr;
+use crate::parse::TypeDeclarations;
+use crate::parsed_extern_fn::ParsedExternFn;
+
 pub use self::bridge_macro_attributes::{SwiftBridgeModuleAttr, SwiftBridgeModuleAttrs};
 pub use self::codegen::CodegenConfig;
-use crate::parsed_extern_fn::ParsedExternFn;
 
 mod errors;
 mod parse;

--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod/opaque_type_attributes.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod/opaque_type_attributes.rs
@@ -1,0 +1,32 @@
+use proc_macro2::Ident;
+use syn::parse::{Parse, ParseStream};
+
+#[derive(Default)]
+pub(super) struct OpaqueTypeAttributes {
+    pub already_declared: bool,
+}
+
+impl OpaqueTypeAttributes {
+    pub fn store_attrib(&mut self, attrib: OpaqueTypeAttr) {
+        match attrib {
+            OpaqueTypeAttr::AlreadyDeclared => self.already_declared = true,
+        }
+    }
+}
+
+pub(super) enum OpaqueTypeAttr {
+    AlreadyDeclared,
+}
+
+impl Parse for OpaqueTypeAttr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let key: Ident = input.parse()?;
+
+        let attrib = match key.to_string().as_str() {
+            "already_declared" => OpaqueTypeAttr::AlreadyDeclared,
+            _ => panic!("TODO: Return spanned error"),
+        };
+
+        Ok(attrib)
+    }
+}

--- a/crates/swift-bridge-ir/src/parse/type_declarations.rs
+++ b/crates/swift-bridge-ir/src/parse/type_declarations.rs
@@ -75,6 +75,10 @@ impl SharedStructDeclaration {
 pub(crate) struct OpaqueForeignTypeDeclaration {
     pub ty: ForeignItemType,
     pub host_lang: HostLang,
+    /// Whether or not the `#[swift_bridge(already_declared)]` attribute was present on the type.
+    /// If it was, we won't generate Swift and C type declarations for this type, since we
+    /// will elsewhere.
+    pub already_declared: bool,
 }
 
 impl Deref for OpaqueForeignTypeDeclaration {

--- a/crates/swift-bridge-ir/src/parsed_extern_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn.rs
@@ -399,27 +399,6 @@ mod tests {
         );
     }
 
-    /// Verify that if a foreign type is marked as enabled we allow taking owned foreign type args.
-    #[test]
-    fn allow_foreign_type_arg_if_type_marked_enabled_or_enabled_unchecked() {
-        let tokens = quote! {
-            #[swift_bridge::bridge]
-            mod ffi {
-                extern "Rust" {
-                    #[swift_bridge(owned_arg = "enabled")]
-                    type Foo;
-                    #[swift_bridge(owned_arg = "enabled_unchecked")]
-                    type Bar;
-
-                    fn a (arg: Foo);
-                    fn b (arg: Bar);
-                }
-            }
-        };
-        let module = parse_ok(tokens);
-        assert_eq!(module.functions.len(), 2);
-    }
-
     /// Verify that we properly take and return String arguments
     #[test]
     fn extern_rust_strings() {

--- a/crates/swift-bridge-ir/src/test_utils.rs
+++ b/crates/swift-bridge-ir/src/test_utils.rs
@@ -46,6 +46,33 @@ Inner Tokens:
     )
 }
 
+/// Converts both token streams to strings, removes all of the whitespace then checks that the outer
+/// token stream does not contain the inner one.
+pub fn assert_tokens_do_not_contain(outer: &TokenStream, inner: &TokenStream) {
+    let outer_string = outer.to_string();
+    let outer_string = outer_string.replace(" ", "").replace("\n", "");
+
+    let inner_string = inner.to_string();
+    let inner_string = inner_string.replace(" ", "").replace("\n", "");
+
+    let is_contained = outer_string.contains(&inner_string);
+
+    assert!(
+        !is_contained,
+        r#"
+Outer tokens do not contain the inner tokens. 
+
+Outer Tokens:
+{}
+
+Inner Tokens:
+{}
+"#,
+        outer.to_string(),
+        inner.to_string()
+    )
+}
+
 /// Trims both generated and expected.
 pub fn assert_trimmed_generated_equals_trimmed_expected(generated: &str, expected: &str) {
     assert_eq!(

--- a/crates/swift-integration-tests/build.rs
+++ b/crates/swift-integration-tests/build.rs
@@ -17,6 +17,7 @@ fn main() {
         "src/rust_function_uses_opaque_swift_type.rs",
         "src/swift_function_uses_opaque_rust_type.rs",
         "src/conditional_compilation.rs",
+        "src/type_attributes/already_declared.rs",
     ];
     for path in &bridges {
         println!("cargo:rerun-if-changed={}", path);

--- a/crates/swift-integration-tests/src/lib.rs
+++ b/crates/swift-integration-tests/src/lib.rs
@@ -12,3 +12,4 @@ mod swift_function_uses_opaque_rust_type;
 mod vec;
 
 mod function_attributes;
+mod type_attributes;

--- a/crates/swift-integration-tests/src/type_attributes.rs
+++ b/crates/swift-integration-tests/src/type_attributes.rs
@@ -1,0 +1,1 @@
+mod already_declared;

--- a/crates/swift-integration-tests/src/type_attributes/already_declared.rs
+++ b/crates/swift-integration-tests/src/type_attributes/already_declared.rs
@@ -1,0 +1,54 @@
+//! Verify that the `#[swift_bridge(already_declared)]` module prevents us from emitting the
+//! same type definitions twice.
+//!
+//! If the Xcode project is able to compile then we know that our attribute works,
+//! because otherwise we would get build time errors that the class was defined twice.
+
+#[swift_bridge::bridge]
+mod ffi1 {
+    extern "Rust" {
+        type AlreadyDeclaredTypeTest;
+    }
+}
+
+#[swift_bridge::bridge]
+mod ffi2 {
+    extern "Rust" {
+        #[swift_bridge(already_declared)]
+        type AlreadyDeclaredTypeTest;
+
+        #[swift_bridge(init)]
+        fn new() -> AlreadyDeclaredTypeTest;
+
+        fn an_owned_method(self) -> bool;
+        fn a_ref_method(&self) -> bool;
+        fn a_ref_mut_method(&mut self) -> bool;
+
+        #[swift_bridge(associated_to = AlreadyDeclaredTypeTest)]
+        fn an_associated_function() -> bool;
+    }
+}
+
+pub struct AlreadyDeclaredTypeTest;
+
+impl AlreadyDeclaredTypeTest {
+    fn new() -> Self {
+        AlreadyDeclaredTypeTest
+    }
+
+    fn an_owned_method(self) -> bool {
+        true
+    }
+
+    fn a_ref_method(&self) -> bool {
+        true
+    }
+
+    fn a_ref_mut_method(&mut self) -> bool {
+        true
+    }
+
+    fn an_associated_function() -> bool {
+        true
+    }
+}


### PR DESCRIPTION
Used to prevent the code generator from emitting declarations for a
type, since we're indicating that this will happen elsewhere.

This lets you use types across multiple bridge modules, which can be
useful for:

- Importing third-party bridged types that were already defined in some
  other crate that you can't access.

- Splitting bridge modules into smaller modules.
