### PR TITLE
Generate public initializers for shared structs

### DIFF
--- a/SwiftRustIntegrationTestRunner/swift-package-rust-library-fixture/src/lib.rs
+++ b/SwiftRustIntegrationTestRunner/swift-package-rust-library-fixture/src/lib.rs
@@ -8,6 +8,9 @@ mod ffi {
     struct SomeStruct {
         field: u8
     }
+
+    #[swift_bridge(swift_repr = "struct")]
+    struct UnnamedStruct(u8);
 }
 
 fn hello_rust() -> String {

--- a/SwiftRustIntegrationTestRunner/swift-package-rust-library-fixture/src/lib.rs
+++ b/SwiftRustIntegrationTestRunner/swift-package-rust-library-fixture/src/lib.rs
@@ -6,7 +6,7 @@ mod ffi {
 
     #[swift_bridge(swift_repr = "struct")]
     struct SomeStruct {
-        field: u8
+        field: u8,
     }
 
     #[swift_bridge(swift_repr = "struct")]

--- a/SwiftRustIntegrationTestRunner/swift-package-rust-library-fixture/src/lib.rs
+++ b/SwiftRustIntegrationTestRunner/swift-package-rust-library-fixture/src/lib.rs
@@ -3,6 +3,11 @@ mod ffi {
     extern "Rust" {
         fn hello_rust() -> String;
     }
+
+    #[swift_bridge(swift_repr = "struct")]
+    struct SomeStruct {
+        field: u8
+    }
 }
 
 fn hello_rust() -> String {

--- a/SwiftRustIntegrationTestRunner/swift-package-test-package/Tests/swift-package-test-packageTests/swift_package_test_packageTests.swift
+++ b/SwiftRustIntegrationTestRunner/swift-package-test-package/Tests/swift-package-test-packageTests/swift_package_test_packageTests.swift
@@ -6,4 +6,8 @@ final class swift_package_test_packageTests: XCTestCase {
     func testPackageRun() throws {
         XCTAssertEqual("Hello, From Rust!", hello_rust().toString())
     }
+
+    func testInstantiateSharedStruct() throws {
+        XCTAssertEqual(SomeStruct(field: 1).field, 1);
+    }
 }

--- a/SwiftRustIntegrationTestRunner/swift-package-test-package/Tests/swift-package-test-packageTests/swift_package_test_packageTests.swift
+++ b/SwiftRustIntegrationTestRunner/swift-package-test-package/Tests/swift-package-test-packageTests/swift_package_test_packageTests.swift
@@ -10,4 +10,8 @@ final class swift_package_test_packageTests: XCTestCase {
     func testInstantiateSharedStruct() throws {
         XCTAssertEqual(SomeStruct(field: 1).field, 1);
     }
+
+    func testInstantiateSharedStructUnnamed() throws {
+        XCTAssertEqual(UnnamedStruct(_0: 1)._0, 1);
+    }
 }

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -16,7 +16,7 @@ pub(crate) use self::shared_struct::{SharedStruct, StructFields, StructSwiftRepr
 
 mod bridged_option;
 mod shared_enum;
-mod shared_struct;
+pub(crate) mod shared_struct;
 
 // FIXME: Rename to BridgedType
 #[derive(Debug, PartialEq, Clone)]

--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
@@ -7,8 +7,8 @@ use std::fmt::{Debug, Formatter};
 use syn::spanned::Spanned;
 use syn::{LitStr, Path};
 
-pub(crate) use self::struct_field::StructFields;
 pub(crate) use self::struct_field::StructField;
+pub(crate) use self::struct_field::StructFields;
 
 mod struct_field;
 

--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
@@ -8,6 +8,7 @@ use syn::spanned::Spanned;
 use syn::{LitStr, Path};
 
 pub(crate) use self::struct_field::StructFields;
+pub(crate) use self::struct_field::StructField;
 
 mod struct_field;
 

--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct/struct_field.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct/struct_field.rs
@@ -106,14 +106,27 @@ pub(crate) struct UnnamedStructField {
     pub idx: usize,
 }
 
-impl NamedStructField {
-    pub fn swift_name_string(&self) -> String {
+pub(crate) trait StructField {
+    fn field_type(&self) -> &Type;
+    fn swift_name_string(&self) -> String;
+}
+
+impl StructField for NamedStructField {
+    fn field_type(&self) -> &Type {
+        &self.ty
+    }
+
+    fn swift_name_string(&self) -> String {
         self.name.to_string()
     }
 }
 
-impl UnnamedStructField {
-    pub fn swift_name_string(&self) -> String {
+impl StructField for UnnamedStructField {
+    fn field_type(&self) -> &Type {
+        &self.ty
+    }
+
+    fn swift_name_string(&self) -> String {
         format!("_{}", self.idx)
     }
 }

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/option_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/option_codegen_tests.rs
@@ -846,10 +846,11 @@ mod shared_struct_with_option_field_ffi_repr {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 public struct SomeStruct {
+    public var field: Optional<UInt8>
+
     public init(field: Optional<UInt8>) {
         self.field = field
     }
-    public var field: Optional<UInt8>
 
     @inline(__always)
     func intoFfiRepr() -> __swift_bridge__$SomeStruct {

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/option_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/option_codegen_tests.rs
@@ -846,7 +846,7 @@ mod shared_struct_with_option_field_ffi_repr {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 public struct SomeStruct {
-    var field: Optional<UInt8>
+    public var field: Optional<UInt8>
 
     @inline(__always)
     func intoFfiRepr() -> __swift_bridge__$SomeStruct {

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/option_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/option_codegen_tests.rs
@@ -846,6 +846,9 @@ mod shared_struct_with_option_field_ffi_repr {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 public struct SomeStruct {
+    public init(field: Optional<UInt8>) {
+        self.field = field
+    }
     public var field: Optional<UInt8>
 
     @inline(__always)

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/shared_struct_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/shared_struct_codegen_tests.rs
@@ -148,7 +148,7 @@ mod generates_struct_to_and_from_ffi_conversions_with_fields {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 struct SomeStruct {
-    var field: UInt8
+    public var field: UInt8
 
     @inline(__always)
     func intoFfiRepr() -> __swift_bridge__$SomeStruct {
@@ -231,11 +231,11 @@ mod struct_with_primitive_field {
         ExpectedSwiftCode::ContainsManyAfterTrim(vec![
             r#"
 struct SomeStruct {
-    var field: UInt8
+    public var field: UInt8
 "#,
             r#"
 struct AnotherStruct {
-    var _0: UInt8
+    public var _0: UInt8
 "#,
         ])
     }

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/shared_struct_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/shared_struct_codegen_tests.rs
@@ -56,6 +56,7 @@ mod generates_struct_to_and_from_ffi_conversions_no_fields {
             r#"
 public struct SomeStruct {
     public init() {}
+
     @inline(__always)
     func intoFfiRepr() -> __swift_bridge__$SomeStruct {
         __swift_bridge__$SomeStruct(_private: 123)
@@ -149,10 +150,11 @@ mod generates_struct_to_and_from_ffi_conversions_with_fields {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 struct SomeStruct {
+    public var field: UInt8
+
     public init(field: UInt8) {
         self.field = field
     }
-    public var field: UInt8
 
     @inline(__always)
     func intoFfiRepr() -> __swift_bridge__$SomeStruct {
@@ -235,17 +237,19 @@ mod struct_with_primitive_field {
         ExpectedSwiftCode::ContainsManyAfterTrim(vec![
             r#"
 struct SomeStruct {
+    public var field: UInt8
+
     public init(field: UInt8) {
         self.field = field
     }
-    public var field: UInt8
 "#,
             r#"
 struct AnotherStruct {
+    public var _0: UInt8
+
     public init(_0: UInt8) {
         self._0 = _0
     }
-    public var _0: UInt8
 "#,
         ])
     }

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/shared_struct_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/shared_struct_codegen_tests.rs
@@ -55,6 +55,7 @@ mod generates_struct_to_and_from_ffi_conversions_no_fields {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 public struct SomeStruct {
+    public init() {}
     @inline(__always)
     func intoFfiRepr() -> __swift_bridge__$SomeStruct {
         __swift_bridge__$SomeStruct(_private: 123)
@@ -148,6 +149,9 @@ mod generates_struct_to_and_from_ffi_conversions_with_fields {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 struct SomeStruct {
+    public init(field: UInt8) {
+        self.field = field
+    }
     public var field: UInt8
 
     @inline(__always)
@@ -231,10 +235,16 @@ mod struct_with_primitive_field {
         ExpectedSwiftCode::ContainsManyAfterTrim(vec![
             r#"
 struct SomeStruct {
+    public init(field: UInt8) {
+        self.field = field
+    }
     public var field: UInt8
 "#,
             r#"
 struct AnotherStruct {
+    public init(_0: UInt8) {
+        self._0 = _0
+    }
     public var _0: UInt8
 "#,
         ])

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -1,5 +1,6 @@
 //! Tests can be found in src/codegen/codegen_tests.rs and its submodules.
 
+use crate::bridged_type::shared_struct::StructField;
 use crate::bridged_type::{BridgedType, StdLibType, StructFields};
 use crate::codegen::CodegenConfig;
 use crate::parse::{SharedTypeDeclaration, TypeDeclaration, TypeDeclarations};

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_struct.rs
@@ -21,32 +21,24 @@ impl SwiftBridgeModule {
             }
             StructSwiftRepr::Structure => {
                 let initializer_params = match &shared_struct.fields {
-                    StructFields::Named(named) => {
-                        self.convert_fields_to_initializer_params(named)
-                    },
+                    StructFields::Named(named) => self.convert_fields_to_initializer_params(named),
                     StructFields::Unnamed(unnamed) => {
                         self.convert_fields_to_initializer_params(unnamed)
-                    },
+                    }
                     StructFields::Unit => "".to_string(),
                 };
 
                 let initializer_body = match &shared_struct.fields {
-                    StructFields::Named(named) => {
-                        self.convert_fields_to_initializer_body(named)
-                    },
+                    StructFields::Named(named) => self.convert_fields_to_initializer_body(named),
                     StructFields::Unnamed(unnamed) => {
                         self.convert_fields_to_initializer_body(unnamed)
-                    },
+                    }
                     StructFields::Unit => "".to_string(),
                 };
 
                 let fields = match &shared_struct.fields {
-                    StructFields::Named(named) => {
-                        self.convert_fields(named)
-                    },
-                    StructFields::Unnamed(unnamed) => {
-                        self.convert_fields(unnamed)
-                    },
+                    StructFields::Named(named) => self.convert_fields(named),
+                    StructFields::Unnamed(unnamed) => self.convert_fields(unnamed),
                     StructFields::Unit => "".to_string(),
                 };
 
@@ -105,21 +97,22 @@ extension {option_ffi_name} {{
         }
     }
 
-    fn convert_fields_to_initializer_params<'a, T>(&self, struct_fields: impl IntoIterator<Item = &'a T>) -> String
+    fn convert_fields_to_initializer_params<'a, T>(
+        &self,
+        struct_fields: impl IntoIterator<Item = &'a T>,
+    ) -> String
     where
-        T: StructField + 'a
+        T: StructField + 'a,
     {
         let mut params = "".to_string();
 
         for field in struct_fields.into_iter() {
-            let bridged_ty =
-                BridgedType::new_with_type(field.field_type(), &self.types).unwrap();
+            let bridged_ty = BridgedType::new_with_type(field.field_type(), &self.types).unwrap();
 
             params += &format!(
                 "{}: {},",
                 field.swift_name_string(),
-                bridged_ty
-                    .to_swift_type(TypePosition::SharedStructField, &self.types)
+                bridged_ty.to_swift_type(TypePosition::SharedStructField, &self.types)
             );
         }
 
@@ -130,9 +123,12 @@ extension {option_ffi_name} {{
         params
     }
 
-    fn convert_fields_to_initializer_body<'a, T>(&self, struct_fields: impl IntoIterator<Item = &'a T>) -> String
+    fn convert_fields_to_initializer_body<'a, T>(
+        &self,
+        struct_fields: impl IntoIterator<Item = &'a T>,
+    ) -> String
     where
-        T: StructField + 'a
+        T: StructField + 'a,
     {
         let mut body = "".to_string();
 
@@ -153,19 +149,17 @@ extension {option_ffi_name} {{
 
     fn convert_fields<'a, T>(&self, struct_fields: impl IntoIterator<Item = &'a T>) -> String
     where
-        T: StructField + 'a
+        T: StructField + 'a,
     {
         let mut fields = "".to_string();
 
         for field in struct_fields.into_iter() {
-            let bridged_ty =
-                BridgedType::new_with_type(field.field_type(), &self.types).unwrap();
+            let bridged_ty = BridgedType::new_with_type(field.field_type(), &self.types).unwrap();
 
             fields += &format!(
                 "    public var {}: {}\n",
                 field.swift_name_string(),
-                bridged_ty
-                    .to_swift_type(TypePosition::SharedStructField, &self.types)
+                bridged_ty.to_swift_type(TypePosition::SharedStructField, &self.types)
             );
         }
 

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_struct.rs
@@ -37,8 +37,8 @@ impl SwiftBridgeModule {
                 };
 
                 let fields = match &shared_struct.fields {
-                    StructFields::Named(named) => self.convert_fields(named),
-                    StructFields::Unnamed(unnamed) => self.convert_fields(unnamed),
+                    StructFields::Named(named) => self.declare_fields(named),
+                    StructFields::Unnamed(unnamed) => self.declare_fields(unnamed),
                     StructFields::Unit => "".to_string(),
                 };
 
@@ -148,7 +148,7 @@ extension {option_ffi_name} {{
         body
     }
 
-    fn convert_fields<'a, T>(&self, struct_fields: impl IntoIterator<Item = &'a T>) -> String
+    fn declare_fields<'a, T>(&self, struct_fields: impl IntoIterator<Item = &'a T>) -> String
     where
         T: StructField + 'a,
     {

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_struct.rs
@@ -50,8 +50,9 @@ impl SwiftBridgeModule {
                 // No need to generate any code. Swift will automatically generate a
                 //  struct from our C header typedef that we generate for this struct.
                 let swift_struct = format!(
-                    r#"public struct {struct_name} {{
-    public init({initializer_params}) {{{initializer_body}}}{fields}
+                    r#"public struct {struct_name} {{{fields}
+    public init({initializer_params}) {{{initializer_body}}}
+
     @inline(__always)
     func intoFfiRepr() -> {ffi_repr_name} {{
         {convert_swift_to_ffi_repr}

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_struct.rs
@@ -28,7 +28,7 @@ impl SwiftBridgeModule {
                                 BridgedType::new_with_type(&field.ty, &self.types).unwrap();
 
                             fields += &format!(
-                                "    var {}: {}\n",
+                                "    public var {}: {}\n",
                                 field.swift_name_string(),
                                 bridged_ty
                                     .to_swift_type(TypePosition::SharedStructField, &self.types)
@@ -45,7 +45,7 @@ impl SwiftBridgeModule {
                                 BridgedType::new_with_type(&field.ty, &self.types).unwrap();
 
                             fields += &format!(
-                                "    var {}: {}\n",
+                                "    public var {}: {}\n",
                                 field.swift_name_string(),
                                 bridged_ty
                                     .to_swift_type(TypePosition::SharedStructField, &self.types)


### PR DESCRIPTION
Fixes https://github.com/chinedufn/swift-bridge/issues/100

Swift's automatic struct initializers default to internal, so I had to generate initializers in order to mark them as public.

In order to simplify some of the generation code I added a `StructField` trait which `NamedStructField` and `UnnamedStructField` both implement. I am not 100% sure if this aligns with your style preferences so feel free to suggest a different arrangement of all of that.