### PR TITLE
Support option generic opaque Rust types

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
@@ -102,10 +102,33 @@ class OptionTests: XCTestCase {
         XCTAssertNil(rust_reflect_option_opaque_rust_type(nil))
     }
     
-     func testSwiftCallRustWithOptionOpaqueRustCopyType() throws {
+    func testSwiftCallRustWithOptionOpaqueRustCopyType() throws {
         let val = new_opaque_rust_copy_type(123)
-        let _: OptTestOpaqueRustCopyType? = rust_reflect_option_opaque_rust_copy_type(val)
+        let reflect: OptTestOpaqueRustCopyType? = rust_reflect_option_opaque_rust_copy_type(val)
+        
+        // TODO: Support methods on generic types
+        // XCTAssertEqual(reflect!.field(), 123)
+        XCTAssertNil(rust_reflect_option_opaque_rust_copy_type(nil))
     }
+    
+    func testSwiftCallRustWithOptionGenericOpaqueRustType() throws {
+        let val = new_generic_opaque_rust_type(123)
+        let reflect = rust_reflect_option_generic_opaque_rust_type(val)
+        
+        // TODO: Support methods on generic types
+        // XCTAssertEqual(reflect!.field(), 123)
+        XCTAssertNil(rust_reflect_option_opaque_rust_type(nil))
+    }
+    
+     func testSwiftCallRustWithOptionGenericOpaqueRustCopyType() throws {
+        let val = new_generic_opaque_rust_copy_type(123)
+        let reflect: OptTestGenericOpaqueRustCopyType? = rust_reflect_option_generic_opaque_rust_copy_type(val)
+         
+        // TODO: Support methods on generic types
+        // XCTAssertEqual(reflect!.field(), 123)
+        XCTAssertNil(rust_reflect_option_generic_opaque_rust_copy_type(nil))
+    }
+
     
     func testStructWithOptionFieldsSome() throws {
         let val = StructWithOptionFields(

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_option.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_option.rs
@@ -445,3 +445,24 @@ impl BridgedOption {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TypeDeclarations;
+
+    /// Verify that we can parse an `Option<&'static str>' bridged type
+    /// This ensures that our logic that removes the spaces in order to normalize generic type
+    /// strings (i.e. "SomeType < u32 >" -> "SomeType<u32>") does not remove spaces from types
+    /// where the spaces matter such as "&'static str".
+    #[test]
+    fn parse_option_static_str() {
+        let type_str = "Option < & 'static str >";
+        assert_eq!(
+            BridgedType::new_with_str(type_str, &TypeDeclarations::default()).unwrap(),
+            BridgedType::StdLib(StdLibType::Option(BridgedOption {
+                ty: Box::new(BridgedType::StdLib(StdLibType::Str))
+            }))
+        );
+    }
+}

--- a/crates/swift-integration-tests/src/option.rs
+++ b/crates/swift-integration-tests/src/option.rs
@@ -34,6 +34,33 @@ mod ffi {
     }
 
     extern "Rust" {
+        type OptTestOpaqueRustType;
+
+        #[swift_bridge(init)]
+        fn new(field: u8) -> OptTestOpaqueRustType;
+        fn field(&self) -> u8;
+    }
+
+    extern "Rust" {
+        #[swift_bridge(Copy(1))]
+        type OptTestOpaqueRustCopyType;
+        fn new_opaque_rust_copy_type(field: u8) -> OptTestOpaqueRustCopyType;
+    }
+
+    extern "Rust" {
+        #[swift_bridge(declare_generic)]
+        type OptTestGenericOpaqueRustType<A>;
+        type OptTestGenericOpaqueRustType<u8>;
+        fn new_generic_opaque_rust_type(field: u8) -> OptTestGenericOpaqueRustType<u8>;
+    }
+
+    extern "Rust" {
+        #[swift_bridge(Copy(1))]
+        type OptTestGenericOpaqueRustCopyType<u8>;
+        fn new_generic_opaque_rust_copy_type(field: u8) -> OptTestGenericOpaqueRustCopyType<u8>;
+    }
+
+    extern "Rust" {
         fn rust_reflect_option_u8(arg: Option<u8>) -> Option<u8>;
         fn rust_reflect_option_i8(arg: Option<i8>) -> Option<i8>;
         fn rust_reflect_option_u16(arg: Option<u16>) -> Option<u16>;
@@ -61,6 +88,14 @@ mod ffi {
             arg: Option<OptTestOpaqueRustCopyType>,
         ) -> Option<OptTestOpaqueRustCopyType>;
 
+        fn rust_reflect_option_generic_opaque_rust_type(
+            arg: Option<OptTestGenericOpaqueRustType<u8>>,
+        ) -> Option<OptTestGenericOpaqueRustType<u8>>;
+
+        fn rust_reflect_option_generic_opaque_rust_copy_type(
+            arg: Option<OptTestGenericOpaqueRustCopyType<u8>>,
+        ) -> Option<OptTestGenericOpaqueRustCopyType<u8>>;
+
         fn rust_reflect_struct_with_option_fields(
             arg: StructWithOptionFields,
         ) -> StructWithOptionFields;
@@ -74,20 +109,6 @@ mod ffi {
         ) -> Option<OptionStruct>;
 
         fn run_option_tests();
-    }
-
-    extern "Rust" {
-        type OptTestOpaqueRustType;
-
-        #[swift_bridge(init)]
-        fn new(field: u8) -> OptTestOpaqueRustType;
-        fn field(&self) -> u8;
-    }
-
-    extern "Rust" {
-        #[swift_bridge(Copy(1))]
-        type OptTestOpaqueRustCopyType;
-        fn new_opaque_rust_copy_type(field: u8) -> OptTestOpaqueRustCopyType;
     }
 
     extern "Swift" {
@@ -123,6 +144,23 @@ pub struct OptTestOpaqueRustCopyType {
 }
 fn new_opaque_rust_copy_type(field: u8) -> OptTestOpaqueRustCopyType {
     OptTestOpaqueRustCopyType { field }
+}
+
+pub struct OptTestGenericOpaqueRustType<T> {
+    #[allow(unused)]
+    field: T,
+}
+fn new_generic_opaque_rust_type<T>(field: T) -> OptTestGenericOpaqueRustType<T> {
+    OptTestGenericOpaqueRustType { field }
+}
+
+#[derive(Copy, Clone)]
+pub struct OptTestGenericOpaqueRustCopyType<T> {
+    #[allow(unused)]
+    field: T,
+}
+fn new_generic_opaque_rust_copy_type<T>(field: T) -> OptTestGenericOpaqueRustCopyType<T> {
+    OptTestGenericOpaqueRustCopyType { field }
 }
 
 use self::reflect_primitives::*;
@@ -163,6 +201,18 @@ fn rust_reflect_option_opaque_rust_type(
 fn rust_reflect_option_opaque_rust_copy_type(
     arg: Option<OptTestOpaqueRustCopyType>,
 ) -> Option<OptTestOpaqueRustCopyType> {
+    arg
+}
+
+fn rust_reflect_option_generic_opaque_rust_type(
+    arg: Option<OptTestGenericOpaqueRustType<u8>>,
+) -> Option<OptTestGenericOpaqueRustType<u8>> {
+    arg
+}
+
+fn rust_reflect_option_generic_opaque_rust_copy_type(
+    arg: Option<OptTestGenericOpaqueRustCopyType<u8>>,
+) -> Option<OptTestGenericOpaqueRustCopyType<u8>> {
     arg
 }
 


### PR DESCRIPTION
This commit adds support for `Option<SomeType<T>>` generic opaque Rust
types.

This works for both `Copy` and non `Copy` opaque Rust types.

For example, the following is now possible:

```rust
#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        #[swift_bridge(Copy(4))]
        type SomeType<u32>;

        fn some_function (arg: Option<SomeType<u32>>) -> Option<SomeType<u32>>;
    }
}
```
