### PR TITLE
Add attribute for `Identifiable` protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,21 +135,44 @@ cd swift-bridge
 cargo test --all && ./test-integration.sh
 ```
 
-## Early Stages
+## Phases
+
+#### Phase 1 (Current Phase): Make it Possible
 
 Bridging Rust and Swift is fairly unexplored territory, so it will take some experimentation in order to
-figure out the right API and code generation.
+figure out the right APIs and code generation.
 
-In these early days I'm looking for feedback from bleeding-edge users in order to continue to improve the
-API and the generated code.
+During this phase we'll focus on adding support for more types, patterns and and common use cases
+that we discover.
 
-I can especially use feedback from people with Swift experience, since I don't have much.
+We won't be overly focused on what the best names or arguments or structure during this phase.
+
+#### Phase 2: Make it Ergonomic
+
+This phase will be focused on making `swift-bridge` feel really good to use.
+
+During this phase we will:
+
+- Simplify our APIs and make them consistent.
+
+- Improve our error messages.
+
+- Improve the information and examples in the book.
+
+#### Phase 3: Make it Stable
+
+This phase is about getting `swift-bridge` to version `1.0.0`.
+
+We'll take inventory of all of our public APIs and aim to remove as much we
+can without impacting the libraries usability.
 
 ---
 
 The `0.1.x` versions will not follow semver.
 
-We'll maintain semver from `0.2` and onwards.
+We will maintain semver from `0.2` and onwards.
+
+---
 
 #### License
 

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		228FE6502749C43100805D9E /* BooleanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228FE64F2749C43100805D9E /* BooleanTests.swift */; };
 		22BC10F62799283100A0D046 /* SharedStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC10F52799283100A0D046 /* SharedStruct.swift */; };
 		22BC10F82799A3A000A0D046 /* SharedStructAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC10F72799A3A000A0D046 /* SharedStructAttributes.swift */; };
+		22BCAAB927A2607700686A21 /* FunctionAttributeIdentifiableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BCAAB827A2607700686A21 /* FunctionAttributeIdentifiableTests.swift */; };
 		22C0AD51278ECA9E00A96469 /* SharedStructAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C0AD50278ECA9E00A96469 /* SharedStructAttributeTests.swift */; };
 		22FD1C542753CB2A00F64281 /* SwiftFnUsesOpaqueRustType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD1C532753CB2A00F64281 /* SwiftFnUsesOpaqueRustType.swift */; };
 		22FD1C562753CB3F00F64281 /* SwiftFnUsesOpaqueRustTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD1C552753CB3F00F64281 /* SwiftFnUsesOpaqueRustTypeTests.swift */; };
@@ -81,6 +82,7 @@
 		228FE64F2749C43100805D9E /* BooleanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooleanTests.swift; sourceTree = "<group>"; };
 		22BC10F52799283100A0D046 /* SharedStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStruct.swift; sourceTree = "<group>"; };
 		22BC10F72799A3A000A0D046 /* SharedStructAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStructAttributes.swift; sourceTree = "<group>"; };
+		22BCAAB827A2607700686A21 /* FunctionAttributeIdentifiableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionAttributeIdentifiableTests.swift; sourceTree = "<group>"; };
 		22C0AD50278ECA9E00A96469 /* SharedStructAttributeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStructAttributeTests.swift; sourceTree = "<group>"; };
 		22FD1C532753CB2A00F64281 /* SwiftFnUsesOpaqueRustType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftFnUsesOpaqueRustType.swift; sourceTree = "<group>"; };
 		22FD1C552753CB3F00F64281 /* SwiftFnUsesOpaqueRustTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftFnUsesOpaqueRustTypeTests.swift; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 				221E16B32786233600F94AC0 /* ConditionalCompilationTests.swift */,
 				221E16B52786F9FF00F94AC0 /* OpaqueTypeAttributeTests.swift */,
 				22C0AD50278ECA9E00A96469 /* SharedStructAttributeTests.swift */,
+				22BCAAB827A2607700686A21 /* FunctionAttributeIdentifiableTests.swift */,
 			);
 			path = SwiftRustIntegrationTestRunnerTests;
 			sourceTree = "<group>";
@@ -350,6 +353,7 @@
 				220432AF274E7BF800BAE645 /* SharedStructTests.swift in Sources */,
 				220432EC27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift in Sources */,
 				228FE6502749C43100805D9E /* BooleanTests.swift in Sources */,
+				22BCAAB927A2607700686A21 /* FunctionAttributeIdentifiableTests.swift in Sources */,
 				221E16B42786233600F94AC0 /* ConditionalCompilationTests.swift in Sources */,
 				22043295274ADA7A00BAE645 /* OptionTests.swift in Sources */,
 				22C0AD51278ECA9E00A96469 /* SharedStructAttributeTests.swift in Sources */,

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/FunctionAttributeIdentifiableTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/FunctionAttributeIdentifiableTests.swift
@@ -1,0 +1,40 @@
+//
+//  FunctionAttributeIdentifiableTests.swift
+//  SwiftRustIntegrationTestRunnerTests
+//
+//  Created by Frankie Nwafili on 1/27/22.
+//
+
+import Foundation
+
+import XCTest
+@testable import SwiftRustIntegrationTestRunner
+
+/// Tests the #[swift_bridge(Identifiable)] attribute.
+class FunctionAttributeIdentifiableTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    /// Verify that the `swift_bridge(Identifiable)` attribute works.
+    func testIdentifiable() throws {
+        XCTAssertEqual(verifyIsIdentifiable(IdentifiableFnNamedId()).id(), 123)
+        XCTAssertEqual(IdentifiableFnNotNamedId().id, 123)
+        
+        XCTAssertEqual(verifyIsIdentifiable(IdentifiableU8()).id(), 123)
+        XCTAssertEqual(verifyIsIdentifiable(IdentifiableI8()).id(), 123)
+        
+        "hello world".toRustStr({rustStr in
+            XCTAssertEqual(verifyIsIdentifiable(IdentifiableStr()).id(), rustStr)
+        })
+    }
+}
+
+func verifyIsIdentifiable<T: Identifiable>(_ arg: T) -> T {
+    arg
+}

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -207,6 +207,8 @@ impl PartialEq for OpaqueForeignType {
 /// Whether or not a PatType's pattern is `self`.
 ///
 /// `self: &Foo` would be true
+/// `self: &mut Foo` would be true
+/// `self: Foo` would be true
 /// `arg: &Foo` would be false.
 pub(crate) fn pat_type_pat_is_self(pat_type: &PatType) -> bool {
     match pat_type.pat.deref() {

--- a/crates/swift-bridge-ir/src/codegen/generate_swift.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift.rs
@@ -29,6 +29,7 @@ impl SwiftBridgeModule {
 
         let mut associated_funcs_and_methods: HashMap<String, Vec<&ParsedExternFn>> =
             HashMap::new();
+        let mut class_protocols: HashMap<String, ClassProtocols> = HashMap::new();
 
         for function in &self.functions {
             if function.host_lang.is_rust() {
@@ -38,11 +39,27 @@ impl SwiftBridgeModule {
                             //
                             todo!("Think about what to do here..")
                         }
-                        TypeDeclaration::Opaque(ty) => {
+                        TypeDeclaration::Opaque(opaque_ty) => {
                             associated_funcs_and_methods
-                                .entry(ty.ident.to_string())
+                                .entry(opaque_ty.ident.to_string())
                                 .or_default()
                                 .push(function);
+
+                            if function.is_swift_identifiable {
+                                let identifiable_protocol = IdentifiableProtocol {
+                                    func_name: function.func.sig.ident.to_string(),
+                                    return_ty: BridgedType::new_with_return_type(
+                                        &function.func.sig.output,
+                                        &self.types,
+                                    )
+                                    .unwrap()
+                                    .to_swift_type(TypePosition::FnReturn(opaque_ty.host_lang)),
+                                };
+                                class_protocols
+                                    .entry(opaque_ty.ident.to_string())
+                                    .or_default()
+                                    .identifiable = Some(identifiable_protocol);
+                            }
                         }
                     };
                     continue;
@@ -74,9 +91,14 @@ impl SwiftBridgeModule {
                 }
                 TypeDeclaration::Opaque(ty) => match ty.host_lang {
                     HostLang::Rust => {
+                        let class_protocols = class_protocols.get(&ty.ty.ident.to_string());
+                        let default_cp = ClassProtocols::default();
+                        let class_protocols = class_protocols.unwrap_or(&default_cp);
+
                         swift += &generate_swift_class(
                             ty,
                             &associated_funcs_and_methods,
+                            class_protocols,
                             &self.types,
                             &self.swift_bridge_path,
                         );
@@ -99,9 +121,20 @@ impl SwiftBridgeModule {
     }
 }
 
+#[derive(Default)]
+struct ClassProtocols {
+    // The name of the function to use for the Identifiable protocol implementation.
+    identifiable: Option<IdentifiableProtocol>,
+}
+struct IdentifiableProtocol {
+    func_name: String,
+    return_ty: String,
+}
+
 fn generate_swift_class(
     ty: &OpaqueForeignTypeDeclaration,
     associated_funcs_and_methods: &HashMap<String, Vec<&ParsedExternFn>>,
+    class_protocols: &ClassProtocols,
     types: &TypeDeclarations,
     swift_bridge_path: &Path,
 ) -> String {
@@ -121,7 +154,7 @@ fn generate_swift_class(
 
             let is_class_func = type_method.func.sig.inputs.is_empty();
 
-            if type_method.is_initializer {
+            if type_method.is_swift_initializer {
                 initializers.push(func_definition);
             } else if is_class_func {
                 ref_self_methods.push(func_definition);
@@ -162,7 +195,7 @@ fn generate_swift_class(
             free_func_call = free_func_call
         )
     };
-    let class_ref_decl = if ty.already_declared {
+    let class_ref_mut_decl = if ty.already_declared {
         "".to_string()
     } else {
         format!(
@@ -175,7 +208,7 @@ public class {type_name}RefMut: {type_name}Ref {{
             type_name = type_name
         )
     };
-    let class_ref_mut_decl = if ty.already_declared {
+    let mut class_ref_decl = if ty.already_declared {
         "".to_string()
     } else {
         format!(
@@ -190,6 +223,28 @@ public class {type_name}Ref {{
             type_name = type_name,
         )
     };
+    if let Some(identifiable) = class_protocols.identifiable.as_ref() {
+        let identifiable_var = if identifiable.func_name == "id" {
+            "".to_string()
+        } else {
+            format!(
+                r#"
+    public var id: {identifiable_return_ty} {{
+        return self.{identifiable_func}()
+    }}
+"#,
+                identifiable_func = identifiable.func_name,
+                identifiable_return_ty = identifiable.return_ty
+            )
+        };
+
+        class_ref_decl += &format!(
+            r#"
+extension {type_name}Ref: Identifiable {{{identifiable_var}}}"#,
+            type_name = type_name,
+            identifiable_var = identifiable_var,
+        );
+    }
 
     let initializers = if initializers.len() == 0 {
         "".to_string()
@@ -251,8 +306,8 @@ extension {type_name}RefMut {{
         r#"
 {class_decl}{initializers}{owned_instance_methods}{class_ref_decl}{ref_mut_instance_methods}{class_ref_mut_decl}{ref_instance_methods}"#,
         class_decl = class_decl,
-        class_ref_decl = class_ref_decl,
-        class_ref_mut_decl = class_ref_mut_decl,
+        class_ref_decl = class_ref_mut_decl,
+        class_ref_mut_decl = class_ref_decl,
         initializers = initializers,
         owned_instance_methods = owned_instance_methods,
         ref_mut_instance_methods = ref_mut_instance_methods,
@@ -329,14 +384,14 @@ fn gen_func_swift_calls_rust(
     };
 
     let maybe_static_class_func = if function.associated_type.is_some()
-        && (!function.is_method() && !function.is_initializer)
+        && (!function.is_method() && !function.is_swift_initializer)
     {
         "class "
     } else {
         ""
     };
 
-    let swift_class_func_name = if function.is_initializer {
+    let swift_class_func_name = if function.is_swift_initializer {
         "convenience init".to_string()
     } else {
         format!("func {}", fn_name.as_str())
@@ -354,7 +409,7 @@ fn gen_func_swift_calls_rust(
         type_name_segment = type_name_segment,
         call_fn = call_fn
     );
-    let mut call_rust = if function.is_initializer {
+    let mut call_rust = if function.is_swift_initializer {
         call_rust
     } else if let Some(built_in) = function.return_ty_built_in(types) {
         built_in.convert_ffi_value_to_swift_value(
@@ -405,7 +460,7 @@ fn gen_func_swift_calls_rust(
     let returns_null = Some(BridgedType::StdLib(StdLibType::Null))
         == BridgedType::new_with_return_type(&function.func.sig.output, types);
 
-    let maybe_return = if returns_null || function.is_initializer {
+    let maybe_return = if returns_null || function.is_swift_initializer {
         ""
     } else {
         "return "
@@ -458,11 +513,11 @@ fn gen_func_swift_calls_rust(
         }
     }
 
-    if function.is_initializer {
+    if function.is_swift_initializer {
         call_rust = format!("self.init(ptr: {})", call_rust)
     }
 
-    let maybe_return = if function.is_initializer {
+    let maybe_return = if function.is_swift_initializer {
         "".to_string()
     } else {
         function.to_swift_return_type(types)
@@ -538,7 +593,7 @@ fn gen_function_exposes_swift_to_rust(
                     ty_name = ty_name,
                     call_fn = call_fn
                 );
-            } else if func.is_initializer {
+            } else if func.is_swift_initializer {
                 call_fn = format!(
                     "__private__PointerToSwiftType(ptr: Unmanaged.passRetained({}({})).toOpaque())",
                     ty_name, args

--- a/crates/swift-bridge-ir/src/errors.rs
+++ b/crates/swift-bridge-ir/src/errors.rs
@@ -1,5 +1,5 @@
 mod parse_error;
-pub(crate) use self::parse_error::ParseError;
+pub(crate) use self::parse_error::*;
 
 pub(crate) struct ParseErrors {
     errors: Vec<ParseError>,

--- a/crates/swift-bridge-ir/src/errors/parse_error.rs
+++ b/crates/swift-bridge-ir/src/errors/parse_error.rs
@@ -19,27 +19,53 @@ pub(crate) enum ParseError {
     },
     /// `fn foo (&self)`
     ///           ----
-    AmbiguousSelf { self_: Receiver },
+    AmbiguousSelf {
+        self_: Receiver,
+    },
     /// fn foo (bar: &Bar);
     /// If Bar wasn't declared using a `type Bar` declaration.
-    UndeclaredType { ty: Type },
+    UndeclaredType {
+        ty: Type,
+    },
     /// Declared a type that we already support.
     /// Example: `type u32`
-    DeclaredBuiltInType { ty: ForeignItemType },
+    DeclaredBuiltInType {
+        ty: ForeignItemType,
+    },
     /// A bridge module struct with one or more fields must have a
     /// `#\[swift_bridge(swift_repr ="...")\[\]` attribute so that we know whether to create a
     /// `struct` or `class` on the Swift side.
-    StructMissingSwiftRepr { struct_ident: Ident },
+    StructMissingSwiftRepr {
+        struct_ident: Ident,
+    },
     /// Only "class" and "struct" can be used as swift_repr.
-    StructInvalidSwiftRepr { swift_repr_attr_value: LitStr },
+    StructInvalidSwiftRepr {
+        swift_repr_attr_value: LitStr,
+    },
     /// A struct was declared with an unrecognized attribute.
-    StructUnrecognizedAttribute { attribute: Ident },
+    StructUnrecognizedAttribute {
+        attribute: Ident,
+    },
     /// There is no reason to use `swift_repr = "class"` on an empty struct.
     /// It's extra overhead with no advantages.
     EmptyStructHasSwiftReprClass {
         struct_ident: Ident,
         swift_repr_attr_value: LitStr,
     },
+    FunctionAttribute(FunctionAttributeParseError),
+}
+
+/// An error while parsing a function attribute.
+pub(crate) enum FunctionAttributeParseError {
+    Identifiable(IdentifiableParseError),
+}
+
+/// An error while parsing a function's `Identifiable` attribute.
+pub(crate) enum IdentifiableParseError {
+    /// An `Identifiable` implementation function must take a single `(&self)` argument.
+    MustBeRefSelf { fn_ident: Ident },
+    /// An `Identifiable` implementation function must return a value.
+    MissingReturnType { fn_ident: Ident },
 }
 
 impl Into<syn::Error> for ParseError {
@@ -135,6 +161,24 @@ struct {struct_name};
                 let message = format!(r#"Did not recognize struct attribute "{}"."#, attribute);
                 Error::new_spanned(attribute, message)
             }
+            ParseError::FunctionAttribute(fn_attrib) => match fn_attrib {
+                FunctionAttributeParseError::Identifiable(identifiable) => match identifiable {
+                    IdentifiableParseError::MustBeRefSelf { fn_ident } => {
+                        let message = format!(
+                            r#"Identifiable function {} must take `&self` as its only argument."#,
+                            fn_ident
+                        );
+                        Error::new_spanned(fn_ident, message)
+                    }
+                    IdentifiableParseError::MissingReturnType { fn_ident } => {
+                        let message = format!(
+                            r#"Identifiable function {} must have a return type."#,
+                            fn_ident
+                        );
+                        Error::new_spanned(fn_ident, message)
+                    }
+                },
+            },
         }
     }
 }

--- a/crates/swift-bridge-ir/src/parsed_extern_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn.rs
@@ -23,9 +23,28 @@ mod to_swift_func;
 /// ... etc
 pub(crate) struct ParsedExternFn {
     pub func: ForeignItemFn,
+    /// The type that this function is associated to.
+    ///
+    /// ```
+    /// # const  _: &str = stringify!(
+    /// #[swift_bridge::bridge]
+    /// mod ffi {
+    ///     extern "Rust" {
+    ///         type SomeType;
+    ///
+    ///         // This function is associated to `SomeType` since it has a receiver `&self`.
+    ///         fn some_function(&self);
+    ///     }
+    /// }
+    /// # );
+    /// ```
     pub associated_type: Option<TypeDeclaration>,
-    pub is_initializer: bool,
     pub host_lang: HostLang,
+    /// Whether or not this function is a Swift initializer.
+    pub is_swift_initializer: bool,
+    /// Whether or not this function should be used for the associated type's Swift
+    /// `Identifiable` protocol implementation.
+    pub is_swift_identifiable: bool,
     pub rust_name_override: Option<syn::LitStr>,
     pub swift_name_override: Option<syn::LitStr>,
     /// If true, we call `.into()` on the expression that the function returns before returning it.

--- a/crates/swift-integration-tests/build.rs
+++ b/crates/swift-integration-tests/build.rs
@@ -18,6 +18,7 @@ fn main() {
         "src/swift_function_uses_opaque_rust_type.rs",
         "src/conditional_compilation.rs",
         "src/opaque_type_attributes/already_declared.rs",
+        "src/function_attributes/identifiable.rs",
         "src/struct_attributes/already_declared.rs",
         "src/struct_attributes/swift_name.rs",
     ];

--- a/crates/swift-integration-tests/src/function_attributes.rs
+++ b/crates/swift-integration-tests/src/function_attributes.rs
@@ -1,3 +1,4 @@
 mod args_into;
+mod identifiable;
 mod into_return_type;
 mod rust_name;

--- a/crates/swift-integration-tests/src/function_attributes/identifiable.rs
+++ b/crates/swift-integration-tests/src/function_attributes/identifiable.rs
@@ -1,0 +1,87 @@
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        type IdentifiableFnNamedId;
+
+        #[swift_bridge(init)]
+        fn new() -> IdentifiableFnNamedId;
+        // Here we make sure that the `Identifiable` attribute works on a function named `id`.
+        // Functions named `id` don't get their Identifiable protocol extension filled out since
+        // the `id` function already exists.
+        // i.e. we generate `extension IdentifiableFnNamedId: Identifiable {}`
+        #[swift_bridge(Identifiable)]
+        fn id(self: &IdentifiableFnNamedId) -> u16;
+    }
+
+    extern "Rust" {
+        type IdentifiableFnNotNamedId;
+
+        #[swift_bridge(init)]
+        fn new() -> IdentifiableFnNotNamedId;
+        // Here we make sure that the `Identifiable` attribute works on a function not named `id`.
+        #[swift_bridge(Identifiable)]
+        fn some_function(self: &IdentifiableFnNotNamedId) -> u32;
+    }
+
+    extern "Rust" {
+        type IdentifiableU8;
+
+        #[swift_bridge(init)]
+        fn new() -> IdentifiableU8;
+        #[swift_bridge(Identifiable)]
+        fn id(&self) -> u8;
+    }
+
+    extern "Rust" {
+        type IdentifiableI8;
+
+        #[swift_bridge(init)]
+        fn new() -> IdentifiableI8;
+        #[swift_bridge(Identifiable)]
+        fn id(&self) -> i8;
+    }
+
+    extern "Rust" {
+        type IdentifiableStr;
+
+        #[swift_bridge(init)]
+        fn new() -> IdentifiableStr;
+        #[swift_bridge(Identifiable)]
+        fn id(&self) -> &'static str;
+    }
+
+    // TODO: Add more Identifiable test types..
+}
+
+pub struct IdentifiableFnNotNamedId;
+
+impl IdentifiableFnNotNamedId {
+    fn new() -> Self {
+        Self
+    }
+
+    fn some_function(&self) -> u32 {
+        123
+    }
+}
+
+macro_rules! identifiable_test_type {
+    ($name:ident, $id_ty:ty, $id_val:expr) => {
+        pub struct $name;
+        impl $name {
+            fn new() -> Self {
+                $name
+            }
+
+            fn id(&self) -> $id_ty {
+                $id_val
+            }
+        }
+    };
+}
+
+identifiable_test_type!(IdentifiableFnNamedId, u16, 123);
+
+identifiable_test_type!(IdentifiableU8, u8, 123);
+identifiable_test_type!(IdentifiableI8, i8, 123);
+identifiable_test_type!(IdentifiableStr, &'static str, "hello world");

--- a/crates/swift-integration-tests/src/slice.rs
+++ b/crates/swift-integration-tests/src/slice.rs
@@ -1,12 +1,5 @@
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//
-//     #[test]
-//     fn todo() {
-//         unimplemented!(
-//             r#"
-// - Define SliceTestOpaqueRustType
+// TODO:
+// - Define struct SliceTestOpaqueRustType
 // - Add a method to create Vec<SliceTestOpaqueRustType>
 // - Add method to reflect &[OpaqueRustType]
 //   - Add test to verify that we can iterate over the slice
@@ -15,7 +8,3 @@
 // - Create SliceTests.swift
 //   - Add Swift test verifying that we can use an Array<SliceTestOpaqueRustType> as a slice
 //   - Add Swift test verifying that we can use a RustVec<SliceTestOpaqueRustType> as a slice
-//         "#
-//         )
-//     }
-// }

--- a/src/std_bridge/string.swift
+++ b/src/std_bridge/string.swift
@@ -44,6 +44,19 @@ extension RustStr {
         return String(bytes: bytes, encoding: .utf8)!
     }
 }
+extension RustStr: Identifiable {
+    public var id: String {
+        self.toString()
+    }
+}
+extension RustStr: Equatable {
+    public static func == (lhs: RustStr, rhs: RustStr) -> Bool {
+        // TODO: Rather than compare Strings, we can avoid allocating by calling a function
+        // on the Rust side that compares the underlying byte slices.
+        return
+            lhs.toString() == rhs.toString()
+    }
+}
 
 protocol IntoRustString {
     func intoRustString() -> RustString;


### PR DESCRIPTION
This commit introduces the `#[swift_bridge(Identifiable)]` attribute
which is used to generate an `Identifiable` protocol implementation
for a type.

For example:

```rust
// Rust

#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        type SomeType;

        #[swift_bridge(Identifiable, swift_name = "someFunction")]
        fn some_function(&self) -> i16;
    }
}
```

```swift
// Generated Swift
// (rough example, the real generated code looks a little different)

class SomeType {
    // ...
}
extension SomeType: Identifiable {
    var id: UInt16 {
        return self.someFunction()
    }
}