### PR TITLE
Fix RustStr bug due to incorrect buffer size

### DIFF
--- a/src/std_bridge/string.swift
+++ b/src/std_bridge/string.swift
@@ -103,10 +103,11 @@ extension String: ToRustStr {
     /// Safely get a scoped pointer to the String and then call the callback with a RustStr
     /// that uses that pointer.
     func toRustStr<T> (_ withUnsafeRustStr: (RustStr) -> T) -> T {
-        return self.utf8CString.withUnsafeBufferPointer({ stringPtr in
+        return self.utf8CString.withUnsafeBufferPointer({ bufferPtr in
             let rustStr = RustStr(
-                start: UnsafeMutableRawPointer(mutating: stringPtr.baseAddress!).assumingMemoryBound(to: UInt8.self),
-                len: UInt(self.count)
+                start: UnsafeMutableRawPointer(mutating: bufferPtr.baseAddress!).assumingMemoryBound(to: UInt8.self),
+                // Subtract 1 because of the null termination character at the end
+                len: UInt(bufferPtr.count - 1)
             )
             return withUnsafeRustStr(rustStr)
         })


### PR DESCRIPTION
This commit fixes a race condition bug where the size that were were
reading from a buffer was corect more than 99%, but when it was
incorrect converting a `RustStr` into a `Swift stdlib String` would panic.
