### PR TITLE
Add example of Rust linking in Swift

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,6 @@ description = "Generate FFI bindings for safe interop between Rust and Swift."
 repository = "https://github.com/chinedufn/swift-bridge"
 license = "Apache-2.0/MIT"
 
-build = "build.rs"
-
 [features]
 default = []
 
@@ -40,4 +38,5 @@ members = [
 
   "examples/async-functions",
   "examples/codegen-visualizer",
+  "examples/rust-binary-calls-swift-package",
 ]

--- a/book/src/building/swiftc-and-cargo/README.md
+++ b/book/src/building/swiftc-and-cargo/README.md
@@ -149,8 +149,8 @@ fn main() {
     swift_bridge_build::parse_bridges(bridges)
         .write_all_concatenated(out_dir, env!("CARGO_PKG_NAME"));
 
-    println!("rustc-link-lib=static=swiftc_link_rust");
-    println!("rustc-link-search=./");
+    println!("cargo:rustc-link-lib=static=swiftc_link_rust");
+    println!("cargo:rustc-link-search=./");
 }
 ```
 

--- a/crates/swift-bridge-macro/tests/ui/invalid-copy-attribute.stderr
+++ b/crates/swift-bridge-macro/tests/ui/invalid-copy-attribute.stderr
@@ -18,3 +18,7 @@ note: required by a bound in `assert_copy`
    |
    | pub fn assert_copy<T: Copy>() {}
    |                       ^^^^ required by this bound in `assert_copy`
+help: consider annotating `DoesNotImplementCopy` with `#[derive(Copy)]`
+   |
+16 | #[derive(Copy)]
+   |

--- a/examples/async-functions/README.md
+++ b/examples/async-functions/README.md
@@ -10,6 +10,7 @@ We call that function from [main.swift](main.swift) and `await` the fetched data
 ```
 git clone https://github.com/chinedufn/swift-bridge
 cd examples/async-functions
+
 ./build.sh
 ./main
 ```

--- a/examples/rust-binary-calls-swift-package/Cargo.toml
+++ b/examples/rust-binary-calls-swift-package/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rust-binary-calls-swift-package"
+version = "0.1.0"
+edition = "2021"
+publish = []
+
+build = "build.rs"
+
+[build-dependencies]
+swift-bridge-build = {path = "../../crates/swift-bridge-build"}
+
+[dependencies]
+swift-bridge = {path = "../../"}

--- a/examples/rust-binary-calls-swift-package/README.md
+++ b/examples/rust-binary-calls-swift-package/README.md
@@ -1,0 +1,35 @@
+# Rust Binary calls Swift Library
+
+In this example we create a Rust binary that statically links to a Swift library.
+
+This means that we:
+
+1. Use `swift-bridge-build` to generate our Swift FFI layer.
+
+2. Compile Swift code into a static library. While doing so we include our generated `swift-bridge` FFI glue from step 1.
+
+3. Compile our Rust executable. Along the way we link to our Swift static library.
+
+---
+
+## To Run
+
+```
+git clone https://github.com/chinedufn/swift-bridge
+cd swift-bridge
+
+cargo run -p rust-binary-calls-swift-package
+```
+
+You should see the following output:
+
+```sh
+The Rust starting number is 100.
+Starting Swift multiply by 4 function...
+Calling the Rust double function twice in order to 4x our number...
+Rust double function called...
+Rust double function called...
+Leaving Swift multiply by 4 function...
+Printing the number from Rust...
+The number is now 400.
+```

--- a/examples/rust-binary-calls-swift-package/build.rs
+++ b/examples/rust-binary-calls-swift-package/build.rs
@@ -1,0 +1,98 @@
+use std::{path::PathBuf, process::Command};
+
+fn main() {
+    // 1. Use `swift-bridge-build` to generate Swift/C FFI glue.
+    //    You can also use the `swift-bridge` CLI.
+    let bridge_files = vec!["src/main.rs"];
+    swift_bridge_build::parse_bridges(bridge_files)
+        .write_all_concatenated(swift_bridge_out_dir(), "rust-calls-swift");
+
+    // 2. Compile Swift library
+    compile_swift();
+
+    // 3. Link to Swift library
+    println!("cargo:rustc-link-lib=static=swift-library");
+    println!(
+        "cargo:rustc-link-search={}",
+        swift_library_static_lib_dir().to_str().unwrap()
+    );
+
+    // Without this we will get warnings about not being able to find dynamic libraries, and then
+    // we won't be able to compile since the Swift static libraries depend on them:
+    // For example:
+    // ld: warning: Could not find or use auto-linked library 'swiftCompatibility51'
+    // ld: warning: Could not find or use auto-linked library 'swiftCompatibility50'
+    // ld: warning: Could not find or use auto-linked library 'swiftCompatibilityDynamicReplacements'
+    // ld: warning: Could not find or use auto-linked library 'swiftCompatibilityConcurrency'
+    println!("cargo:rustc-link-search={}",
+        "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/"
+    );
+    println!("cargo:rustc-link-search={}", "/usr/lib/swift");
+}
+
+fn compile_swift() {
+    let swift_package_dir = manifest_dir().join("swift-library");
+
+    let mut cmd = Command::new("swift");
+
+    cmd.current_dir(swift_package_dir)
+        .arg("build")
+        .args(&["-Xswiftc", "-static"])
+        .args(&[
+            "-Xswiftc",
+            "-import-objc-header",
+            "-Xswiftc",
+            swift_source_dir()
+                .join("bridging-header.h")
+                .to_str()
+                .unwrap(),
+        ]);
+
+    if is_release_build() {
+        cmd.args(&["-c", "release"]);
+    }
+
+    let exit_status = cmd.spawn().unwrap().wait_with_output().unwrap();
+
+    if !exit_status.status.success() {
+        panic!(
+            r#"
+Stderr: {}
+Stdout: {}
+"#,
+            String::from_utf8(exit_status.stderr).unwrap(),
+            String::from_utf8(exit_status.stdout).unwrap(),
+        )
+    }
+}
+
+fn swift_bridge_out_dir() -> PathBuf {
+    generated_code_dir()
+}
+
+fn manifest_dir() -> PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    PathBuf::from(manifest_dir)
+}
+
+fn is_release_build() -> bool {
+    std::env::var("PROFILE").unwrap() == "release"
+}
+
+fn swift_source_dir() -> PathBuf {
+    manifest_dir().join("swift-library/Sources/swift-library")
+}
+
+fn generated_code_dir() -> PathBuf {
+    swift_source_dir().join("generated")
+}
+
+fn swift_library_static_lib_dir() -> PathBuf {
+    let debug_or_release = if is_release_build() {
+        "release"
+    } else {
+        "debug"
+    };
+
+    manifest_dir().join(format!("swift-library/.build/{}", debug_or_release))
+}

--- a/examples/rust-binary-calls-swift-package/src/main.rs
+++ b/examples/rust-binary-calls-swift-package/src/main.rs
@@ -1,0 +1,27 @@
+fn main() {
+    let start_num = 100;
+
+    println!("The Rust starting number is {}.", start_num);
+
+    let num = ffi::swift_multiply_by_4(start_num);
+
+    println!("Printing the number from Rust...");
+    println!("The number is now {}.", num)
+}
+
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        fn rust_double_number(num: i64) -> i64;
+    }
+
+    extern "Swift" {
+        fn swift_multiply_by_4(num: i64) -> i64;
+    }
+}
+
+fn rust_double_number(num: i64) -> i64 {
+    println!("Rust double function called...");
+
+    num * 2
+}

--- a/examples/rust-binary-calls-swift-package/swift-library/.gitignore
+++ b/examples/rust-binary-calls-swift-package/swift-library/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/examples/rust-binary-calls-swift-package/swift-library/Package.swift
+++ b/examples/rust-binary-calls-swift-package/swift-library/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.6
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "swift-library",
+    products: [
+        .library(name: "swift-library", type: .static, targets: ["swift-library"]),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "swift-library",
+            dependencies: []
+        )
+    ]
+)

--- a/examples/rust-binary-calls-swift-package/swift-library/README.md
+++ b/examples/rust-binary-calls-swift-package/swift-library/README.md
@@ -1,0 +1,3 @@
+# swift-library
+
+A description of this package.

--- a/examples/rust-binary-calls-swift-package/swift-library/Sources/swift-library/bridging-header.h
+++ b/examples/rust-binary-calls-swift-package/swift-library/Sources/swift-library/bridging-header.h
@@ -1,0 +1,7 @@
+#ifndef BRIDGING_HEADER_H
+#define BRIDGING_HEADER_H
+
+#import "./generated/SwiftBridgeCore.h"
+#import "./generated/rust-calls-swift/rust-calls-swift.h"
+
+#endif BRIDGING_HEADER_H

--- a/examples/rust-binary-calls-swift-package/swift-library/Sources/swift-library/generated/.gitignore
+++ b/examples/rust-binary-calls-swift-package/swift-library/Sources/swift-library/generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/examples/rust-binary-calls-swift-package/swift-library/Sources/swift-library/swift_library.swift
+++ b/examples/rust-binary-calls-swift-package/swift-library/Sources/swift-library/swift_library.swift
@@ -1,0 +1,10 @@
+func swift_multiply_by_4(num: Int64) -> Int64 {
+    print("Starting Swift multiply by 4 function...")
+
+    print("Calling the Rust double function twice in order to 4x our number...")
+    let double = rust_double_number(num);
+    let four_times = rust_double_number(double);
+
+    print("Leaving Swift multiply by 4 function...")
+    return four_times
+}

--- a/src/std_bridge/string.rs
+++ b/src/std_bridge/string.rs
@@ -8,9 +8,6 @@ mod ffi {
         #[swift_bridge(init)]
         fn new() -> RustString;
 
-        // TODO: We need to prevent footguns where you can call this with a Swift standard library
-        //  String .toRustStr() but then that String gets de-allocated under our feet.
-        //  Needs more research...
         #[swift_bridge(init)]
         fn new_with_str(str: &str) -> RustString;
 


### PR DESCRIPTION
This commit adds an example of a Rust executable that statically links
to a Swift native library.

Along the way we also make `swift-bridge-build` always generate the
core Swift bridge files, instead of having these files generated
unpredictably as we did before this commit.

---

In the future we can consider abstracting away the swift build command
behind a builder (or some other pattern) that has sane defaults.
