### PR TITLE
Add `into_return_type` back temporarily

### DIFF
--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod/function_attributes.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod/function_attributes.rs
@@ -94,7 +94,10 @@ impl Parse for FunctionAttr {
             }
             "init" => FunctionAttr::Init,
             "Identifiable" => FunctionAttr::Identifiable,
-            "return_into" => FunctionAttr::ReturnInto,
+            // TODO: Right before we release 0.2.0 we should remove this
+            //  "into_return_type" variant since it is deprecated.
+            //
+            "return_into" | "into_return_type" => FunctionAttr::ReturnInto,
             "return_with" => {
                 input.parse::<Token![=]>()?;
                 FunctionAttr::ReturnWith(input.parse()?)


### PR DESCRIPTION
This commit re-introduces the `into_return_type` attribute.

This lets us make more releases on the `0.1.*` semver train.

We'll fully deprecate and remove support for this attribute
again for `0.2.0` (now that we have its successor `return_into`).
