### PR TITLE
Add instructions to install Rust toolchains

### DIFF
--- a/book/src/building/swift-packages/README.md
+++ b/book/src/building/swift-packages/README.md
@@ -95,6 +95,12 @@ cargo build --target aarch64-apple-ios
 cargo build --target x86_64-apple-ios
 ```
 
+Install Rust toolchains for the desired platforms:
+
+```bash
+rustup target add x86_64-apple-darwin aarch64-apple-ios x86_64-apple-ios
+```
+
 Run the script to build our Rust libraries:
 
 ```sh


### PR DESCRIPTION
I followed the instructions from the book but got a wall of cryptic errors like these.

```
error[E0433]: failed to resolve: use of undeclared type `Box`
  --> /Users/shritesh/.cargo/git/checkouts/swift-bridge-cc2009e90e2b9ee8/54e0b7e/src/std_bridge/rust_vec.rs:33:40
   |
12 | vec_externs!(i64, OptionI64, 123);
   | --------------------------------- in this macro invocation
...
33 |                     let vec = unsafe { Box::from_raw(vec) };
   |                                        ^^^ use of undeclared type `Box`
   |
```

Turns out, I didn't have the required toolchains installed. 