### PR TITLE
Support enums as fn args and fn returns

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2202BC0827B2DD1700D43CC4 /* SharedEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2202BC0727B2DD1700D43CC4 /* SharedEnumTests.swift */; };
 		22043293274A8FDF00BAE645 /* VecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22043292274A8FDF00BAE645 /* VecTests.swift */; };
 		22043295274ADA7A00BAE645 /* OptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22043294274ADA7A00BAE645 /* OptionTests.swift */; };
 		22043297274B0AB000BAE645 /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22043296274B0AB000BAE645 /* Option.swift */; };
@@ -50,6 +51,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2202BC0727B2DD1700D43CC4 /* SharedEnumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedEnumTests.swift; sourceTree = "<group>"; };
 		22043292274A8FDF00BAE645 /* VecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VecTests.swift; sourceTree = "<group>"; };
 		22043294274ADA7A00BAE645 /* OptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionTests.swift; sourceTree = "<group>"; };
 		22043296274B0AB000BAE645 /* Option.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Option.swift; sourceTree = "<group>"; };
@@ -167,6 +169,7 @@
 				22043292274A8FDF00BAE645 /* VecTests.swift */,
 				22043294274ADA7A00BAE645 /* OptionTests.swift */,
 				220432A6274C953E00BAE645 /* PointerTests.swift */,
+				2202BC0727B2DD1700D43CC4 /* SharedEnumTests.swift */,
 				220432AE274E7BF800BAE645 /* SharedStructTests.swift */,
 				220432EB27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift */,
 				22FD1C552753CB3F00F64281 /* SwiftFnUsesOpaqueRustTypeTests.swift */,
@@ -353,6 +356,7 @@
 				220432AF274E7BF800BAE645 /* SharedStructTests.swift in Sources */,
 				220432EC27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift in Sources */,
 				228FE6502749C43100805D9E /* BooleanTests.swift in Sources */,
+				2202BC0827B2DD1700D43CC4 /* SharedEnumTests.swift in Sources */,
 				22BCAAB927A2607700686A21 /* FunctionAttributeIdentifiableTests.swift in Sources */,
 				221E16B42786233600F94AC0 /* ConditionalCompilationTests.swift in Sources */,
 				22043295274ADA7A00BAE645 /* OptionTests.swift in Sources */,

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
@@ -1,0 +1,34 @@
+//
+//  SharedEnumTests.swift
+//  SwiftRustIntegrationTestRunnerTests
+//
+//  Created by Frankie Nwafili on 2/8/22.
+//
+
+import XCTest
+@testable import SwiftRustIntegrationTestRunner
+
+class SharedEnumTests: XCTestCase {
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testEnumWithNoData() {
+        let enumWithNoData1 = EnumWithNoData.Variant1
+        let enumWithNoData2 = EnumWithNoData.Variant2
+        
+        let reflected1 = reflect_enum_with_no_data(enumWithNoData1)
+        let reflected2 = reflect_enum_with_no_data(enumWithNoData2)
+        
+        switch (reflected1, reflected2) {
+        case (.Variant1, .Variant2):
+            break;
+        default:
+            fatalError()
+        }
+    }
+}

--- a/crates/swift-bridge-ir/src/bridged_type/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_enum.rs
@@ -1,4 +1,6 @@
-use proc_macro2::Ident;
+use crate::SWIFT_BRIDGE_PREFIX;
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
 use std::fmt::{Debug, Formatter};
 
 mod enum_variant;
@@ -8,6 +10,32 @@ pub(crate) use self::enum_variant::EnumVariant;
 pub(crate) struct SharedEnum {
     pub name: Ident,
     pub variants: Vec<EnumVariant>,
+}
+
+impl SharedEnum {
+    /// SomeEnum
+    pub fn swift_name_string(&self) -> String {
+        format!("{}", self.name)
+    }
+
+    /// __swift_bridge__$SomeEnum
+    pub fn ffi_name_string(&self) -> String {
+        format!("{}${}", SWIFT_BRIDGE_PREFIX, self.name)
+    }
+
+    /// __swift_bridge__$SomeEnumTag
+    pub fn ffi_tag_name_string(&self) -> String {
+        format!("{}Tag", self.ffi_name_string())
+    }
+
+    /// __swift_bridge__SomeEnum
+    pub fn ffi_name_tokens(&self) -> TokenStream {
+        let name = Ident::new(
+            &format!("{}{}", SWIFT_BRIDGE_PREFIX, self.name),
+            self.name.span(),
+        );
+        quote! { #name }
+    }
 }
 
 impl PartialEq for SharedEnum {

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests.rs
@@ -36,6 +36,7 @@ mod extern_rust_method_swift_class_placement_codegen_tests;
 mod extern_rust_opaque_type_codegen_tests;
 mod function_attribute_codegen_tests;
 mod option_codegen_tests;
+mod shared_enum_codegen_tests;
 mod shared_struct_codegen_tests;
 mod string_codegen_tests;
 mod vec_codegen_tests;
@@ -264,8 +265,6 @@ impl CodegenTest {
         };
 
         let swift = module.generate_swift(&codegen_config);
-        let c_header = module.generate_c_header_inner(&codegen_config);
-
         match self.expected_swift_code {
             ExpectedSwiftCode::ExactAfterTrim(expected_swift) => {
                 assert_trimmed_generated_equals_trimmed_expected(&swift, expected_swift);
@@ -301,6 +300,7 @@ impl CodegenTest {
             ExpectedSwiftCode::SkipTest => {}
         };
 
+        let c_header = module.generate_c_header_inner(&codegen_config);
         match self.expected_c_header {
             ExpectedCHeader::ExactAfterTrim(expected) => {
                 assert_trimmed_generated_equals_trimmed_expected(&c_header, expected);

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/shared_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/shared_enum_codegen_tests.rs
@@ -1,0 +1,177 @@
+use super::{CodegenTest, ExpectedCHeader, ExpectedRustTokens, ExpectedSwiftCode};
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Verify that we generate the correct to_ffi_repr() and to_rust_repr() implementations for an
+/// enum where none of the variants contain any data.
+mod generates_struct_to_and_from_ffi_conversions_no_data {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            #[swift_bridge::bridge]
+            mod ffi {
+                enum SomeEnum {
+                    Variant1,
+                    Variant2,
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::Contains(quote! {
+            mod ffi {
+                pub enum SomeEnum {
+                    Variant1,
+                    Variant2
+                }
+
+                #[repr(C)]
+                #[doc(hidden)]
+                pub enum __swift_bridge__SomeEnum {
+                    Variant1,
+                    Variant2
+                }
+
+                impl swift_bridge::SharedEnum for SomeEnum {
+                    type FfiRepr = __swift_bridge__SomeEnum;
+                }
+
+                impl SomeEnum {
+                    #[doc(hidden)]
+                    #[inline(always)]
+                    pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
+                        match self {
+                            SomeEnum::Variant1 => __swift_bridge__SomeEnum::Variant1,
+                            SomeEnum::Variant2 => __swift_bridge__SomeEnum::Variant2
+                        }
+                    }
+                }
+
+                impl __swift_bridge__SomeEnum {
+                    #[doc(hidden)]
+                    #[inline(always)]
+                    pub fn into_rust_repr(self) -> SomeEnum {
+                        match self {
+                            __swift_bridge__SomeEnum::Variant1 => SomeEnum::Variant1,
+                            __swift_bridge__SomeEnum::Variant2 => SomeEnum::Variant2
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(
+            r#"
+public enum SomeEnum {
+    case Variant1
+    case Variant2
+}
+extension SomeEnum {
+    func intoFfiRepr() -> __swift_bridge__$SomeEnum {
+        switch self {
+            case SomeEnum.Variant1:
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant1)
+            case SomeEnum.Variant2:
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant2)
+        }
+    }
+}
+extension __swift_bridge__$SomeEnum {
+    func intoSwiftRepr() -> SomeEnum {
+        switch self.tag {
+            case __swift_bridge__$SomeEnum$Variant1:
+                return SomeEnum.Variant1
+            case __swift_bridge__$SomeEnum$Variant2:
+                return SomeEnum.Variant2
+            default:
+                fatalError("Unreachable")
+        }
+    }
+}
+"#,
+        )
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ExactAfterTrim(
+            r#"
+typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$Variant1, __swift_bridge__$SomeEnum$Variant2, } __swift_bridge__$SomeEnumTag;
+typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; } __swift_bridge__$SomeEnum;
+    "#,
+        )
+    }
+
+    #[test]
+    fn generates_struct_to_and_from_ffi_conversions_no_data() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}
+
+/// Verify that we generate the correct code for a function that has an enum as an argument and
+/// returns an enum.
+mod using_enum_in_extern_rust_fn {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            #[swift_bridge::bridge]
+            mod ffi {
+                enum SomeEnum {
+                    Variant1,
+                    Variant2,
+                }
+
+                extern "Rust" {
+                    fn some_function(arg: SomeEnum) -> SomeEnum;
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::Contains(quote! {
+            pub extern "C" fn __swift_bridge__some_function(arg: __swift_bridge__SomeEnum) -> __swift_bridge__SomeEnum {
+                super::some_function(arg.into_rust_repr()).into_ffi_repr()
+            }
+        })
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(
+            r#"
+func some_function(_ arg: SomeEnum) -> SomeEnum {
+    __swift_bridge__$some_function(arg.intoFfiRepr()).intoSwiftRepr()
+}
+"#,
+        )
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ContainsAfterTrim(
+            r#"
+struct __swift_bridge__$SomeEnum __swift_bridge__$some_function(struct __swift_bridge__$SomeEnum arg);
+    "#,
+        )
+    }
+
+    #[test]
+    fn using_enum_in_extern_rust_fn() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -115,9 +115,27 @@ impl SwiftBridgeModule {
                         header += &ty_decl;
                         header += "\n";
                     }
-                    SharedTypeDeclaration::Enum(_ty_enum) => {
-                        //
-                        todo!("Generate enum C header")
+                    SharedTypeDeclaration::Enum(ty_enum) => {
+                        let ffi_name = ty_enum.ffi_name_string();
+                        let ffi_tag_name = ty_enum.ffi_tag_name_string();
+
+                        let mut variants = "".to_string();
+
+                        for variant in ty_enum.variants.iter() {
+                            let v = format!("{}${}, ", ffi_name, variant.name);
+                            variants += &v;
+                        }
+
+                        let enum_decl = format!(
+                            r#"typedef enum {ffi_tag_name} {{ {variants}}} {ffi_tag_name};
+typedef struct {ffi_name} {{ {ffi_tag_name} tag; }} {ffi_name};"#,
+                            ffi_name = ffi_name,
+                            ffi_tag_name = ffi_tag_name,
+                            variants = variants
+                        );
+
+                        header += &enum_decl;
+                        header += "\n";
                     }
                 },
                 TypeDeclaration::Opaque(ty) => {

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
@@ -11,6 +11,7 @@ use crate::codegen::generate_rust_tokens::vec::generate_vec_of_opaque_rust_type_
 use crate::parse::{HostLang, SharedTypeDeclaration, TypeDeclaration};
 use crate::{SwiftBridgeModule, SWIFT_BRIDGE_PREFIX};
 
+mod shared_enum;
 mod shared_struct;
 mod vec;
 
@@ -23,6 +24,7 @@ impl ToTokens for SwiftBridgeModule {
         let mut structs_for_swift_classes = vec![];
 
         let mut shared_struct_definitions = vec![];
+        let mut shared_enum_definitions = vec![];
         let mut impl_fn_tokens: HashMap<String, Vec<TokenStream>> = HashMap::new();
         let mut freestanding_rust_call_swift_fn_tokens = vec![];
         let mut extern_swift_fn_tokens = vec![];
@@ -70,9 +72,10 @@ impl ToTokens for SwiftBridgeModule {
                         shared_struct_definitions.push(definition);
                     }
                 }
-                TypeDeclaration::Shared(SharedTypeDeclaration::Enum(_shared_enum)) => {
-                    //
-                    todo!("Generate enum Rust tokens")
+                TypeDeclaration::Shared(SharedTypeDeclaration::Enum(shared_enum)) => {
+                    if let Some(definition) = self.generate_shared_enum_tokens(shared_enum) {
+                        shared_enum_definitions.push(definition);
+                    }
                 }
                 TypeDeclaration::Opaque(ty) => {
                     let link_name =
@@ -167,6 +170,8 @@ impl ToTokens for SwiftBridgeModule {
 
         let module_inner = quote! {
             #(#shared_struct_definitions)*
+
+            #(#shared_enum_definitions)*
 
             #(#extern_rust_fn_tokens)*
 

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
@@ -1,0 +1,98 @@
+//! More tests can be found in
+//! crates/swift-bridge-ir/src/codegen/codegen_tests/shared_enum_codegen_tests.rs
+
+use crate::bridged_type::SharedEnum;
+use crate::{SwiftBridgeModule, SWIFT_BRIDGE_PREFIX};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Ident;
+
+impl SwiftBridgeModule {
+    /// Generate the tokens for a shared enum.
+    pub(super) fn generate_shared_enum_tokens(
+        &self,
+        shared_enum: &SharedEnum,
+    ) -> Option<TokenStream> {
+        let enum_name = &shared_enum.name;
+        let swift_bridge_path = &self.swift_bridge_path;
+
+        let enum_ffi_name = format!("{}{}", SWIFT_BRIDGE_PREFIX, enum_name);
+        let enum_ffi_name = Ident::new(&enum_ffi_name, enum_name.span());
+
+        let mut enum_variants = vec![];
+        let mut enum_ffi_variants = vec![];
+
+        for variant in shared_enum.variants.iter() {
+            let variant_name = &variant.name;
+            let v = quote! {
+                #variant_name
+            };
+            enum_variants.push(v);
+        }
+
+        for variant in shared_enum.variants.iter() {
+            let variant_name = &variant.name;
+            let v = quote! {
+                #variant_name
+            };
+            enum_ffi_variants.push(v);
+        }
+
+        let mut convert_rust_variants_to_ffi = vec![];
+        let mut convert_ffi_variants_to_rust = vec![];
+
+        for variant in shared_enum.variants.iter() {
+            let variant_name = &variant.name;
+            let v = quote! {
+                #enum_name :: #variant_name => #enum_ffi_name :: #variant_name
+            };
+            convert_rust_variants_to_ffi.push(v);
+        }
+
+        for variant in shared_enum.variants.iter() {
+            let variant_name = &variant.name;
+            let v = quote! {
+                #enum_ffi_name :: #variant_name => #enum_name :: #variant_name
+            };
+            convert_ffi_variants_to_rust.push(v);
+        }
+
+        let definition = quote! {
+            pub enum #enum_name {
+                #(#enum_variants),*
+            }
+
+            #[repr(C)]
+            #[doc(hidden)]
+            pub enum #enum_ffi_name {
+                #(#enum_ffi_variants),*
+            }
+
+            impl #swift_bridge_path::SharedEnum for #enum_name {
+                type FfiRepr = #enum_ffi_name;
+            }
+
+            impl #enum_name {
+                #[doc(hidden)]
+                #[inline(always)]
+                pub fn into_ffi_repr(self) -> #enum_ffi_name {
+                    match self {
+                        #(#convert_rust_variants_to_ffi),*
+                    }
+                }
+            }
+
+            impl #enum_ffi_name {
+                #[doc(hidden)]
+                #[inline(always)]
+                pub fn into_rust_repr(self) -> #enum_name {
+                    match self {
+                        #(#convert_ffi_variants_to_rust),*
+                    }
+                }
+            }
+        };
+
+        Some(definition)
+    }
+}

--- a/crates/swift-bridge-ir/src/codegen/generate_swift.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift.rs
@@ -16,6 +16,7 @@ use crate::{SwiftBridgeModule, SWIFT_BRIDGE_PREFIX};
 
 mod vec;
 
+mod shared_enum;
 mod shared_struct;
 
 impl SwiftBridgeModule {
@@ -89,9 +90,11 @@ impl SwiftBridgeModule {
                         swift += "\n";
                     }
                 }
-                TypeDeclaration::Shared(SharedTypeDeclaration::Enum(_shared_enum)) => {
-                    //
-                    todo!("Generate shared enum")
+                TypeDeclaration::Shared(SharedTypeDeclaration::Enum(shared_enum)) => {
+                    if let Some(swift_enum) = self.generate_shared_enum_string(shared_enum) {
+                        swift += &swift_enum;
+                        swift += "\n";
+                    }
                 }
                 TypeDeclaration::Opaque(ty) => match ty.host_lang {
                     HostLang::Rust => {

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
@@ -1,0 +1,83 @@
+use crate::bridged_type::SharedEnum;
+use crate::SwiftBridgeModule;
+
+impl SwiftBridgeModule {
+    /// Generate the tokens for a shared enum.
+    pub(super) fn generate_shared_enum_string(&self, shared_enum: &SharedEnum) -> Option<String> {
+        let enum_name = shared_enum.swift_name_string();
+        let enum_ffi_name = shared_enum.ffi_name_string();
+
+        let mut variants = "".to_string();
+        let mut convert_swift_to_ffi_repr = "".to_string();
+        let mut convert_ffi_repr_to_swift = "".to_string();
+
+        for variant in shared_enum.variants.iter() {
+            let v = format!(
+                r#"
+    case {name}"#,
+                name = variant.name
+            );
+            variants += &v;
+        }
+        if variants.len() > 0 {
+            variants += "\n";
+        }
+
+        for variant in shared_enum.variants.iter() {
+            let case = format!(
+                r#"
+            case {enum_name}.{variant_name}:
+                return {enum_ffi_name}(tag: {enum_ffi_name}${variant_name})"#,
+                enum_name = enum_name,
+                enum_ffi_name = enum_ffi_name,
+                variant_name = variant.name
+            );
+            convert_swift_to_ffi_repr += &case;
+        }
+        if convert_swift_to_ffi_repr.len() > 0 {
+            convert_swift_to_ffi_repr += "\n        ";
+        }
+
+        for variant in shared_enum.variants.iter() {
+            let case = format!(
+                r#"
+            case {enum_ffi_name}${variant_name}:
+                return {enum_name}.{variant_name}"#,
+                enum_name = enum_name,
+                enum_ffi_name = enum_ffi_name,
+                variant_name = variant.name
+            );
+            convert_ffi_repr_to_swift += &case;
+        }
+        if convert_ffi_repr_to_swift.len() > 0 {
+            convert_ffi_repr_to_swift += &format!(
+                r#"
+            default:
+                fatalError("Unreachable")
+        "#
+            );
+        }
+
+        let swift_enum = format!(
+            r#"public enum {enum_name} {{{variants}}}
+extension {enum_name} {{
+    func intoFfiRepr() -> {ffi_repr_name} {{
+        switch self {{{convert_swift_to_ffi_repr}}}
+    }}
+}}
+extension {enum_ffi_name} {{
+    func intoSwiftRepr() -> {enum_name} {{
+        switch self.tag {{{convert_ffi_repr_to_swift}}}
+    }}
+}}"#,
+            enum_name = enum_name,
+            enum_ffi_name = enum_ffi_name,
+            ffi_repr_name = shared_enum.ffi_name_string(),
+            variants = variants,
+            convert_swift_to_ffi_repr = convert_swift_to_ffi_repr,
+            convert_ffi_repr_to_swift = convert_ffi_repr_to_swift
+        );
+
+        Some(swift_enum)
+    }
+}

--- a/crates/swift-integration-tests/build.rs
+++ b/crates/swift-integration-tests/build.rs
@@ -14,6 +14,7 @@ fn main() {
         "src/vec.rs",
         "src/slice.rs",
         "src/shared_types/shared_struct.rs",
+        "src/shared_types/shared_enum.rs",
         "src/rust_function_uses_opaque_swift_type.rs",
         "src/swift_function_uses_opaque_rust_type.rs",
         "src/conditional_compilation.rs",

--- a/crates/swift-integration-tests/src/option.rs
+++ b/crates/swift-integration-tests/src/option.rs
@@ -22,6 +22,10 @@ mod ffi {
         // str: Option<&'static str>,
     }
 
+    // enum OptionEnumWithNoData {
+    //     Variant,
+    // }
+
     extern "Rust" {
         fn rust_reflect_option_u8(arg: Option<u8>) -> Option<u8>;
         fn rust_reflect_option_i8(arg: Option<i8>) -> Option<i8>;
@@ -49,6 +53,8 @@ mod ffi {
         fn rust_reflect_struct_with_option_fields(
             arg: StructWithOptionFields,
         ) -> StructWithOptionFields;
+
+        // fn rust_reflect_option_enum_wit_no_data(arg: OptionEnumWithNoData) -> OptionEnumWithNoData;
 
         fn run_option_tests();
     }
@@ -127,3 +133,8 @@ fn rust_reflect_struct_with_option_fields(
 ) -> ffi::StructWithOptionFields {
     arg
 }
+// fn rust_reflect_option_enum_wit_no_data(
+//     arg: ffi::OptionEnumWithNoData,
+// ) -> ffi::OptionEnumWithNoData {
+//     arg
+// }

--- a/crates/swift-integration-tests/src/shared_types.rs
+++ b/crates/swift-integration-tests/src/shared_types.rs
@@ -1,1 +1,2 @@
+mod shared_enum;
 mod shared_struct;

--- a/crates/swift-integration-tests/src/shared_types/shared_enum.rs
+++ b/crates/swift-integration-tests/src/shared_types/shared_enum.rs
@@ -1,0 +1,15 @@
+#[swift_bridge::bridge]
+mod ffi {
+    enum EnumWithNoData {
+        Variant1,
+        Variant2,
+    }
+
+    extern "Rust" {
+        fn reflect_enum_with_no_data(arg: EnumWithNoData) -> EnumWithNoData;
+    }
+}
+
+fn reflect_enum_with_no_data(arg: ffi::EnumWithNoData) -> ffi::EnumWithNoData {
+    arg
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,27 @@ pub trait SharedStruct {
     type FfiRepr;
 }
 
+// The code generation automatically implements this for all shared enum.
+// This trait is private and should not be used outside of swift-bridge.
+#[doc(hidden)]
+pub trait SharedEnum {
+    /// The FFI friendly representation of this struct.
+    ///
+    /// ```
+    /// enum MyEnum {
+    ///     Variant1,
+    ///     Variant2,
+    /// }
+    /// // This is the auto generated ffi representation.
+    /// #[repr(C)]
+    /// enum __swift_bridge__MyEnum {
+    ///     Variant1,
+    ///     Variant2,
+    /// }
+    /// ```
+    type FfiRepr;
+}
+
 #[no_mangle]
 #[doc(hidden)]
 pub extern "C" fn __swift_bridge__null_pointer() -> *const std::ffi::c_void {


### PR DESCRIPTION
This commit introduces the ability to pass enums as function
arguments and return enums from functions.

For example, the following signature is now possible:

```rust
// Rust
#[swift_bridge::bridge]
mod ffi {
    enum SomeEnum {
        Variant1,
        Variant2,
    }

    extern "Rust" {
        fn some_function(arg: SomeEnum) -> SomeEnum;
    }
}
```

```swift
// Swift
let _: SomeEnum = some_function(SomeEnum.Variant2)
```
