### PR TITLE
Add UI tests for unrecognized attributes

### DIFF
--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod/function_attributes.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod/function_attributes.rs
@@ -145,9 +145,13 @@ impl Parse for FunctionAttr {
                     path,
                 })
             }
-            _ => panic!(
-                "TODO: Return spanned error for unrecognized attribute... Like we do for StructAttr"
-            ),
+            _ => {
+                let attrib = key.to_string();
+                Err(syn::Error::new_spanned(
+                    key,
+                    format!(r#"Unrecognized attribute "{}"."#, attrib,),
+                ))?
+            }
         };
 
         Ok(attrib)

--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod/opaque_type_attributes.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod/opaque_type_attributes.rs
@@ -112,7 +112,13 @@ impl Parse for OpaqueTypeAttr {
                 }
             }
             "declare_generic" => OpaqueTypeAttr::DeclareGeneric,
-            _ => panic!("TODO: Return spanned error"),
+            _ => {
+                let attrib = key.to_string();
+                Err(syn::Error::new_spanned(
+                    key,
+                    format!(r#"Unrecognized attribute "{}"."#, attrib),
+                ))?
+            }
         };
 
         Ok(attrib)

--- a/crates/swift-bridge-macro/tests/ui/unrecognized-function-attribute.rs
+++ b/crates/swift-bridge-macro/tests/ui/unrecognized-function-attribute.rs
@@ -1,0 +1,14 @@
+//! # To Run
+//! cargo test -p swift-bridge-macro -- ui trybuild=unrecognized-function-attribute.rs
+
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        #[swift_bridge(InvalidAttribute)]
+        fn some_function();
+    }
+}
+
+pub struct SomeType;
+
+fn main() {}

--- a/crates/swift-bridge-macro/tests/ui/unrecognized-function-attribute.stderr
+++ b/crates/swift-bridge-macro/tests/ui/unrecognized-function-attribute.stderr
@@ -1,0 +1,5 @@
+error: Unrecognized attribute "InvalidAttribute".
+ --> tests/ui/unrecognized-function-attribute.rs:7:24
+  |
+7 |         #[swift_bridge(InvalidAttribute)]
+  |                        ^^^^^^^^^^^^^^^^

--- a/crates/swift-bridge-macro/tests/ui/unrecognized-opaque-type-attribute.rs
+++ b/crates/swift-bridge-macro/tests/ui/unrecognized-opaque-type-attribute.rs
@@ -1,0 +1,14 @@
+//! # To Run
+//! cargo test -p swift-bridge-macro -- ui trybuild=unrecognized-opaque-type-attribute.rs
+
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        #[swift_bridge(InvalidAttribute)]
+        type SomeType;
+    }
+}
+
+pub struct SomeType;
+
+fn main() {}

--- a/crates/swift-bridge-macro/tests/ui/unrecognized-opaque-type-attribute.stderr
+++ b/crates/swift-bridge-macro/tests/ui/unrecognized-opaque-type-attribute.stderr
@@ -1,0 +1,5 @@
+error: Unrecognized attribute "InvalidAttribute".
+ --> tests/ui/unrecognized-opaque-type-attribute.rs:7:24
+  |
+7 |         #[swift_bridge(InvalidAttribute)]
+  |                        ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Added for:

- Function attributes
- Opaque Rust type attributes

For example:

```
error: Unrecognized attribute "InvalidAttribute".
 --> tests/ui/unrecognized-function-attribute.rs:7:24
  |
7 |         #[swift_bridge(InvalidAttribute)]
  |                        ^^^^^^^^^^^^^^^^
```