### PR TITLE
Add support for args in async functions

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
@@ -19,9 +19,9 @@ class AsyncTests: XCTestCase {
     func testSwiftCallsRustAsyncFn() async throws {
         await rust_async_return_null()
     }
-    
-    func testSwiftCallsRustAsyncFnRetU8() async throws {
-        let num = await rust_async_return_u8()
+   
+    func testSwiftCallsRustAsyncFnReflectU8() async throws {
+        let num = await rust_async_reflect_u8(123)
         XCTAssertEqual(num, 123)
     }
     

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -260,8 +260,14 @@ fn declare_func(
             format!(", {} ret", maybe_ret.to_c())
         };
 
+        let maybe_params = if func.sig.inputs.is_empty() {
+            "".to_string()
+        } else {
+            format!(", {}", params)
+        };
+
         format!(
-            "void {name}(void* callback_wrapper, void {name}$async(void* callback_wrapper{maybe_ret}));\n",
+            "void {name}(void* callback_wrapper, void {name}$async(void* callback_wrapper{maybe_ret}){maybe_params});\n",
             name = name,
             maybe_ret = maybe_ret
         )

--- a/crates/swift-bridge-ir/src/codegen/generate_swift.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift.rs
@@ -376,7 +376,13 @@ fn gen_func_swift_calls_rust(
     let call_args = function.to_swift_call_args(true, false, types, swift_bridge_path);
 
     let call_fn = if function.sig.asyncness.is_some() {
-        format!("{}(wrapperPtr, onComplete)", fn_name)
+        let maybe_args = if function.sig.inputs.is_empty() {
+            "".to_string()
+        } else {
+            format!(", {}", call_args)
+        };
+
+        format!("{}(wrapperPtr, onComplete{})", fn_name, maybe_args)
     } else {
         format!("{}({})", fn_name, call_args)
     };

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_fn.rs
@@ -41,7 +41,9 @@ impl ParsedExternFn {
 
                 let maybe_return_ty = self.maybe_async_rust_fn_return_ty(swift_bridge_path, types);
 
-                if self.sig.asyncness.is_none() {
+                let is_async = self.sig.asyncness.is_some();
+
+                if !is_async {
                     quote! {
                         #[export_name = #link_name]
                         pub extern "C" fn #prefixed_fn_name ( #params ) #ret {
@@ -73,7 +75,8 @@ impl ParsedExternFn {
                         #[export_name = #link_name]
                         pub extern "C" fn #prefixed_fn_name (
                             callback_wrapper: *mut std::ffi::c_void,
-                            callback: extern "C" fn(*mut std::ffi::c_void #maybe_return_ty) -> ()
+                            callback: extern "C" fn(*mut std::ffi::c_void #maybe_return_ty) -> (),
+                            #params
                         ) {
                             let callback_wrapper = swift_bridge::async_support::SwiftCallbackWrapper(callback_wrapper);
                             let task = async move {

--- a/crates/swift-integration-tests/src/async_function.rs
+++ b/crates/swift-integration-tests/src/async_function.rs
@@ -4,15 +4,15 @@ mod ffi {
 
     extern "Rust" {
         async fn rust_async_return_null();
-        async fn rust_async_return_u8() -> u8;
+        async fn rust_async_reflect_u8(arg: u8) -> u8;
         async fn rust_async_return_struct() -> AsyncRustFnReturnStruct;
     }
 }
 
 async fn rust_async_return_null() {}
 
-async fn rust_async_return_u8() -> u8 {
-    123
+async fn rust_async_reflect_u8(arg: u8) -> u8 {
+    arg
 }
 
 async fn rust_async_return_struct() -> ffi::AsyncRustFnReturnStruct {


### PR DESCRIPTION
For example, the following is now possible:

```rust
#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        async fn some_async_fn(arg: u8);
    }
}
```
