### PR TITLE
Support `Option<Enum>`

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
@@ -147,6 +147,21 @@ class OptionTests: XCTestCase {
         XCTAssertEqual(reflected.boolean, nil)
     }
     
+    func testEnumWhereVariantsHaveNoData() {
+        let val = OptionEnumWithNoData.Variant2
+        let reflectedSome = rust_reflect_option_enum_wit_no_data(val)
+        let reflectedNone = rust_reflect_option_enum_wit_no_data(nil)
+        
+        switch reflectedSome! {
+        case .Variant2:
+            break;
+        default:
+            fatalError()
+        }
+        
+        XCTAssertNil(reflectedNone)
+    }
+    
     func testRustCallSwiftReturnOption() {
         run_option_tests()
     }

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -551,9 +551,10 @@ impl BridgedType {
                         todo!("Option<SharedStruct> is not yet supported")
                     }
                     BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(
-                        _shared_enum,
+                        shared_enum,
                     ))) => {
-                        todo!("Option<SharedEnum> is not yet supported")
+                        let name = shared_enum.ffi_option_name_tokens();
+                        quote! { #name }
                     }
                     BridgedType::Foreign(CustomBridgedType::Opaque(opaque)) => {
                         let type_name = &opaque.ident;
@@ -1378,8 +1379,12 @@ impl BridgedType {
             BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Struct(_shared_struct))) => {
                 todo!("Support Option<SharedStruct>")
             }
-            BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(_shared_enum))) => {
-                todo!("Support Option<SharedEnum>")
+            BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(shared_enum))) => {
+                let option_name = shared_enum.ffi_option_name_tokens();
+                UnusedOptionNoneValue {
+                    rust: quote! { #option_name { is_some: false, val: std::mem::MaybeUninit::uninit() } },
+                    swift: "TODO..Support Swift Option<Enum>::None value".into(),
+                }
             }
             BridgedType::Foreign(CustomBridgedType::Opaque(opaque)) => {
                 let ty_name = &opaque.ty.ident;

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_option.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_option.rs
@@ -104,8 +104,14 @@ impl BridgedOption {
                     todo!("Support Option<Option<T>>")
                 }
             },
-            BridgedType::Foreign(CustomBridgedType::Shared(_shared_type)) => {
-                todo!("Support Option<SharedType>")
+            BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Struct(_shared_struct))) => {
+                todo!("Support Option<SharedStruct>")
+            }
+            BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(shared_enum))) => {
+                let option_name = shared_enum.ffi_option_name_tokens();
+                quote! {
+                    #option_name::from_rust_repr(#expression)
+                }
             }
             BridgedType::Foreign(CustomBridgedType::Opaque(_opaque_type)) => {
                 quote! {
@@ -167,8 +173,13 @@ impl BridgedOption {
                     todo!("Option<Option<T>> is not yet supported")
                 }
             },
-            BridgedType::Foreign(CustomBridgedType::Shared(_shared_struct)) => {
+            BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Struct(_shared_struct))) => {
                 todo!("Option<SharedStruct> is not yet supported")
+            }
+            BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(_shared_enum))) => {
+                quote! {
+                    #value.into_rust_repr()
+                }
             }
             BridgedType::Foreign(CustomBridgedType::Opaque(_opaque)) => {
                 quote! {
@@ -225,8 +236,11 @@ impl BridgedOption {
                     todo!("Support Option<Option<T>>")
                 }
             },
-            BridgedType::Foreign(CustomBridgedType::Shared(_shared)) => {
-                todo!("Support Option<SharedType>")
+            BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Struct(_shared_struct))) => {
+                todo!("Support Option<SharedStruct>")
+            }
+            BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(_shared_enum))) => {
+                format!("{expression}.intoSwiftRepr()", expression = expression)
             }
             BridgedType::Foreign(CustomBridgedType::Opaque(opaque)) => {
                 let type_name = opaque.swift_name();
@@ -304,8 +318,13 @@ impl BridgedOption {
             BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Struct(_shared_struct))) => {
                 todo!("Shared structs within options are not yet supported")
             }
-            BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(_shared_enum))) => {
-                todo!("Shared enums within options are not yet supported")
+            BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(shared_enum))) => {
+                let ffi_name = shared_enum.ffi_option_name_string();
+                format!(
+                    "{ffi_name}.fromSwiftRepr({expression})",
+                    ffi_name = ffi_name,
+                    expression = expression
+                )
             }
             BridgedType::Foreign(CustomBridgedType::Opaque(_opaque)) => {
                 format!("{{ if let val = {expression} {{ val.isOwned = false; return val.ptr }} else {{ return nil }} }}()", expression = expression,)
@@ -352,8 +371,8 @@ impl BridgedOption {
             BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Struct(_shared_struct))) => {
                 todo!("Option<SharedStruct> is not yet supported")
             }
-            BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(_shared_enum))) => {
-                todo!("Option<SharedEnum> is not yet supported")
+            BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(shared_enum))) => {
+                format!("struct {}", shared_enum.ffi_option_name_string())
             }
             BridgedType::Foreign(CustomBridgedType::Opaque(_opaque)) => "void*".to_string(),
         }

--- a/crates/swift-bridge-ir/src/bridged_type/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_enum.rs
@@ -36,6 +36,20 @@ impl SharedEnum {
         );
         quote! { #name }
     }
+
+    /// __swift_bridge__Option_SomeEnum
+    pub fn ffi_option_name_tokens(&self) -> TokenStream {
+        let name = Ident::new(
+            &format!("{}Option_{}", SWIFT_BRIDGE_PREFIX, self.name),
+            self.name.span(),
+        );
+        quote! { #name }
+    }
+
+    /// __swift_bridge__$Option$SomeEnum
+    pub fn ffi_option_name_string(&self) -> String {
+        format!("{}$Option${}", SWIFT_BRIDGE_PREFIX, self.name)
+    }
 }
 
 impl PartialEq for SharedEnum {

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/shared_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/shared_enum_codegen_tests.rs
@@ -4,7 +4,7 @@ use quote::quote;
 
 /// Verify that we generate the correct to_ffi_repr() and to_rust_repr() implementations for an
 /// enum where none of the variants contain any data.
-mod generates_struct_to_and_from_ffi_conversions_no_data {
+mod generates_enum_to_and_from_ffi_conversions_no_data {
     use super::*;
 
     fn bridge_module_tokens() -> TokenStream {
@@ -21,42 +21,40 @@ mod generates_struct_to_and_from_ffi_conversions_no_data {
 
     fn expected_rust_tokens() -> ExpectedRustTokens {
         ExpectedRustTokens::Contains(quote! {
-            mod ffi {
-                pub enum SomeEnum {
-                    Variant1,
-                    Variant2
-                }
+            pub enum SomeEnum {
+                Variant1,
+                Variant2
+            }
 
-                #[repr(C)]
+            #[repr(C)]
+            #[doc(hidden)]
+            pub enum __swift_bridge__SomeEnum {
+                Variant1,
+                Variant2
+            }
+
+            impl swift_bridge::SharedEnum for SomeEnum {
+                type FfiRepr = __swift_bridge__SomeEnum;
+            }
+
+            impl SomeEnum {
                 #[doc(hidden)]
-                pub enum __swift_bridge__SomeEnum {
-                    Variant1,
-                    Variant2
-                }
-
-                impl swift_bridge::SharedEnum for SomeEnum {
-                    type FfiRepr = __swift_bridge__SomeEnum;
-                }
-
-                impl SomeEnum {
-                    #[doc(hidden)]
-                    #[inline(always)]
-                    pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
-                        match self {
-                            SomeEnum::Variant1 => __swift_bridge__SomeEnum::Variant1,
-                            SomeEnum::Variant2 => __swift_bridge__SomeEnum::Variant2
-                        }
+                #[inline(always)]
+                pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
+                    match self {
+                        SomeEnum::Variant1 => __swift_bridge__SomeEnum::Variant1,
+                        SomeEnum::Variant2 => __swift_bridge__SomeEnum::Variant2
                     }
                 }
+            }
 
-                impl __swift_bridge__SomeEnum {
-                    #[doc(hidden)]
-                    #[inline(always)]
-                    pub fn into_rust_repr(self) -> SomeEnum {
-                        match self {
-                            __swift_bridge__SomeEnum::Variant1 => SomeEnum::Variant1,
-                            __swift_bridge__SomeEnum::Variant2 => SomeEnum::Variant2
-                        }
+            impl __swift_bridge__SomeEnum {
+                #[doc(hidden)]
+                #[inline(always)]
+                pub fn into_rust_repr(self) -> SomeEnum {
+                    match self {
+                        __swift_bridge__SomeEnum::Variant1 => SomeEnum::Variant1,
+                        __swift_bridge__SomeEnum::Variant2 => SomeEnum::Variant2
                     }
                 }
             }
@@ -99,14 +97,16 @@ extension __swift_bridge__$SomeEnum {
     fn expected_c_header() -> ExpectedCHeader {
         ExpectedCHeader::ExactAfterTrim(
             r#"
+#include <stdbool.h>
 typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$Variant1, __swift_bridge__$SomeEnum$Variant2, } __swift_bridge__$SomeEnumTag;
 typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; } __swift_bridge__$SomeEnum;
-    "#,
+typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__$SomeEnum val; } __swift_bridge__$Option$SomeEnum;
+"#,
         )
     }
 
     #[test]
-    fn generates_struct_to_and_from_ffi_conversions_no_data() {
+    fn generates_enum_to_and_from_ffi_conversions_no_data() {
         CodegenTest {
             bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),
@@ -166,6 +166,127 @@ struct __swift_bridge__$SomeEnum __swift_bridge__$some_function(struct __swift_b
 
     #[test]
     fn using_enum_in_extern_rust_fn() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}
+
+/// Verify that we can use `Option<Enum>` as Rust function arg and return type.
+mod extern_rust_option_enum {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            #[swift_bridge::bridge]
+            mod ffi {
+                enum SomeEnum {
+                    Variant1,
+                    Variant2,
+                }
+
+                extern "Rust" {
+                    fn some_function(arg: Option<SomeEnum>) -> Option<SomeEnum>;
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::ContainsMany(vec![
+            quote! {
+                #[repr(C)]
+                #[doc(hidden)]
+                pub struct __swift_bridge__Option_SomeEnum {
+                    is_some: bool,
+                    val: std::mem::MaybeUninit<__swift_bridge__SomeEnum>,
+                }
+
+                impl __swift_bridge__Option_SomeEnum {
+                    #[doc(hidden)]
+                    #[inline(always)]
+                    pub fn into_rust_repr(self) -> Option<SomeEnum> {
+                        if self.is_some {
+                            Some(unsafe { self.val.assume_init().into_rust_repr() })
+                        } else {
+                            None
+                        }
+                    }
+
+                    #[doc(hidden)]
+                    #[inline(always)]
+                    pub fn from_rust_repr(val: Option<SomeEnum>) -> __swift_bridge__Option_SomeEnum {
+                        if let Some(val) = val {
+                            __swift_bridge__Option_SomeEnum {
+                                is_some: true,
+                                val: std::mem::MaybeUninit::new(val.into_ffi_repr())
+                            }
+                        } else {
+                            __swift_bridge__Option_SomeEnum {
+                                is_some: false,
+                                val: std::mem::MaybeUninit::uninit()
+                            }
+                        }
+                    }
+                }
+            },
+            quote! {
+                pub extern "C" fn __swift_bridge__some_function(arg: __swift_bridge__Option_SomeEnum) -> __swift_bridge__Option_SomeEnum {
+                    __swift_bridge__Option_SomeEnum::from_rust_repr(super::some_function(arg.into_rust_repr()))
+                }
+            },
+        ])
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsManyAfterTrim(vec![
+            r#"
+extension __swift_bridge__$Option$SomeEnum {
+    @inline(__always)
+    func intoSwiftRepr() -> Optional<SomeEnum> {
+        if self.is_some {
+            return self.val.intoSwiftRepr()
+        } else {
+            return nil
+        }
+    }
+
+    @inline(__always)
+    static func fromSwiftRepr(_ val: Optional<SomeEnum>) -> __swift_bridge__$Option$SomeEnum {
+        if let v = val {
+            return __swift_bridge__$Option$SomeEnum(is_some: true, val: v.intoFfiRepr())
+        } else {
+            return __swift_bridge__$Option$SomeEnum(is_some: false, val: __swift_bridge__$SomeEnum())
+        }
+    }
+}
+"#,
+            r#"
+func some_function(_ arg: Optional<SomeEnum>) -> Optional<SomeEnum> {
+    __swift_bridge__$some_function(__swift_bridge__$Option$SomeEnum.fromSwiftRepr(arg)).intoSwiftRepr()
+}
+"#,
+        ])
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ExactAfterTrim(
+            r#"
+#include <stdbool.h>
+typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$Variant1, __swift_bridge__$SomeEnum$Variant2, } __swift_bridge__$SomeEnumTag;
+typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; } __swift_bridge__$SomeEnum;
+typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__$SomeEnum val; } __swift_bridge__$Option$SomeEnum;
+struct __swift_bridge__$Option$SomeEnum __swift_bridge__$some_function(struct __swift_bridge__$Option$SomeEnum arg);
+    "#,
+        )
+    }
+
+    #[test]
+    fn option_enum() {
         CodegenTest {
             bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -118,6 +118,11 @@ impl SwiftBridgeModule {
                     SharedTypeDeclaration::Enum(ty_enum) => {
                         let ffi_name = ty_enum.ffi_name_string();
                         let ffi_tag_name = ty_enum.ffi_tag_name_string();
+                        let option_ffi_name = ty_enum.ffi_option_name_string();
+
+                        // Used for `Option<T>` ...
+                        // typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; ...
+                        bookkeeping.includes.insert("stdbool.h");
 
                         let mut variants = "".to_string();
 
@@ -128,9 +133,11 @@ impl SwiftBridgeModule {
 
                         let enum_decl = format!(
                             r#"typedef enum {ffi_tag_name} {{ {variants}}} {ffi_tag_name};
-typedef struct {ffi_name} {{ {ffi_tag_name} tag; }} {ffi_name};"#,
+typedef struct {ffi_name} {{ {ffi_tag_name} tag; }} {ffi_name};
+typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi_name};"#,
                             ffi_name = ffi_name,
                             ffi_tag_name = ffi_tag_name,
+                            option_ffi_name = option_ffi_name,
                             variants = variants
                         );
 

--- a/crates/swift-integration-tests/src/option.rs
+++ b/crates/swift-integration-tests/src/option.rs
@@ -22,9 +22,11 @@ mod ffi {
         // str: Option<&'static str>,
     }
 
-    // enum OptionEnumWithNoData {
-    //     Variant,
-    // }
+    // An enum where none of the variants have data.
+    enum OptionEnumWithNoData {
+        Variant1,
+        Variant2,
+    }
 
     extern "Rust" {
         fn rust_reflect_option_u8(arg: Option<u8>) -> Option<u8>;
@@ -54,7 +56,9 @@ mod ffi {
             arg: StructWithOptionFields,
         ) -> StructWithOptionFields;
 
-        // fn rust_reflect_option_enum_wit_no_data(arg: OptionEnumWithNoData) -> OptionEnumWithNoData;
+        fn rust_reflect_option_enum_wit_no_data(
+            arg: Option<OptionEnumWithNoData>,
+        ) -> Option<OptionEnumWithNoData>;
 
         fn run_option_tests();
     }
@@ -133,8 +137,8 @@ fn rust_reflect_struct_with_option_fields(
 ) -> ffi::StructWithOptionFields {
     arg
 }
-// fn rust_reflect_option_enum_wit_no_data(
-//     arg: ffi::OptionEnumWithNoData,
-// ) -> ffi::OptionEnumWithNoData {
-//     arg
-// }
+fn rust_reflect_option_enum_wit_no_data(
+    arg: Option<ffi::OptionEnumWithNoData>,
+) -> Option<ffi::OptionEnumWithNoData> {
+    arg
+}


### PR DESCRIPTION
This commit adds support for passing `Option<Enum>` across the FFI boundary.

For example, the following is now possible:

```rust
#[swift_bridge::bridge]
mod ffi {
    enum SomeEnum {
        Variant1,
        Variant2,
    }

    extern "Rust" {
        fn some_function(arg: Option<SomeEnum>) -> Option<SomeEnum>;
    }
}
```
