### PR TITLE
Support async methods (&self)

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
@@ -20,10 +20,20 @@ class AsyncTests: XCTestCase {
         await rust_async_return_null()
     }
    
+    /// Verify that we can call async Rust functions
     func testSwiftCallsRustAsyncFnReflectU8() async throws {
         let num = await rust_async_reflect_u8(123)
         XCTAssertEqual(num, 123)
     }
+    
+    /// Verify that we can call async Rust methods
+    func testSwiftCallsRustAsyncMethodReflectU16() async throws {
+        let test = TestRustAsyncSelf()
+
+        let num = await test.reflect_u16(567)
+        XCTAssertEqual(num, 567)
+    }
+
     
     func testSwiftCallsRustAsyncFnRetStruct() async throws {
         let _: AsyncRustFnReturnStruct = await rust_async_return_struct()

--- a/crates/swift-integration-tests/src/async_function.rs
+++ b/crates/swift-integration-tests/src/async_function.rs
@@ -6,6 +6,15 @@ mod ffi {
         async fn rust_async_return_null();
         async fn rust_async_reflect_u8(arg: u8) -> u8;
         async fn rust_async_return_struct() -> AsyncRustFnReturnStruct;
+
+    }
+
+    extern "Rust" {
+        type TestRustAsyncSelf;
+
+        #[swift_bridg(init)]
+        fn new() -> TestRustAsyncSelf;
+        async fn reflect_u16(&self, arg: u16) -> u16;
     }
 }
 
@@ -17,4 +26,16 @@ async fn rust_async_reflect_u8(arg: u8) -> u8 {
 
 async fn rust_async_return_struct() -> ffi::AsyncRustFnReturnStruct {
     ffi::AsyncRustFnReturnStruct
+}
+
+pub struct TestRustAsyncSelf;
+
+impl TestRustAsyncSelf {
+    fn new() -> Self {
+        TestRustAsyncSelf
+    }
+
+    async fn reflect_u16(&self, arg: u16) -> u16 {
+        arg
+    }
 }


### PR DESCRIPTION
For example, the following is now possible:

```rust
#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        type SomeType;
        async fn some_async_method (&self);
    }
}
```
