### PR TITLE
Introduce get and get_with attributes

### DIFF
--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
@@ -458,9 +458,9 @@ mod tests {
         assert_tokens_contain(&parse_ok(start).to_token_stream(), &expected_func);
     }
 
-    /// Verify that we respect the `into_return_type` attribute from within extern "Rust" blocks.
+    /// Verify that we respect the `return_into` attribute from within extern "Rust" blocks.
     #[test]
-    fn extern_rust_into_return_type() {
+    fn extern_rust_return_into() {
         let start = quote! {
             #[swift_bridge::bridge]
             mod foo {

--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod.rs
@@ -183,6 +183,7 @@ impl<'a> ForeignModParser<'a> {
                         return_into: attributes.return_into,
                         return_with: attributes.return_with,
                         args_into: attributes.args_into,
+                        get_field: attributes.get_field,
                     };
                     self.functions.push(func);
                 }

--- a/crates/swift-bridge-ir/src/parsed_extern_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn.rs
@@ -73,6 +73,43 @@ pub(crate) struct ParsedExternFn {
     /// }
     /// ```
     pub args_into: Option<Vec<Ident>>,
+    /// Get one of the associated type's fields
+    pub get_field: Option<GetField>,
+}
+
+pub(crate) enum GetField {
+    Direct(GetFieldDirect),
+    With(GetFieldWith),
+}
+
+pub struct GetFieldDirect {
+    pub(crate) maybe_ref: Option<Token![&]>,
+    pub(crate) maybe_mut: Option<Token![mut]>,
+    pub(crate) field_name: Ident,
+}
+
+pub struct GetFieldWith {
+    pub(crate) maybe_ref: Option<Token![&]>,
+    pub(crate) maybe_mut: Option<Token![mut]>,
+    pub(crate) field_name: Ident,
+    pub(crate) path: Path,
+}
+
+#[cfg(test)]
+impl GetField {
+    pub(crate) fn unwrap_direct(&self) -> &GetFieldDirect {
+        match self {
+            GetField::Direct(d) => d,
+            _ => panic!(),
+        }
+    }
+
+    pub(crate) fn unwrap_with(&self) -> &GetFieldWith {
+        match self {
+            GetField::With(d) => d,
+            _ => panic!(),
+        }
+    }
 }
 
 impl ParsedExternFn {

--- a/crates/swift-integration-tests/src/function_attributes.rs
+++ b/crates/swift-integration-tests/src/function_attributes.rs
@@ -1,4 +1,6 @@
 mod args_into;
+mod get;
+mod get_with;
 mod identifiable;
 mod return_into;
 mod return_with;

--- a/crates/swift-integration-tests/src/function_attributes/get.rs
+++ b/crates/swift-integration-tests/src/function_attributes/get.rs
@@ -1,0 +1,17 @@
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        type SomeTypeGet;
+
+        #[swift_bridge(get(my_u8))]
+        fn my_u8(&self) -> u8;
+
+        #[swift_bridge(get(&my_string))]
+        fn my_string_reference(&self) -> &str;
+    }
+}
+
+pub struct SomeTypeGet {
+    my_u8: u8,
+    my_string: String,
+}

--- a/crates/swift-integration-tests/src/function_attributes/get_with.rs
+++ b/crates/swift-integration-tests/src/function_attributes/get_with.rs
@@ -1,0 +1,33 @@
+use Clone;
+
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        type SomeTypeGetWith;
+
+        // Returns ui_to_i16(self.my_u8)
+        #[swift_bridge(get_with(my_u8 = u8_to_i16))]
+        fn my_u8_converted(&self) -> i16;
+
+        // Returns Clone::clone(&self.my_string)
+        #[swift_bridge(get_with(&my_string = Clone::clone))]
+        fn my_string_cloned(&self) -> String;
+
+        // Returns string_to_u32(&self.my_string)
+        #[swift_bridge(get_with(&my_string = string_to_u32))]
+        fn my_string_parsed(&self) -> u32;
+    }
+}
+
+pub struct SomeTypeGetWith {
+    my_u8: u8,
+    my_string: String,
+}
+
+fn u8_to_i16(num: u8) -> i16 {
+    num as i16
+}
+
+fn string_to_u32(string: &str) -> u32 {
+    string.parse().unwrap()
+}


### PR DESCRIPTION
This commit introduces the `#[swift_bridge(get(field))]` and
`#[swift_bridge(get_with(field = path::to::function))]` attributes.

These allow you to pass a field from Rust to Swift even if that field
without needing to go through an existing method on the type.

Use cases include:

1. Not needing to define a method just so that you can pass a value to
   Swift

2. Exposing fields on third-party Rust types where the orphan rule
   prevents you from defining a getter function.

---

For example the following is now possible:

```rust
#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        type SomeType;

        // Returns self.my_u8
        #[swift_bridge(get(my_u8))]
        fn my_u8(&self) -> u8;

        // Returns ui_to_i16(self.my_u8)
        #[swift_bridge(get_with(my_u8 = u8_to_i16))]
        fn my_u8_converted(&self) -> i16;

        // Returns &self.my_string
        #[swift_bridge(get(&my_string))]
        fn my_string_reference(&self) -> &str;

        // Returns Clone::clone(&self.my_string)
        #[swift_bridge(get_with(&my_string = Clone::clone))]
        fn my_string_cloned(&self) -> String;

        // Returns string_to_u32(&self.my_string)
        #[swift_bridge(get_with(&my_string = string_to_u32))]
        fn my_string_parsed(&self) -> u32;
    }
}

pub struct SomeType {
    my_u8: u8,
    my_string: String,
}

fn u8_to_i16 (num: u8) -> i16 {
    num as i16
}

fn string_to_u32(string: String) -> u32 {
    string.parse().unwrap()
}
```
