### PR TITLE
Support generic Copy types

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/GenericTests.rs.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/GenericTests.rs.swift
@@ -22,5 +22,15 @@ class GenericTests: XCTestCase {
         let val = new_some_generic_type_u32()
         let _: SomeGenericType<UInt32> = reflect_generic_u32(val)
     }
+    
+    func testReflectGenericOpaqueCopyRustType() {
+        let val = new_some_generic_copy_type_u32()
+        let _: SomeGenericCopyType<UInt32> = reflect_generic_copy_u32(val)
+    }
+    
+    func testReflectGenericWithInnerOpaqueRustType() {
+        let val = new_generic_with_inner_opaque_type()
+        let _: GenericWithOpaqueRustInnerTy<InnerTy> = reflect_generic_with_inner_opaque_type(val)
+    }
 }
 

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/StringTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/StringTests.swift
@@ -48,4 +48,3 @@ class StringTests: XCTestCase {
     }
 }
 
-

--- a/book/src/bridge-module/generics/README.md
+++ b/book/src/bridge-module/generics/README.md
@@ -26,3 +26,27 @@ fn some_function(arg: MyType<u32, String>) -> &str {
     unimplemented!()
 }
 ```
+
+## Generic Copy
+
+You do not need to use the `declare_geneic` attribute for generic opaque Rust types
+that use their `Copy` implementation across FFI bounds.
+
+```rust
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        #[swift_bridge(Copy(6))]
+        type MyType<u32, u16>;
+        fn some_function(arg: MyType<u32, u16>) -> &str;
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct MyType<T, U> {
+    my_field1: T,
+    mu_field2: U
+}
+fn some_function(arg: MyType<u32, u16>) -> &str {
+    unimplemented!()
+}

--- a/build.rs
+++ b/build.rs
@@ -64,6 +64,7 @@ fn core_swift() -> String {
     }
 
     core_swift += &generic_freer();
+    core_swift += &generic_copy_type_ffi_repr();
 
     core_swift
 }
@@ -194,12 +195,21 @@ extension {swift_ty}: Vectorizable {{
     )
 }
 
+/// Used to free memory for generic Opaque Rust types such as `type SomeType<u32>`
 fn generic_freer() -> &'static str {
     r#"
 protocol SwiftBridgeGenericFreer {
     func rust_free();
 }
     "#
+}
+
+/// A Swift protocol that is implemented for the FFI representation of all generic Copy types
+/// such as `#[swift_bride(Copy(4))] type SomeType<u32>`
+fn generic_copy_type_ffi_repr() -> &'static str {
+    r#"
+protocol SwiftBridgeGenericCopyTypeFfiRepr {}
+"#
 }
 
 fn manifest_dir() -> PathBuf {

--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
@@ -119,8 +119,11 @@ impl SharedStruct {
                 let access_field = norm_field.append_field_accessor(&quote! {val});
 
                 let ty = BridgedType::new_with_type(&norm_field.ty, types).unwrap();
-                let converted_field =
-                    ty.convert_rust_value_to_ffi_compatible_value(&access_field, swift_bridge_path);
+                let converted_field = ty.convert_rust_value_to_ffi_compatible_value(
+                    &access_field,
+                    swift_bridge_path,
+                    types,
+                );
 
                 quote! {
                     #maybe_name_and_colon #converted_field

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -171,10 +171,11 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
 
                     if let Some(copy) = ty.attributes.copy {
                         bookkeeping.includes.insert("stdint.h");
+                        let c_ty_name = ty.ffi_copy_repr_string();
+
                         let ty_decl = format!(
-                            "typedef struct {prefix}${ty_name} {{ uint8_t bytes[{size}]; }} {prefix}${ty_name};",
-                            prefix = SWIFT_BRIDGE_PREFIX,
-                            ty_name = ty_name,
+                            "typedef struct {copy_ffi_repr} {{ uint8_t bytes[{size}]; }} {copy_ffi_repr};",
+                            copy_ffi_repr = c_ty_name,
                             size = copy.size_bytes
                         );
 

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_struct.rs
@@ -49,7 +49,7 @@ impl SwiftBridgeModule {
                 let ty = &norm_field.ty;
 
                 let ty = BridgedType::new_with_type(ty, &self.types).unwrap();
-                let ty = ty.to_ffi_compatible_rust_type(&self.swift_bridge_path);
+                let ty = ty.to_ffi_compatible_rust_type(&self.swift_bridge_path, &self.types);
 
                 quote! {
                     #maybe_name_and_colon #ty

--- a/crates/swift-bridge-ir/src/parsed_extern_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn.rs
@@ -145,7 +145,7 @@ impl ParsedExternFn {
         let sig = &self.func.sig;
 
         if let Some(ret) = BridgedType::new_with_return_type(&sig.output, types) {
-            let ty = ret.to_ffi_compatible_rust_type(swift_bridge_path);
+            let ty = ret.to_ffi_compatible_rust_type(swift_bridge_path, types);
             if ty.to_string() == "()" {
                 quote! {}
             } else {
@@ -164,7 +164,7 @@ impl ParsedExternFn {
         let sig = &self.func.sig;
 
         if let Some(ret) = BridgedType::new_with_return_type(&sig.output, types) {
-            let ty = ret.to_ffi_compatible_rust_type(swift_bridge_path);
+            let ty = ret.to_ffi_compatible_rust_type(swift_bridge_path, types);
             if ty.to_string() == "()" {
                 None
             } else {
@@ -266,6 +266,7 @@ impl ParsedExternFn {
                             arg = built_in.convert_rust_value_to_ffi_compatible_value(
                                 &arg,
                                 swift_bridge_path,
+                                types,
                             );
                         };
                     } else {

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_fn.rs
@@ -56,6 +56,7 @@ impl ParsedExternFn {
                         let awaited_val = return_ty.convert_rust_value_to_ffi_compatible_value(
                             &quote! {fut.await},
                             swift_bridge_path,
+                            types,
                         );
 
                         (
@@ -148,8 +149,11 @@ impl ParsedExternFn {
 
         // Async functions get this conversion done after awaiting the returned future.
         if self.sig.asyncness.is_none() {
-            call_fn =
-                return_ty.convert_rust_value_to_ffi_compatible_value(&call_fn, swift_bridge_path);
+            call_fn = return_ty.convert_rust_value_to_ffi_compatible_value(
+                &call_fn,
+                swift_bridge_path,
+                types,
+            );
         }
 
         call_fn

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_param_names_and_types.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_param_names_and_types.rs
@@ -42,7 +42,7 @@ impl ParsedExternFn {
                     if !pat_ty_is_self {
                         if let Some(built_in) = BridgedType::new_with_type(&pat_ty.ty, types) {
                             let pat = &pat_ty.pat;
-                            let ty = built_in.to_ffi_compatible_rust_type(swift_bridge_path);
+                            let ty = built_in.to_ffi_compatible_rust_type(swift_bridge_path, types);
                             params.push(quote! { #pat: #ty});
                             continue;
                         } else {

--- a/crates/swift-integration-tests/src/generics.rs
+++ b/crates/swift-integration-tests/src/generics.rs
@@ -7,8 +7,27 @@ mod ffi {
         type SomeGenericType<u32>;
 
         fn new_some_generic_type_u32() -> SomeGenericType<u32>;
-
         fn reflect_generic_u32(arg: SomeGenericType<u32>) -> SomeGenericType<u32>;
+    }
+
+    extern "Rust" {
+        #[swift_bridge(Copy(4))]
+        type SomeGenericCopyType<u32>;
+
+        fn new_some_generic_copy_type_u32() -> SomeGenericCopyType<u32>;
+        fn reflect_generic_copy_u32(arg: SomeGenericCopyType<u32>) -> SomeGenericCopyType<u32>;
+    }
+
+    extern "Rust" {
+        #[swift_bridge(declare_generic)]
+        type GenericWithOpaqueRustInnerTy<A>;
+        type GenericWithOpaqueRustInnerTy<InnerTy>;
+        type InnerTy;
+
+        fn new_generic_with_inner_opaque_type() -> GenericWithOpaqueRustInnerTy<InnerTy>;
+        fn reflect_generic_with_inner_opaque_type(
+            arg: GenericWithOpaqueRustInnerTy<InnerTy>,
+        ) -> GenericWithOpaqueRustInnerTy<InnerTy>;
     }
 }
 
@@ -17,10 +36,38 @@ pub struct SomeGenericType<T> {
     field: T,
 }
 
+#[derive(Copy, Clone)]
+pub struct SomeGenericCopyType<T> {
+    #[allow(unused)]
+    field: T,
+}
+
+pub struct GenericWithOpaqueRustInnerTy<T> {
+    #[allow(unused)]
+    field: T,
+}
+pub struct InnerTy;
+
 fn new_some_generic_type_u32() -> SomeGenericType<u32> {
     SomeGenericType { field: 123 }
 }
 
 fn reflect_generic_u32(arg: SomeGenericType<u32>) -> SomeGenericType<u32> {
+    arg
+}
+
+fn new_some_generic_copy_type_u32() -> SomeGenericCopyType<u32> {
+    SomeGenericCopyType { field: 123 }
+}
+fn reflect_generic_copy_u32(arg: SomeGenericCopyType<u32>) -> SomeGenericCopyType<u32> {
+    arg
+}
+
+fn new_generic_with_inner_opaque_type() -> GenericWithOpaqueRustInnerTy<InnerTy> {
+    GenericWithOpaqueRustInnerTy { field: InnerTy }
+}
+fn reflect_generic_with_inner_opaque_type(
+    arg: GenericWithOpaqueRustInnerTy<InnerTy>,
+) -> GenericWithOpaqueRustInnerTy<InnerTy> {
     arg
 }


### PR DESCRIPTION
This commit adds support for generic Copy types.

For example, the following is now possible:

```rust
#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        #[swift_bridge(Copy(6))]
        type SomeType<u32, u16>;

        fn some_function(arg: SomeType<u32, u16>);
    }
}
```

We also fix support for generics with an opaque Rust inner type.

For example, the following now works:

```rust
#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        #[swift_bridge(declare_generic)]
        type SomeType<A>;
        type SomeType<AnOpaqueType>;

        type AnOpaqueType;
    }
}
```
