### PR TITLE
Make generated Swift structs public

### DIFF
--- a/book/src/tutorial/running-rust-analyzer-on-an-iphone/README.md
+++ b/book/src/tutorial/running-rust-analyzer-on-an-iphone/README.md
@@ -233,6 +233,8 @@ Select the same `target/universal/debug/libios_rust_analyzer.a` in the link bina
 Add the following to the `build.rs` file that we created earlier.
 
 ```rust
+const XCODE_CONFIGURATION_ENV: &'static str = "CONFIGURATION";
+
 fn main() {
     let out_dir = "IosRustAnalyzer/Generated";
 
@@ -240,6 +242,7 @@ fn main() {
     for path in &bridges {
         println!("cargo:rerun-if-changed={}", path);
     }
+    println!("cargo:rerun-if-env-changed={}", XCODE_CONFIGURATION_ENV);
 
     swift_bridge_build::parse_bridges(bridges)
         .write_all_concatenated(out_dir, env!("CARGO_PKG_NAME"));

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/shared_struct_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/shared_struct_codegen_tests.rs
@@ -54,7 +54,7 @@ mod generates_struct_to_and_from_ffi_conversions_no_fields {
     fn expected_swift_code() -> ExpectedSwiftCode {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
-struct SomeStruct {
+public struct SomeStruct {
     @inline(__always)
     func intoFfiRepr() -> __swift_bridge__$SomeStruct {
         __swift_bridge__$SomeStruct(_private: 123)

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_struct.rs
@@ -65,7 +65,7 @@ impl SwiftBridgeModule {
                 // No need to generate any code. Swift will automatically generate a
                 //  struct from our C header typedef that we generate for this struct.
                 let swift_struct = format!(
-                    r#"struct {struct_name} {{{fields}
+                    r#"public struct {struct_name} {{{fields}
     @inline(__always)
     func intoFfiRepr() -> {ffi_repr_name} {{
         {convert_swift_to_ffi_repr}

--- a/examples/codegen-visualizer/build.rs
+++ b/examples/codegen-visualizer/build.rs
@@ -1,3 +1,5 @@
+const XCODE_CONFIGURATION_ENV: &'static str = "CONFIGURATION";
+
 fn main() {
     let out_dir = "./CodegenVisualizer/Generated/";
 
@@ -5,6 +7,7 @@ fn main() {
     for path in &bridges {
         println!("cargo:rerun-if-changed={}", path);
     }
+    println!("cargo:rerun-if-env-changed={}", XCODE_CONFIGURATION_ENV);
 
     swift_bridge_build::parse_bridges(bridges)
         .write_all_concatenated(out_dir, env!("CARGO_PKG_NAME"));

--- a/examples/ios-rust-analyzer/build.rs
+++ b/examples/ios-rust-analyzer/build.rs
@@ -1,3 +1,5 @@
+const XCODE_CONFIGURATION_ENV: &'static str = "CONFIGURATION";
+
 fn main() {
     let out_dir = "IosRustAnalyzer/Generated";
 
@@ -5,6 +7,7 @@ fn main() {
     for path in &bridges {
         println!("cargo:rerun-if-changed={}", path);
     }
+    println!("cargo:rerun-if-env-changed={}", XCODE_CONFIGURATION_ENV);
 
     swift_bridge_build::parse_bridges(bridges)
         .write_all_concatenated(out_dir, env!("CARGO_PKG_NAME"));


### PR DESCRIPTION
Allows you to (at this time manually) implement certain protocols, such as `Identifiable`, on generated structs in Swift.

Without this you get an error:

```
Property 'id' must be declared public because it matches a requirement in public protocol 'Identifiable'
```

---

In the future we might allow the user to control whether or not the generated struct is public (perhaps by declaring `pub` on the struct declaration in the bridge module..) but let's hold off on that until we are more familiar with Swift's [Access Control](https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html).