### PR TITLE
Add `return_with = path::to::fn` attribute

### DIFF
--- a/book/src/bridge-module/extern-rust/README.md
+++ b/book/src/bridge-module/extern-rust/README.md
@@ -309,6 +309,7 @@ impl From<Uuid> for ffi::FFiUuid {
 	}
 }
 
+use self::some_other_crate::make_uuid;
 mod some_other_crate {
 	pub struct Uuid {
 	    uuid: [u8; 16]
@@ -317,6 +318,31 @@ mod some_other_crate {
     // Here we can return a Uuid, even though swift-bridge is expecting an FfiUuid.
     pub fn make_uuid() -> Uuid {
         Uuid::new_v4()
+    }
+}
+```
+
+#### #[swift_bridge(return_with = path::to::some_function)]
+
+Allows a swift-bridge definition of `fn foo() -> T` to work for a `fn foo() -> U` by
+passing `T` to a `fn(T) -> U`.
+
+```rust
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        #[swift_bridge(return_with = some_module::convert_str_to_u32)]
+        fn get_str_value_return_with() -> u32;
+    }
+}
+
+fn get_str_value_return_with() -> &'static str {
+    "123"
+}
+
+mod some_module {
+    pub fn convert_str_to_u32(val: &str) -> u32 {
+        val.parse().unwrap()
     }
 }
 ```

--- a/book/src/bridge-module/structs/README.md
+++ b/book/src/bridge-module/structs/README.md
@@ -9,7 +9,8 @@ You can define structs whos fields can be accessed by both Rust and Swift.
 mod ffi {
     #[swift_bridge::bridge(swift_repr = "struct")]
     struct SomeSharedStruct {
-        some_field: u8
+        some_field: u8,
+        another_field: Option<u64>
     }
 
     extern "Rust" {
@@ -30,7 +31,7 @@ fn some_function (val: ffi::SomeSharedStruct) {
 // Swift 
 
 func another_function() -> SomeSharedStruct {
-    return SomeSharedStruct(some_field: 123)
+    return SomeSharedStruct(some_field: 123, another_field: nil)
 }
 ```
 

--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod.rs
@@ -194,6 +194,7 @@ impl<'a> ForeignModParser<'a> {
                         rust_name_override: attributes.rust_name,
                         swift_name_override: attributes.swift_name,
                         into_return_type: attributes.into_return_type,
+                        return_with: attributes.return_with,
                         args_into: attributes.args_into,
                     });
                 }

--- a/crates/swift-bridge-ir/src/parsed_extern_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn.rs
@@ -59,6 +59,7 @@ pub(crate) struct ParsedExternFn {
     /// }
     /// ```
     pub into_return_type: bool,
+    pub return_with: Option<Path>,
     /// Call `.into()` before passing this argument to the function that handles it.
     ///
     /// ```no_run,ignore

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_fn.rs
@@ -87,6 +87,12 @@ impl ParsedExternFn {
             call_fn = return_ty.rust_expression_into(&call_fn);
         }
 
+        if let Some(return_with) = self.return_with.as_ref() {
+            call_fn = quote! {
+                super:: #return_with ( #call_fn )
+            }
+        }
+
         call_fn = return_ty.convert_rust_value_to_ffi_compatible_value(&call_fn, swift_bridge_path);
 
         call_fn

--- a/crates/swift-integration-tests/src/function_attributes.rs
+++ b/crates/swift-integration-tests/src/function_attributes.rs
@@ -1,4 +1,5 @@
 mod args_into;
 mod identifiable;
 mod into_return_type;
+mod return_with;
 mod rust_name;

--- a/crates/swift-integration-tests/src/function_attributes/return_with.rs
+++ b/crates/swift-integration-tests/src/function_attributes/return_with.rs
@@ -1,0 +1,19 @@
+//! If this file compiles then we know that our return value was converted.
+
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        #[swift_bridge(return_with = some_module::convert_str_to_u32)]
+        fn get_str_value_return_with() -> u32;
+    }
+}
+
+fn get_str_value_return_with() -> &'static str {
+    "123"
+}
+
+mod some_module {
+    pub fn convert_str_to_u32(val: &str) -> u32 {
+        val.parse().unwrap()
+    }
+}


### PR DESCRIPTION
```rust
#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        #[swift_bridge(return_with = some_module::convert_str_to_u32)]
        fn get_str_value_return_with() -> u32;
    }
}

fn get_str_value_return_with() -> &'static str {
    "123"
}

mod some_module {
    pub fn convert_str_to_u32(val: &str) -> u32 {
        val.parse().unwrap()
    }
}
```
