### PR TITLE
Support Option<Opaque Rust Copy Type>

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
@@ -102,6 +102,11 @@ class OptionTests: XCTestCase {
         XCTAssertNil(rust_reflect_option_opaque_rust_type(nil))
     }
     
+     func testSwiftCallRustWithOptionOpaqueRustCopyType() throws {
+        let val = new_opaque_rust_copy_type(123)
+        let _: OptTestOpaqueRustCopyType? = rust_reflect_option_opaque_rust_copy_type(val)
+    }
+    
     func testStructWithOptionFieldsSome() throws {
         let val = StructWithOptionFields(
             u8: 123, i8: 123, u16: 123, i16: 123,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_rust_type_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_rust_type_codegen_tests.rs
@@ -127,6 +127,13 @@ mod extern_rust_copy_type {
                             unsafe { std::mem::transmute(repr) }
                         }
                     }
+
+                    #[repr(C)]
+                    #[doc(hidden)]
+                    pub struct __swift_bridge__Option_SomeType {
+                        is_some: bool,
+                        val: std::mem::MaybeUninit<__swift_bridge__SomeType>
+                    }
                 },
             ],
             // Copy types don't need a function for freeing memory.
@@ -161,8 +168,12 @@ extension __swift_bridge__$SomeType {
         ExpectedCHeader::ContainsManyAfterTrim(vec![
             r#"
 typedef struct __swift_bridge__$SomeType { uint8_t bytes[32]; } __swift_bridge__$SomeType;
+typedef struct __swift_bridge__$Option$SomeType { bool is_some; __swift_bridge__$SomeType val; } __swift_bridge__$Option$SomeType;
     "#,
-            "#include <stdint.h>",
+            r#"
+#include <stdint.h>
+#include <stdbool.h>
+"#,
         ])
     }
 

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -171,15 +171,24 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
 
                     if let Some(copy) = ty.attributes.copy {
                         bookkeeping.includes.insert("stdint.h");
+                        bookkeeping.includes.insert("stdbool.h");
                         let c_ty_name = ty.ffi_copy_repr_string();
+                        let c_option_ty_name = ty.ffi_option_copy_repr_string();
 
                         let ty_decl = format!(
                             "typedef struct {copy_ffi_repr} {{ uint8_t bytes[{size}]; }} {copy_ffi_repr};",
                             copy_ffi_repr = c_ty_name,
                             size = copy.size_bytes
                         );
+                        let option_ty_decl = format!(
+                            "typedef struct {option_copy_ffi_repr} {{ bool is_some; {copy_ffi_repr} val; }} {option_copy_ffi_repr};",
+                            copy_ffi_repr = c_ty_name,
+                            option_copy_ffi_repr = c_option_ty_name,
+                        );
 
                         header += &ty_decl;
+                        header += "\n";
+                        header += &option_ty_decl;
                         header += "\n";
                     } else {
                         let ty_decl =

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
@@ -113,6 +113,7 @@ impl ToTokens for SwiftBridgeModule {
                                 };
 
                                 let copy_ty_name = ty.ffi_copy_repr_ident();
+                                let option_copy_ty_name = ty.ffi_option_copy_repr_ident();
 
                                 let copy_ty = quote! {
                                     #[repr(C)]
@@ -127,6 +128,13 @@ impl ToTokens for SwiftBridgeModule {
                                         fn from_rust_repr(repr: super:: #ty_name #generics) -> Self {
                                             unsafe { std::mem::transmute(repr) }
                                         }
+                                    }
+
+                                    #[repr(C)]
+                                    #[doc(hidden)]
+                                    pub struct #option_copy_ty_name {
+                                        is_some: bool,
+                                        val: std::mem::MaybeUninit<#copy_ty_name>
                                     }
                                 };
 

--- a/crates/swift-bridge-ir/src/parse/type_declarations.rs
+++ b/crates/swift-bridge-ir/src/parse/type_declarations.rs
@@ -139,6 +139,32 @@ impl OpaqueForeignTypeDeclaration {
         )
     }
 
+    /// The identifier for the FFI representation of an `Option<T>` where `T` is
+    /// the `#[repr(C)] __swift_bridge__SomeStruct([u8; 123usize])`
+    /// type that is generated to pass a Copy type over FFI.
+    pub(crate) fn ffi_option_copy_repr_ident(&self) -> Ident {
+        Ident::new(
+            &format!(
+                "{}Option_{}{}",
+                SWIFT_BRIDGE_PREFIX,
+                self.ty,
+                self.generics.underscore_prefixed_generics_string()
+            ),
+            self.ty.span(),
+        )
+    }
+
+    /// The String for the FFI representation of the type used to pass an Option Copy Opaque Rust
+    /// type over FFI.
+    pub(crate) fn ffi_option_copy_repr_string(&self) -> String {
+        format!(
+            "{}$Option${}{}",
+            SWIFT_BRIDGE_PREFIX,
+            self.ty,
+            self.generics.dollar_prefixed_generics_string()
+        )
+    }
+
     /// The String for the FFI representation of the type used to pass a Copy Opaque Rust type
     /// over FFI.
     pub(crate) fn ffi_copy_repr_string(&self) -> String {

--- a/crates/swift-integration-tests/src/option.rs
+++ b/crates/swift-integration-tests/src/option.rs
@@ -57,6 +57,10 @@ mod ffi {
             arg: Option<OptTestOpaqueRustType>,
         ) -> Option<OptTestOpaqueRustType>;
 
+        fn rust_reflect_option_opaque_rust_copy_type(
+            arg: Option<OptTestOpaqueRustCopyType>,
+        ) -> Option<OptTestOpaqueRustCopyType>;
+
         fn rust_reflect_struct_with_option_fields(
             arg: StructWithOptionFields,
         ) -> StructWithOptionFields;
@@ -78,6 +82,12 @@ mod ffi {
         #[swift_bridge(init)]
         fn new(field: u8) -> OptTestOpaqueRustType;
         fn field(&self) -> u8;
+    }
+
+    extern "Rust" {
+        #[swift_bridge(Copy(1))]
+        type OptTestOpaqueRustCopyType;
+        fn new_opaque_rust_copy_type(field: u8) -> OptTestOpaqueRustCopyType;
     }
 
     extern "Swift" {
@@ -104,6 +114,15 @@ impl OptTestOpaqueRustType {
     fn field(&self) -> u8 {
         self.field
     }
+}
+
+#[derive(Copy, Clone)]
+pub struct OptTestOpaqueRustCopyType {
+    #[allow(unused)]
+    field: u8,
+}
+fn new_opaque_rust_copy_type(field: u8) -> OptTestOpaqueRustCopyType {
+    OptTestOpaqueRustCopyType { field }
 }
 
 use self::reflect_primitives::*;
@@ -138,6 +157,12 @@ fn rust_reflect_option_str(arg: Option<&str>) -> Option<&str> {
 fn rust_reflect_option_opaque_rust_type(
     arg: Option<OptTestOpaqueRustType>,
 ) -> Option<OptTestOpaqueRustType> {
+    arg
+}
+
+fn rust_reflect_option_opaque_rust_copy_type(
+    arg: Option<OptTestOpaqueRustCopyType>,
+) -> Option<OptTestOpaqueRustCopyType> {
     arg
 }
 


### PR DESCRIPTION
This commit adds support for `Option<T>` where `T` is an opaque Rust
Copy type.

For example, the following is now possible:

```rust
mod ffi {
    extern "Rust" {
        #[swift_bridge(Copy(4))]
        type SomeType;
        fn some_function (arg: Option<SomeType>) -> Option<SomeType>;
    }
}
```
