### PR TITLE
Support return_into attribute on enums

### DIFF
--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -1658,6 +1658,12 @@ impl BridgedType {
                     { let val: #maybe_super #struct_name = #expression.into(); val }
                 }
             }
+            BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(shared_enum))) => {
+                let enum_name = &shared_enum.name;
+                quote! {
+                    { let val: #enum_name = #expression.into(); val }
+                }
+            }
             // TODO: Instead of this catchall.. explicitly match on all variants and use
             //  a similar approach to how we handle shared structs
             _ => {

--- a/crates/swift-integration-tests/src/function_attributes/return_into.rs
+++ b/crates/swift-integration-tests/src/function_attributes/return_into.rs
@@ -7,6 +7,10 @@ mod ffi {
     #[swift_bridge(already_declared, swift_repr = "struct")]
     struct AlreadyDeclaredStruct;
 
+    enum SomeTransparentEnum {
+        Variant,
+    }
+
     extern "Rust" {
         type SomeType;
 
@@ -24,6 +28,11 @@ mod ffi {
         // shared struct.
         #[swift_bridge(return_into)]
         fn get_already_declared_struct() -> AlreadyDeclaredStruct;
+
+        // Verify that our code compiles when we use `return_into` on an already declared
+        // shared struct.
+        #[swift_bridge(return_into)]
+        fn get_transparent_enum() -> SomeTransparentEnum;
     }
 }
 #[swift_bridge::bridge]
@@ -45,6 +54,15 @@ fn get_struct() -> SomeType {
 
 fn get_already_declared_struct() -> SomeType {
     SomeType
+}
+
+fn get_transparent_enum() -> u32 {
+    123
+}
+impl Into<ffi::SomeTransparentEnum> for u32 {
+    fn into(self) -> ffi::SomeTransparentEnum {
+        ffi::SomeTransparentEnum::Variant
+    }
 }
 
 impl Into<SomeType> for AnotherType {


### PR DESCRIPTION
For example, the following is now possible:

```rust
#[swift_bridge::bridge]
mod ffi {
    enum MyEnum {
        Variant
    }

    extern "Rust" {
        #[swift_bridge(return_into)]
        fn some_function(&self) -> MyEnum;
    }
}
```

Closes #93 