### PR TITLE
Fix first run of integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,11 +44,6 @@ jobs:
       with:
         toolchain: stable
 
-    # Make sure the files that we will generate exist before the build begins.
-    # This prevents the "Build input files cannot be found" error for generated files.
-    - name: Create generated files
-      run: PROJECT_DIR="$(pwd)/SwiftRustIntegrationTestRunner" ./SwiftRustIntegrationTestRunner/build-rust.sh
-
     - name: Add rust targets
       run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
 

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -32,6 +32,14 @@ cd swift-package-test-package
 swift test
 cd ..
 
+# If project files don't exist before Xcode begins building we get something like:
+# error: Build input file cannot be found: '/path/to/Generated/SwiftBridgeCore.swift'
+# So.. here we create empty versions of the files that will get generated during the
+# build so that Xcode knows about them.
+# During the build process these will get overwritten with their real final contents.
+touch ./Generated/SwiftBridgeCore.{h,swift}
+mkdir -p ./Generated/swift-integration-tests
+touch ./Generated/swift-integration-tests/swift-integration-tests.{h,swift}
 
 xcodebuild \
   -project SwiftRustIntegrationTestRunner.xcodeproj \


### PR DESCRIPTION
This commit makes the `./test-integration.sh` script create empty
versions of the generated bridge files before the Xcodebuild process
starts.

This fixes an issue where if a file is generated during Xcode build, but
was not there before the build process started, you get an error such
as:
`error: Build input file cannot be found: '/path/to/genrated-file'.
