### PR TITLE
Support parsing generic opaque Rust types

### DIFF
--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::ToTokens;
 use quote::{quote, quote_spanned};
-use syn::{FnArg, ForeignItemType, Pat, PatType, Path, ReturnType, Type};
+use syn::{FnArg, Pat, PatType, Path, ReturnType, Type};
 
 use crate::parse::{HostLang, TypeDeclarations};
 use crate::SWIFT_BRIDGE_PREFIX;
@@ -180,7 +180,7 @@ pub(crate) enum SharedType {
 
 #[derive(Clone)]
 pub(crate) struct OpaqueForeignType {
-    pub ty: ForeignItemType,
+    pub ty: Ident,
     pub host_lang: HostLang,
     pub reference: bool,
     pub mutable: bool,
@@ -188,7 +188,7 @@ pub(crate) struct OpaqueForeignType {
 
 impl OpaqueForeignType {
     fn swift_name(&self) -> String {
-        format!("{}", self.ty.ident)
+        format!("{}", self.ty)
     }
 }
 
@@ -237,7 +237,7 @@ pub(crate) fn fn_arg_name(fn_arg: &FnArg) -> Option<&Ident> {
 }
 
 impl Deref for OpaqueForeignType {
-    type Target = ForeignItemType;
+    type Target = Ident;
 
     fn deref(&self) -> &Self::Target {
         &self.ty
@@ -426,7 +426,7 @@ impl BridgedType {
                 todo!("Shared enum to Rust type name")
             }
             BridgedType::Foreign(CustomBridgedType::Opaque(opaque)) => {
-                let ty_name = &opaque.ty.ident;
+                let ty_name = &opaque.ty;
 
                 if opaque.host_lang.is_rust() {
                     quote! {
@@ -565,7 +565,7 @@ impl BridgedType {
                         quote! { #name }
                     }
                     BridgedType::Foreign(CustomBridgedType::Opaque(opaque)) => {
-                        let type_name = &opaque.ident;
+                        let type_name = &opaque.ty;
 
                         quote! { *mut super::#type_name }
                     }
@@ -592,7 +592,7 @@ impl BridgedType {
                 quote! { #ffi_ty_name }
             }
             BridgedType::Foreign(CustomBridgedType::Opaque(opaque)) => {
-                let ty_name = &opaque.ty.ident;
+                let ty_name = &opaque.ty;
 
                 if opaque.host_lang.is_rust() {
                     if opaque.reference {
@@ -753,7 +753,7 @@ impl BridgedType {
                         TypePosition::FnArg(func_host_lang)
                         | TypePosition::FnReturn(func_host_lang) => {
                             if func_host_lang.is_rust() {
-                                let mut class_name = opaque.ty.ident.to_string();
+                                let mut class_name = opaque.ty.to_string();
 
                                 if opaque.reference {
                                     class_name += "Ref";
@@ -781,7 +781,7 @@ impl BridgedType {
                         TypePosition::FnArg(func_host_lang)
                         | TypePosition::FnReturn(func_host_lang) => {
                             if func_host_lang.is_rust() {
-                                opaque.ty.ident.to_string()
+                                opaque.ty.to_string()
                             } else {
                                 "__private__PointerToSwiftType".to_string()
                             }
@@ -961,7 +961,7 @@ impl BridgedType {
                 }
             }
             BridgedType::Foreign(CustomBridgedType::Opaque(opaque)) => {
-                let ty_name = &opaque.ty.ident;
+                let ty_name = &opaque.ty;
 
                 if opaque.host_lang.is_rust() {
                     if opaque.reference {
@@ -1154,7 +1154,7 @@ impl BridgedType {
                 format!("{}.intoSwiftRepr()", value)
             }
             BridgedType::Foreign(CustomBridgedType::Opaque(opaque)) => {
-                let mut ty_name = opaque.ty.ident.to_string();
+                let mut ty_name = opaque.ty.to_string();
 
                 if opaque.reference {
                     ty_name += "Ref";
@@ -1265,7 +1265,7 @@ impl BridgedType {
                 format!("{}.intoFfiRepr()", value)
             }
             BridgedType::Foreign(CustomBridgedType::Opaque(opaque)) => {
-                let ty_name = &opaque.ty.ident;
+                let ty_name = &opaque.ty;
 
                 if opaque.host_lang.is_rust() {
                     if opaque.reference {
@@ -1438,7 +1438,7 @@ impl BridgedType {
                 }
             }
             BridgedType::Foreign(CustomBridgedType::Opaque(opaque)) => {
-                let ty_name = &opaque.ty.ident;
+                let ty_name = &opaque.ty;
 
                 if opaque.reference {
                     todo!("Support returning Option<&T> where T is an opaque type")

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -163,7 +163,7 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                         continue;
                     }
 
-                    let ty_name = ty.ident.to_string();
+                    let ty_name = ty.to_string();
 
                     let ty_decl = format!("typedef struct {ty_name} {ty_name};", ty_name = ty_name);
                     let drop_ty = format!(

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
@@ -49,7 +49,7 @@ impl ToTokens for SwiftBridgeModule {
                             }
                             TypeDeclaration::Opaque(ty) => {
                                 impl_fn_tokens
-                                    .entry(ty.ident.to_string())
+                                    .entry(ty.to_string())
                                     .or_default()
                                     .push(tokens);
                             }
@@ -78,14 +78,13 @@ impl ToTokens for SwiftBridgeModule {
                     }
                 }
                 TypeDeclaration::Opaque(ty) => {
-                    let link_name =
-                        format!("{}${}$_free", SWIFT_BRIDGE_PREFIX, ty.ident.to_string(),);
+                    let link_name = format!("{}${}$_free", SWIFT_BRIDGE_PREFIX, ty.to_string(),);
                     let free_mem_func_name = Ident::new(
-                        &format!("{}{}__free", SWIFT_BRIDGE_PREFIX, ty.ident.to_string()),
-                        ty.ident.span(),
+                        &format!("{}{}__free", SWIFT_BRIDGE_PREFIX, ty.to_string()),
+                        ty.span(),
                     );
-                    let this = &ty.ident;
-                    let ty_name = &ty.ident;
+                    let this = &ty.ty;
+                    let ty_name = &ty.ty;
 
                     match ty.host_lang {
                         HostLang::Rust => {
@@ -105,7 +104,7 @@ impl ToTokens for SwiftBridgeModule {
                             }
                         }
                         HostLang::Swift => {
-                            let ty_name = &ty.ident;
+                            let ty_name = &ty.ty;
 
                             let impls = match impl_fn_tokens.get(&ty_name.to_string()) {
                                 Some(impls) if impls.len() > 0 => {

--- a/crates/swift-bridge-ir/src/codegen/generate_swift.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift.rs
@@ -42,7 +42,7 @@ impl SwiftBridgeModule {
                         }
                         TypeDeclaration::Opaque(opaque_ty) => {
                             associated_funcs_and_methods
-                                .entry(opaque_ty.ident.to_string())
+                                .entry(opaque_ty.to_string())
                                 .or_default()
                                 .push(function);
 
@@ -57,7 +57,7 @@ impl SwiftBridgeModule {
                                     .to_swift_type(TypePosition::FnReturn(opaque_ty.host_lang)),
                                 };
                                 class_protocols
-                                    .entry(opaque_ty.ident.to_string())
+                                    .entry(opaque_ty.to_string())
                                     .or_default()
                                     .identifiable = Some(identifiable_protocol);
                             }
@@ -98,7 +98,7 @@ impl SwiftBridgeModule {
                 }
                 TypeDeclaration::Opaque(ty) => match ty.host_lang {
                     HostLang::Rust => {
-                        let class_protocols = class_protocols.get(&ty.ty.ident.to_string());
+                        let class_protocols = class_protocols.get(&ty.ty.to_string());
                         let default_cp = ClassProtocols::default();
                         let class_protocols = class_protocols.unwrap_or(&default_cp);
 
@@ -112,7 +112,7 @@ impl SwiftBridgeModule {
                         swift += "\n";
 
                         if !ty.already_declared {
-                            swift += &generate_vectorizable_extension(&ty.ident);
+                            swift += &generate_vectorizable_extension(&ty);
                             swift += "\n";
                         }
                     }
@@ -145,7 +145,7 @@ fn generate_swift_class(
     types: &TypeDeclarations,
     swift_bridge_path: &Path,
 ) -> String {
-    let type_name = ty.ident.to_string();
+    let type_name = ty.to_string();
 
     let mut initializers = vec![];
 
@@ -388,7 +388,7 @@ fn gen_func_swift_calls_rust(
                 todo!()
             }
             TypeDeclaration::Opaque(ty) => {
-                format!("${}", ty.ident.to_string())
+                format!("${}", ty.to_string())
             }
         }
     } else {
@@ -671,7 +671,7 @@ fn gen_function_exposes_swift_to_rust(
                     //
                     todo!()
                 }
-                TypeDeclaration::Opaque(associated_type) => associated_type.ident.to_string(),
+                TypeDeclaration::Opaque(associated_type) => associated_type.to_string(),
             };
 
             if func.is_method() {

--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod/function_attributes.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod/function_attributes.rs
@@ -184,7 +184,7 @@ mod tests {
         let module = parse_ok(tokens);
 
         let ty = &module.types.types()[0].unwrap_opaque();
-        assert_eq!(ty.ident.to_string(), "Foo");
+        assert_eq!(ty.to_string(), "Foo");
 
         assert_eq!(module.functions.len(), 1,);
     }
@@ -206,7 +206,7 @@ mod tests {
         let module = parse_ok(tokens);
 
         let ty = &module.types.types()[0].unwrap_opaque();
-        assert_eq!(ty.ident.to_string(), "Foo");
+        assert_eq!(ty.to_string(), "Foo");
 
         assert_eq!(module.functions.len(), 1,);
     }

--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod/generic_opaque_type.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod/generic_opaque_type.rs
@@ -1,0 +1,24 @@
+use proc_macro2::Ident;
+use syn::parse::{Parse, ParseStream};
+use syn::{Generics, Token};
+
+pub(crate) struct GenericOpaqueType {
+    #[allow(unused)]
+    pub type_token: Token![type],
+    pub ident: Ident,
+    #[allow(unused)]
+    pub generics: Generics,
+    #[allow(unused)]
+    pub semicolon: Token![;],
+}
+
+impl Parse for GenericOpaqueType {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(GenericOpaqueType {
+            type_token: input.parse()?,
+            ident: input.parse()?,
+            generics: input.parse()?,
+            semicolon: input.parse()?,
+        })
+    }
+}

--- a/crates/swift-bridge-ir/src/parse/type_declarations.rs
+++ b/crates/swift-bridge-ir/src/parse/type_declarations.rs
@@ -7,7 +7,7 @@ use proc_macro2::Ident;
 use quote::ToTokens;
 use std::collections::HashMap;
 use std::ops::Deref;
-use syn::{ForeignItemType, PatType, Type, TypePath};
+use syn::{GenericParam, PatType, Type, TypePath};
 
 #[derive(Default)]
 pub(crate) struct TypeDeclarations {
@@ -61,7 +61,7 @@ impl TypeDeclaration {
 
 #[derive(Clone)]
 pub(crate) struct OpaqueForeignTypeDeclaration {
-    pub ty: ForeignItemType,
+    pub ty: Ident,
     pub host_lang: HostLang,
     /// Whether or not the `#[swift_bridge(already_declared)]` attribute was present on the type.
     /// If it was, we won't generate Swift and C type declarations for this type, since we
@@ -71,10 +71,12 @@ pub(crate) struct OpaqueForeignTypeDeclaration {
     // TODO: Use this to generate doc comment for the generated Swift type.
     #[allow(unused)]
     pub doc_comment: Option<String>,
+    #[allow(unused)]
+    pub generics: Vec<GenericParam>,
 }
 
 impl Deref for OpaqueForeignTypeDeclaration {
-    type Target = ForeignItemType;
+    type Target = Ident;
 
     fn deref(&self) -> &Self::Target {
         &self.ty
@@ -84,20 +86,16 @@ impl Deref for OpaqueForeignTypeDeclaration {
 impl OpaqueForeignTypeDeclaration {
     // "__swift_bridge__$TypeName$_free"
     pub fn free_link_name(&self) -> String {
-        format!(
-            "{}${}$_free",
-            SWIFT_BRIDGE_PREFIX,
-            self.ty.ident.to_string()
-        )
+        format!("{}${}$_free", SWIFT_BRIDGE_PREFIX, self.ty.to_string())
     }
 
     // "__swift_bridge__TypeName__free"
     pub fn free_func_name(&self) -> String {
-        format!("{}{}__free", SWIFT_BRIDGE_PREFIX, self.ty.ident.to_string())
+        format!("{}{}__free", SWIFT_BRIDGE_PREFIX, self.ty.to_string())
     }
 
     pub fn ty_name_ident(&self) -> &Ident {
-        &self.ty.ident
+        &self.ty
     }
 }
 

--- a/crates/swift-bridge-ir/src/parsed_extern_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn.rs
@@ -147,7 +147,7 @@ impl ParsedExternFn {
                     todo!()
                 }
                 TypeDeclaration::Opaque(associated_ty) => {
-                    format!("{}_", associated_ty.ident)
+                    format!("{}_", associated_ty.ty)
                 }
             }
         } else {
@@ -352,7 +352,7 @@ impl ParsedExternFn {
                         todo!()
                     }
                     TypeDeclaration::Opaque(h) => {
-                        format!("${}", h.ident.to_string())
+                        format!("${}", h.to_string())
                     }
                 }
             })
@@ -377,7 +377,7 @@ impl ParsedExternFn {
                         todo!()
                     }
                     TypeDeclaration::Opaque(h) => {
-                        format!("{}_", h.ident.to_token_stream().to_string())
+                        format!("{}_", h.to_token_stream().to_string())
                     }
                 }
             })

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_fn.rs
@@ -175,7 +175,7 @@ impl ParsedExternFn {
                     todo!()
                 }
                 TypeDeclaration::Opaque(ty) => {
-                    let ty = &ty.ident;
+                    let ty = &ty.ty;
                     quote! {#ty::}
                 }
             }

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_param_names_and_types.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_param_names_and_types.rs
@@ -17,7 +17,7 @@ impl ParsedExternFn {
             TypeDeclaration::Shared(_) => {
                 todo!()
             }
-            TypeDeclaration::Opaque(h) => &h.ident,
+            TypeDeclaration::Opaque(h) => &h.ty,
         });
         let mut params = vec![];
         let inputs = &self.func.sig.inputs;
@@ -25,7 +25,7 @@ impl ParsedExternFn {
             match arg {
                 FnArg::Receiver(_receiver) => match self.host_lang {
                     HostLang::Rust => {
-                        let this = host_type.as_ref().unwrap();
+                        let this = &host_type.as_ref().unwrap();
                         let this = quote! { this: *mut super:: #this };
                         params.push(this);
                     }
@@ -121,7 +121,7 @@ impl ParsedExternFn {
                                     if opaque.host_lang.is_swift() {
                                         quote! { *mut std::ffi::c_void }
                                     } else {
-                                        let ty = &opaque.ty.ident;
+                                        let ty = &opaque.ty;
                                         quote! { *mut super::#ty }
                                     }
                                 }
@@ -132,7 +132,7 @@ impl ParsedExternFn {
                                     todo!("Add a test that hits this code path")
                                 }
                                 TypeDeclaration::Opaque(opaque) => {
-                                    let ty = &opaque.ty.ident;
+                                    let ty = &opaque.ty;
 
                                     if opaque.host_lang.is_swift() {
                                         quote! { #ty }

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_rust_impl_call_swift.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_rust_impl_call_swift.rs
@@ -116,7 +116,7 @@ impl ParsedExternFn {
                                         todo!("Add a test that hits this code path")
                                     }
                                     TypeDeclaration::Opaque(opaque) => {
-                                        let ty = &opaque.ty.ident;
+                                        let ty = &opaque.ty;
                                         if opaque.host_lang.is_rust() {
                                             quote! { #pat: super:: #ty}
                                         } else {


### PR DESCRIPTION
This commit adds support for parsing generic opaque types such as.

```rust
struct SomeType<K, V> {
    field1: K,
    field2: V
}

#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        type SomeType<K, V>;
    }
}
```

This is meant to be groundwork for supporting generics.

Note that we can only parse these types. We can't actually use them yet.

The main blocker is figuring out how to handle freeing generic types.

Every monomorphization of `SomeType<K,V>`, such as `SomeType<u8, u16>` and
`SomeType<String, Vec<u32>>` needs a function that Swift can call
in order to free the memory.

One approach would be to look at everywhere that you use
`SomeType<K,V>` and generate all of the appropriate freeing functions.

This works when you have a single bridge module, but breaks
down if you're splitting your definitions across multiple bridge
modules using the `#[already_declared]` attribute.

Yeah.. We need to figure out a good approachh to freeing.. And maybe
some other things as well.
