### PR TITLE
Build examples in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,3 +49,24 @@ jobs:
 
     - name: Run integration tests
       run: ./test-integration.sh
+
+  # Used to make sure that all of our examples build
+  build-examples:
+    runs-on: macOS-11
+    timeout-minutes: 15
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Add rust targets
+      run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+    - name: Build codegen-visualizer example
+      run: xcodebuild -project examples/codegen-visualizer/CodegenVisualizer/CodegenVisualizer.xcodeproj -scheme CodegenVisualizer
+
+    - name: Build async function example
+      run: ./examples/async-functions/build.sh

--- a/examples/codegen-visualizer/CodegenVisualizer/CodegenVisualizer.xcodeproj/project.pbxproj
+++ b/examples/codegen-visualizer/CodegenVisualizer/CodegenVisualizer.xcodeproj/project.pbxproj
@@ -338,7 +338,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = CodegenVisualizer/CodegenVisualizer.entitlements;
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -366,7 +365,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = CodegenVisualizer/CodegenVisualizer.entitlements;
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;

--- a/examples/codegen-visualizer/CodegenVisualizer/CodegenVisualizer/ContentView.swift
+++ b/examples/codegen-visualizer/CodegenVisualizer/CodegenVisualizer/ContentView.swift
@@ -116,7 +116,7 @@ struct GeneratedCodeView: View {
     }
 }
 
-class GeneratedCodeHolder: ObservableObject {
+public class GeneratedCodeHolder: ObservableObject {
     @Published var generatedRust = ""
     @Published var generatedSwift = ""
     @Published var generatedC = ""


### PR DESCRIPTION
This commit adds a CI job for building our examples during
our GitHub actions CI workflow.

Closes https://github.com/chinedufn/swift-bridge/issues/88
