### PR TITLE
Add support for Option<T> struct fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,15 +171,4 @@ We will maintain semver from `0.2` and onwards.
 
 #### License
 
-<sup>
-Licensed under either of <a href="LICENSE-APACHE">Apache License, Version
-2.0</a> or <a href="LICENSE-MIT">MIT license</a> at your option.
-</sup>
-
-<br>
-
-<sub>
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in this project by you, as defined in the Apache-2.0 license,
-shall be dual licensed as above, without any additional terms or conditions.
-</sub>
+_Licensed under [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE)._

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/ASwiftStack.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/ASwiftStack.swift
@@ -30,3 +30,4 @@ public class ASwiftStack {
         UnsafeBufferPointer(start: self.as_ptr(), count: Int(self.len()))
     }
 }
+

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
@@ -102,6 +102,51 @@ class OptionTests: XCTestCase {
         XCTAssertNil(rust_reflect_option_opaque_rust_type(nil))
     }
     
+    func testStructWithOptionFieldsSome() throws {
+        let val = StructWithOptionFields(
+            u8: 123, i8: 123, u16: 123, i16: 123,
+            u32: 123, i32: 123, u64: 123, i64: 123,
+            usize: 123, isize: 123, f32: 123.4, f64: 123.4,
+            boolean: true
+        )
+        let reflected = rust_reflect_struct_with_option_fields(val)
+        XCTAssertEqual(reflected.u8, 123)
+        XCTAssertEqual(reflected.i8, 123)
+        XCTAssertEqual(reflected.u16, 123)
+        XCTAssertEqual(reflected.i16, 123)
+        XCTAssertEqual(reflected.u32, 123)
+        XCTAssertEqual(reflected.i32, 123)
+        XCTAssertEqual(reflected.u64, 123)
+        XCTAssertEqual(reflected.i64, 123)
+        XCTAssertEqual(reflected.usize, 123)
+        XCTAssertEqual(reflected.isize, 123)
+        XCTAssertEqual(reflected.f32, 123.4)
+        XCTAssertEqual(reflected.f64, 123.4)
+        XCTAssertEqual(reflected.boolean, true)
+    }
+    
+    func testStructWithOptionFieldsNone() {
+        let val = StructWithOptionFields(
+            u8: nil, i8: nil, u16: nil, i16: nil,
+            u32: nil, i32: nil, u64: nil, i64: nil,
+            usize: nil, isize: nil, f32: nil, f64: nil,
+            boolean: nil
+        )
+        let reflected = rust_reflect_struct_with_option_fields(val)
+        XCTAssertEqual(reflected.i8, nil)
+        XCTAssertEqual(reflected.u16, nil)
+        XCTAssertEqual(reflected.i16, nil)
+        XCTAssertEqual(reflected.u32, nil)
+        XCTAssertEqual(reflected.i32, nil)
+        XCTAssertEqual(reflected.u64, nil)
+        XCTAssertEqual(reflected.i64, nil)
+        XCTAssertEqual(reflected.usize, nil)
+        XCTAssertEqual(reflected.isize, nil)
+        XCTAssertEqual(reflected.f32, nil)
+        XCTAssertEqual(reflected.f64, nil)
+        XCTAssertEqual(reflected.boolean, nil)
+    }
+    
     func testRustCallSwiftReturnOption() {
         run_option_tests()
     }

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_option.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_option.rs
@@ -119,80 +119,65 @@ impl BridgedOption {
         }
     }
 
-    pub(super) fn convert_ffi_value_to_rust_value(
-        &self,
-        value: &TokenStream,
-        type_pos: TypePosition,
-    ) -> TokenStream {
-        match type_pos {
-            TypePosition::FnArg(func_host_lang) | TypePosition::FnReturn(func_host_lang) => {
-                if func_host_lang.is_rust() {
-                    match self.ty.deref() {
-                        BridgedType::StdLib(stdlib_ty) => match stdlib_ty {
-                            StdLibType::Null => {
-                                todo!("Option<()> is not yet supported")
-                            }
-                            StdLibType::U8
-                            | StdLibType::I8
-                            | StdLibType::U16
-                            | StdLibType::I16
-                            | StdLibType::U32
-                            | StdLibType::I32
-                            | StdLibType::U64
-                            | StdLibType::I64
-                            | StdLibType::Usize
-                            | StdLibType::Isize
-                            | StdLibType::F32
-                            | StdLibType::F64
-                            | StdLibType::Bool => {
-                                quote! { if #value.is_some { Some(#value.val) } else { None } }
-                            }
-                            StdLibType::Pointer(_) => {
-                                todo!("Option<*const T> and Option<*mut T> are not yet supported.")
-                            }
-                            StdLibType::RefSlice(_) => {
-                                todo!("Option<*const T> and Option<*mut T> are not yet supported.")
-                            }
-                            StdLibType::Str => {
-                                quote! {
-                                    if #value.start.is_null() { None } else { Some(#value.to_str()) }
-                                }
-                            }
-                            StdLibType::String => {
-                                quote! {
-                                    if #value.is_null() {
-                                        None
-                                    } else {
-                                        Some(unsafe { Box::from_raw(#value).0 } )
-                                    }
-                                }
-                            }
-                            StdLibType::Vec(_) => {
-                                todo!("Option<Vec<T>> is not yet supported")
-                            }
-                            StdLibType::Option(_) => {
-                                todo!("Option<Option<T>> is not yet supported")
-                            }
-                        },
-                        BridgedType::Foreign(CustomBridgedType::Shared(_shared_struct)) => {
-                            todo!("Option<SharedStruct> is not yet supported")
-                        }
-                        BridgedType::Foreign(CustomBridgedType::Opaque(_opaque)) => {
-                            quote! {
-                                if #value.is_null() {
-                                    None
-                                } else {
-                                    Some(unsafe { * Box::from_raw(#value) } )
-                                }
-                            }
+    pub(super) fn convert_ffi_value_to_rust_value(&self, value: &TokenStream) -> TokenStream {
+        match self.ty.deref() {
+            BridgedType::StdLib(stdlib_ty) => match stdlib_ty {
+                StdLibType::Null => {
+                    todo!("Option<()> is not yet supported")
+                }
+                StdLibType::U8
+                | StdLibType::I8
+                | StdLibType::U16
+                | StdLibType::I16
+                | StdLibType::U32
+                | StdLibType::I32
+                | StdLibType::U64
+                | StdLibType::I64
+                | StdLibType::Usize
+                | StdLibType::Isize
+                | StdLibType::F32
+                | StdLibType::F64
+                | StdLibType::Bool => {
+                    quote! { if #value.is_some { Some(#value.val) } else { None } }
+                }
+                StdLibType::Pointer(_) => {
+                    todo!("Option<*const T> and Option<*mut T> are not yet supported.")
+                }
+                StdLibType::RefSlice(_) => {
+                    todo!("Option<*const T> and Option<*mut T> are not yet supported.")
+                }
+                StdLibType::Str => {
+                    quote! {
+                        if #value.start.is_null() { None } else { Some(#value.to_str()) }
+                    }
+                }
+                StdLibType::String => {
+                    quote! {
+                        if #value.is_null() {
+                            None
+                        } else {
+                            Some(unsafe { Box::from_raw(#value).0 } )
                         }
                     }
-                } else {
-                    todo!("Option<T> Swift function arguments are not yet supported.")
                 }
+                StdLibType::Vec(_) => {
+                    todo!("Option<Vec<T>> is not yet supported")
+                }
+                StdLibType::Option(_) => {
+                    todo!("Option<Option<T>> is not yet supported")
+                }
+            },
+            BridgedType::Foreign(CustomBridgedType::Shared(_shared_struct)) => {
+                todo!("Option<SharedStruct> is not yet supported")
             }
-            TypePosition::SharedStructField => {
-                todo!("Option<T> struct fields are not yet supported.")
+            BridgedType::Foreign(CustomBridgedType::Opaque(_opaque)) => {
+                quote! {
+                    if #value.is_null() {
+                        None
+                    } else {
+                        Some(unsafe { * Box::from_raw(#value) } )
+                    }
+                }
             }
         }
     }

--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct/struct_field/normalized_field.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct/struct_field/normalized_field.rs
@@ -1,0 +1,67 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+use std::str::FromStr;
+use syn::Type;
+
+pub(crate) struct NormalizedStructField {
+    pub accessor: NormalizedStructFieldAccessor,
+    pub ty: Type,
+}
+
+pub(crate) enum NormalizedStructFieldAccessor {
+    Named(Ident),
+    Unnamed(usize),
+}
+
+impl NormalizedStructField {
+    /// ```
+    /// struct A(
+    ///     // name_and_colon for this field is ""
+    ///     u8
+    /// );
+    ///
+    /// struct B {
+    ///     // name_and_colon for this field is "field: u8"
+    ///     field: u8
+    /// }
+    /// ```
+    pub fn maybe_name_and_colon(&self) -> TokenStream {
+        match &self.accessor {
+            NormalizedStructFieldAccessor::Named(name) => {
+                quote! {
+                    #name:
+                }
+            }
+            NormalizedStructFieldAccessor::Unnamed(_idx) => {
+                quote! {}
+            }
+        }
+    }
+
+    /// Access a struct's field
+    ///
+    /// // Example named field access
+    /// val -> val.field
+    /// // Example tuple access
+    /// val -> val.1
+    pub fn append_field_accessor(&self, expression: &TokenStream) -> TokenStream {
+        match &self.accessor {
+            NormalizedStructFieldAccessor::Named(name) => {
+                quote! { #expression.#name }
+            }
+            NormalizedStructFieldAccessor::Unnamed(idx) => {
+                let idx = TokenStream::from_str(&idx.to_string()).unwrap();
+                quote! { #expression.#idx }
+            }
+        }
+    }
+
+    pub fn ffi_field_name(&self) -> String {
+        match &self.accessor {
+            NormalizedStructFieldAccessor::Named(name) => name.to_string(),
+            NormalizedStructFieldAccessor::Unnamed(idx) => {
+                format!("_{}", idx)
+            }
+        }
+    }
+}

--- a/crates/swift-bridge-ir/src/codegen/generate_swift.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift.rs
@@ -413,8 +413,8 @@ fn gen_func_swift_calls_rust(
         call_rust
     } else if let Some(built_in) = function.return_ty_built_in(types) {
         built_in.convert_ffi_value_to_swift_value(
-            TypePosition::FnReturn(function.host_lang),
             &call_rust,
+            TypePosition::FnReturn(function.host_lang),
         )
     } else {
         if function.host_lang.is_swift() {

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_struct.rs
@@ -58,9 +58,10 @@ impl SwiftBridgeModule {
                     fields = format!("\n{}", fields)
                 }
 
-                let convert_swift_to_ffi_repr = shared_struct.convert_swift_to_ffi_repr("self");
+                let convert_swift_to_ffi_repr =
+                    shared_struct.convert_swift_to_ffi_repr("self", &self.types);
                 let convert_ffi_repr_to_swift =
-                    shared_struct.convert_ffi_expression_to_swift("self");
+                    shared_struct.convert_ffi_expression_to_swift("self", &self.types);
 
                 // No need to generate any code. Swift will automatically generate a
                 //  struct from our C header typedef that we generate for this struct.

--- a/crates/swift-bridge-ir/src/errors/parse_error.rs
+++ b/crates/swift-bridge-ir/src/errors/parse_error.rs
@@ -124,13 +124,14 @@ representation.
 ```
 // Valid values are "struct" and "class"
 #[swift_bridge(swift_repr = "struct")]
-struct MyStruct {{
-    count: u8
+struct {struct_name} {{
+    // ... fields ...
 }}
 ```
 
 TODO: Link to documntation on how to decide on the swift representation.
-"#
+"#,
+                    struct_name = struct_ident
                 );
                 Error::new_spanned(struct_ident, message)
             }

--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod.rs
@@ -61,7 +61,7 @@ impl<'a> ForeignModParser<'a> {
                 ForeignItem::Type(foreign_ty) => {
                     let ty_name = foreign_ty.ident.to_string();
 
-                    if let Some(_builtin) = BridgedType::with_str(
+                    if let Some(_builtin) = BridgedType::new_with_str(
                         &foreign_ty.ident.to_string(),
                         &self.type_declarations,
                     ) {
@@ -250,7 +250,8 @@ impl<'a> ForeignModParser<'a> {
                     }
                 }
                 _ => {
-                    todo!(r#"
+                    todo!(
+                        r#"
 One way to hit this block is with a `fn foo (&self: SomeType)`.
 Note that this is an invalid signature since the `&` should be in front of `SomeType`, not `self`.
 i.e., this would be correct: `fn foo (self: &SomeType)`
@@ -259,7 +260,8 @@ indicating that the function signature is invalid.
 For common mistakes such as the `&self: SomeType` example, we can have dedicated errors telling you
 exactly how to fix it.
 Otherwise we use a more general error that says that your argument is invalid.
-"#)
+"#
+                    )
                 }
             },
             None => {

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_fn.rs
@@ -33,7 +33,7 @@ impl ParsedExternFn {
 
         let prefixed_fn_name = self.prefixed_fn_name();
 
-        let ret = self.rust_return_type(self.host_lang, swift_bridge_path, types);
+        let ret = self.rust_return_type(swift_bridge_path, types);
 
         match self.host_lang {
             HostLang::Rust => {
@@ -87,7 +87,7 @@ impl ParsedExternFn {
             call_fn = return_ty.rust_expression_into(&call_fn);
         }
 
-        call_fn = return_ty.convert_rust_value_to_ffi_compatible_value(swift_bridge_path, &call_fn);
+        call_fn = return_ty.convert_rust_value_to_ffi_compatible_value(&call_fn, swift_bridge_path);
 
         call_fn
     }

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_param_names_and_types.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_param_names_and_types.rs
@@ -51,8 +51,7 @@ impl ParsedExternFn {
                         }
                     } else if let Some(built_in) = BridgedType::new_with_type(&pat_ty.ty, types) {
                         let pat = &pat_ty.pat;
-                        let ty =
-                            built_in.to_ffi_compatible_rust_type(self.host_lang, swift_bridge_path);
+                        let ty = built_in.to_ffi_compatible_rust_type(swift_bridge_path);
                         params.push(quote! { #pat: #ty});
                         continue;
                     } else {

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_rust_impl_call_swift.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_rust_impl_call_swift.rs
@@ -1,4 +1,4 @@
-use crate::bridged_type::{pat_type_pat_is_self, BridgedType, TypePosition};
+use crate::bridged_type::{pat_type_pat_is_self, BridgedType};
 use crate::parse::{SharedTypeDeclaration, TypeDeclaration, TypeDeclarations};
 use crate::parsed_extern_fn::ParsedExternFn;
 use proc_macro2::TokenStream;
@@ -64,11 +64,7 @@ impl ParsedExternFn {
         };
 
         if let Some(built_in) = BridgedType::new_with_return_type(&sig.output, types) {
-            inner = built_in.convert_ffi_value_to_rust_value(
-                &inner,
-                TypePosition::FnReturn(self.host_lang),
-                sig.output.span(),
-            );
+            inner = built_in.convert_ffi_value_to_rust_value(&inner, sig.output.span());
         } else {
             todo!("Push to ParsedErrors")
         }

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_swift_func.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_swift_func.rs
@@ -110,8 +110,8 @@ impl ParsedExternFn {
                                 )
                             } else {
                                 bridged_ty.convert_ffi_value_to_swift_value(
-                                    TypePosition::FnArg(self.host_lang),
                                     &arg,
+                                    TypePosition::FnArg(self.host_lang),
                                 )
                             }
                         } else {

--- a/crates/swift-integration-tests/src/option.rs
+++ b/crates/swift-integration-tests/src/option.rs
@@ -2,6 +2,26 @@
 
 #[swift_bridge::bridge]
 mod ffi {
+    #[swift_bridge(swift_repr = "struct")]
+    struct StructWithOptionFields {
+        u8: Option<u8>,
+        i8: Option<i8>,
+        u16: Option<u16>,
+        i16: Option<i16>,
+        u32: Option<u32>,
+        i32: Option<i32>,
+        u64: Option<u64>,
+        i64: Option<i64>,
+        usize: Option<usize>,
+        isize: Option<isize>,
+        f32: Option<f32>,
+        f64: Option<f64>,
+        boolean: Option<bool>,
+        // TODO: Support test more types:
+        // string: Option<String>,
+        // str: Option<&'static str>,
+    }
+
     extern "Rust" {
         fn rust_reflect_option_u8(arg: Option<u8>) -> Option<u8>;
         fn rust_reflect_option_i8(arg: Option<i8>) -> Option<i8>;
@@ -25,6 +45,10 @@ mod ffi {
         fn rust_reflect_option_opaque_rust_type(
             arg: Option<OptTestOpaqueRustType>,
         ) -> Option<OptTestOpaqueRustType>;
+
+        fn rust_reflect_struct_with_option_fields(
+            arg: StructWithOptionFields,
+        ) -> StructWithOptionFields;
 
         fn run_option_tests();
     }
@@ -95,5 +119,11 @@ fn rust_reflect_option_str(arg: Option<&str>) -> Option<&str> {
 fn rust_reflect_option_opaque_rust_type(
     arg: Option<OptTestOpaqueRustType>,
 ) -> Option<OptTestOpaqueRustType> {
+    arg
+}
+
+fn rust_reflect_struct_with_option_fields(
+    arg: ffi::StructWithOptionFields,
+) -> ffi::StructWithOptionFields {
     arg
 }


### PR DESCRIPTION
For example, the following is now possible:

```rust
\#[swift_bridge::bridge]
mod ffi {
    \#[swift_bridge(swift_repr = "struct")]
    struct SomeStruct {
        field: Option<u8>,
        another_field: Option<f32>,
    }
}
```
