### PR TITLE
Passing callbacks from Rust -> Swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,24 +110,26 @@ In addition to allowing you to share your own custom structs, enums and classes 
 `swift-bridge` comes with support for a number of Rust and Swift standard library types.
 
 <!-- ANCHOR: built-in-types-table -->
-| name in Rust                                                    | name in Swift                                                    | notes               |
-| ---                                                             | ---                                                              | ---                 |
-| u8, i8, u16, i16... etc                                         | UInt8, Int8, UInt16, Int16 ... etc                               |                     |
-| bool                                                            | Bool                                                             |                     |
-| String, &String, &mut String                                    | RustString, RustStringRef, RustStringRefMut                      |                     |
-| &str                                                            | RustStr                                                          |                     |
-| Vec\<T>                                                         | RustVec\<T>                                                      |                     |
-| SwiftArray\<T>                                                  | Array\<T>                                                        | Not yet implemented |
-| &[T]                                                            |                                                                  | Not yet implemented |
-| &mut [T]                                                        |                                                                  | Not yet implemented |
-| Box<T>                                                          |                                                                  | Not yet implemented |
-| [T; N]                                                          |                                                                  | Not yet implemented |
-| *const T                                                        | UnsafePointer\<T>                                                |                     |
-| *mut T                                                          | UnsafeMutablePointer\<T>                                         |                     |
-| Option\<T>                                                      | Optional\<T>                                                     |                     |
-| Result\<T>                                                      |                                                                  | Not yet implemented |
-| Have a Rust standard library type in mind?<br /> Open an issue! |                                                                  |                     |
-|                                                                 | Have a Swift standard library type in mind?<br /> Open an issue! |                     |
+| name in Rust                                                    | name in Swift                                                    | notes                                                                              |
+| ---                                                             | ---                                                              | ---                                                                                |
+| u8, i8, u16, i16... etc                                         | UInt8, Int8, UInt16, Int16 ... etc                               |                                                                                    |
+| bool                                                            | Bool                                                             |                                                                                    |
+| String, &String, &mut String                                    | RustString, RustStringRef, RustStringRefMut                      |                                                                                    |
+| &str                                                            | RustStr                                                          |                                                                                    |
+| Vec\<T>                                                         | RustVec\<T>                                                      |                                                                                    |
+| SwiftArray\<T>                                                  | Array\<T>                                                        | Not yet implemented                                                                |
+| &[T]                                                            |                                                                  | Not yet implemented                                                                |
+| &mut [T]                                                        |                                                                  | Not yet implemented                                                                |
+| Box<T>                                                          |                                                                  | Not yet implemented                                                                |
+| Box<dyn FnOnce(A,B,C)> -> D>                                    | (A, B, C) -> D                                                   | Passing from Rust to Swift is supported, but Swift to Rust is not yet implemented. |
+| Box<dyn Fn(A,B,C)> -> D>                                        | (A, B, C) -> D                                                   | Not yet implemented                                                                |
+| [T; N]                                                          |                                                                  | Not yet implemented                                                                |
+| *const T                                                        | UnsafePointer\<T>                                                |                                                                                    |
+| *mut T                                                          | UnsafeMutablePointer\<T>                                         |                                                                                    |
+| Option\<T>                                                      | Optional\<T>                                                     |                                                                                    |
+| Result\<T>                                                      |                                                                  | Not yet implemented                                                                |
+| Have a Rust standard library type in mind?<br /> Open an issue! |                                                                  |                                                                                    |
+|                                                                 | Have a Swift standard library type in mind?<br /> Open an issue! |                                                                                    |
 <!-- ANCHOR_END: built-in-types-table -->
 
 ## To Test

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		22BC10F62799283100A0D046 /* SharedStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC10F52799283100A0D046 /* SharedStruct.swift */; };
 		22BC10F82799A3A000A0D046 /* SharedStructAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC10F72799A3A000A0D046 /* SharedStructAttributes.swift */; };
 		22BCAAB927A2607700686A21 /* FunctionAttributeIdentifiableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BCAAB827A2607700686A21 /* FunctionAttributeIdentifiableTests.swift */; };
+		22C0625328CE699D007A6F67 /* Callbacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C0625228CE699D007A6F67 /* Callbacks.swift */; };
+		22C0625528CE6C9A007A6F67 /* CallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C0625428CE6C9A007A6F67 /* CallbackTests.swift */; };
 		22C0AD51278ECA9E00A96469 /* SharedStructAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C0AD50278ECA9E00A96469 /* SharedStructAttributeTests.swift */; };
 		22D092A327B7E865009A4C2B /* AsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22D092A227B7E865009A4C2B /* AsyncTests.swift */; };
 		22EE4E0928B5388000FEC83C /* SwiftFnUsesOpaqueSwiftType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EE4E0828B5388000FEC83C /* SwiftFnUsesOpaqueSwiftType.swift */; };
@@ -94,6 +96,8 @@
 		22BC10F52799283100A0D046 /* SharedStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStruct.swift; sourceTree = "<group>"; };
 		22BC10F72799A3A000A0D046 /* SharedStructAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStructAttributes.swift; sourceTree = "<group>"; };
 		22BCAAB827A2607700686A21 /* FunctionAttributeIdentifiableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionAttributeIdentifiableTests.swift; sourceTree = "<group>"; };
+		22C0625228CE699D007A6F67 /* Callbacks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Callbacks.swift; sourceTree = "<group>"; };
+		22C0625428CE6C9A007A6F67 /* CallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallbackTests.swift; sourceTree = "<group>"; };
 		22C0AD50278ECA9E00A96469 /* SharedStructAttributeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStructAttributeTests.swift; sourceTree = "<group>"; };
 		22D092A227B7E865009A4C2B /* AsyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTests.swift; sourceTree = "<group>"; };
 		22EE4E0828B5388000FEC83C /* SwiftFnUsesOpaqueSwiftType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftFnUsesOpaqueSwiftType.swift; sourceTree = "<group>"; };
@@ -161,6 +165,7 @@
 				228FE5DD2740DB6D00805D9E /* SwiftRustIntegrationTestRunner.entitlements */,
 				228FE5D42740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift */,
 				22EE4E0828B5388000FEC83C /* SwiftFnUsesOpaqueSwiftType.swift */,
+				22C0625228CE699D007A6F67 /* Callbacks.swift */,
 			);
 			path = SwiftRustIntegrationTestRunner;
 			sourceTree = "<group>";
@@ -195,6 +200,7 @@
 				22043292274A8FDF00BAE645 /* VecTests.swift */,
 				22553323281DB5FC008A3121 /* GenericTests.rs.swift */,
 				22EE4E0A28B538A700FEC83C /* SwiftFnUsesOpaqueSwiftTypeTests.swift */,
+				22C0625428CE6C9A007A6F67 /* CallbackTests.swift */,
 			);
 			path = SwiftRustIntegrationTestRunnerTests;
 			sourceTree = "<group>";
@@ -362,6 +368,7 @@
 				228FE64627480E1D00805D9E /* SwiftBridgeCore.swift in Sources */,
 				228FE5D52740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift in Sources */,
 				228FE64A274919C600805D9E /* swift-integration-tests.swift in Sources */,
+				22C0625328CE699D007A6F67 /* Callbacks.swift in Sources */,
 				22BC10F82799A3A000A0D046 /* SharedStructAttributes.swift in Sources */,
 				22EE4E0928B5388000FEC83C /* SwiftFnUsesOpaqueSwiftType.swift in Sources */,
 				228FE60C2740F42000805D9E /* ASwiftStack.swift in Sources */,
@@ -386,6 +393,7 @@
 				22043295274ADA7A00BAE645 /* OptionTests.swift in Sources */,
 				22C0AD51278ECA9E00A96469 /* SharedStructAttributeTests.swift in Sources */,
 				228FE5E72740DB6D00805D9E /* StringTests.swift in Sources */,
+				22C0625528CE6C9A007A6F67 /* CallbackTests.swift in Sources */,
 				228FE61227428A8D00805D9E /* OpaqueSwiftStructTests.swift in Sources */,
 				22FD1C562753CB3F00F64281 /* SwiftFnUsesOpaqueRustTypeTests.swift in Sources */,
 				228FE61027416C0300805D9E /* OpaqueRustStructTests.swift in Sources */,

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Callbacks.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Callbacks.swift
@@ -1,0 +1,57 @@
+//
+//  Callbacks.swift
+//  SwiftRustIntegrationTestRunner
+//
+//  Created by Frankie Nwafili on 9/11/22.
+//
+
+import Foundation
+
+func swift_takes_fnonce_callback_no_args_no_return(arg: () -> ()) {
+    arg()
+}
+
+func swift_takes_fnonce_callback_primitive(
+    arg: (UInt8) -> UInt8
+) -> UInt8 {
+    arg(4)
+}
+
+func swift_takes_fnonce_callback_opaque_rust(
+    arg: (CallbackTestOpaqueRustType) -> CallbackTestOpaqueRustType
+) {
+    let doubled = arg(CallbackTestOpaqueRustType(10))
+    if doubled.val() != 20 {
+        fatalError("Callback not called")
+    }
+}
+
+func swift_takes_two_fnonce_callbacks(
+    arg1: () -> (),
+    arg2: (UInt8) -> UInt16
+) -> UInt16 {
+    arg1()
+    return arg2(3)
+}
+
+func swift_takes_fnonce_callback_with_two_params(
+    arg: (UInt8, UInt16) -> UInt16
+) -> UInt16 {
+    arg(1, 2)
+}
+
+/// When given an FnOnce callback this should panic.
+func swift_calls_rust_fnonce_callback_twice(arg: () -> ()) {
+    arg()
+    arg()
+}
+
+class SwiftMethodCallbackTester {
+    func method_with_fnonce_callback(callback: () -> ()) {
+        callback()
+    }
+    
+    func method_with_fnonce_callback_primitive(callback: (UInt16) -> UInt16) -> UInt16 {
+        callback(5)
+    }
+}

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/CallbackTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/CallbackTests.swift
@@ -1,0 +1,17 @@
+//
+//  CallbackTests.swift
+//  SwiftRustIntegrationTestRunnerTests
+//
+//  Created by Frankie Nwafili on 9/11/22.
+//
+
+import XCTest
+@testable import SwiftRustIntegrationTestRunner
+
+class CallbackTests: XCTestCase {
+    
+    /// Run our tests where Rust passes a callback to Swift.
+    func testRustCallsSwift() throws {
+        test_callbacks_rust_calls_swift()
+    }
+}

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -24,6 +24,7 @@
   - [Vec<T> <---> RustVec<T>](./built-in/vec/README.md)
   - [String <---> String](./built-in/string/README.md)
   - [&str <---> RustStr](./built-in/str/README.md)
+  - [Box<dyn FnOnce(A, B) -> C>](./built-in/boxed-functions/README.md)
 
 - [Safety](./safety/README.md)
 

--- a/book/src/built-in/boxed-functions/README.md
+++ b/book/src/built-in/boxed-functions/README.md
@@ -1,0 +1,23 @@
+# Boxed Functions
+
+## Box<dyn FnOnce(A, B) -> C>
+
+`swift-bridge` supports bridging boxed `FnOnce` functions with any number of arguments.
+
+There is a panic if you attempt to call a bridged `FnOnce` function more than once.
+
+```rust
+#[swift_bridge::bridge]
+mod ffi {
+	extern "Swift" {
+	    type CreditCardReader;
+	    type Card;
+	    type CardError;
+
+        fn processCard(
+            self: &CreditCardReader,
+            callback: Box<dyn FnOnce(Result<Card, CardError>) -> ()>
+        );
+	}
+}
+```

--- a/crates/swift-bridge-build/src/generate_core.rs
+++ b/crates/swift-bridge-build/src/generate_core.rs
@@ -1,3 +1,6 @@
+use crate::generate_core::boxed_fn_support::{
+    C_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN, SWIFT_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN,
+};
 use std::path::{Path, PathBuf};
 
 const RUST_STRING_SWIFT: &'static str = include_str!("./generate_core/rust_string.swift");
@@ -6,11 +9,15 @@ const RUST_STRING_C: &'static str = include_str!("./generate_core/rust_string.c.
 const STRING_SWIFT: &'static str = include_str!("./generate_core/string.swift");
 const RUST_VEC_SWIFT: &'static str = include_str!("./generate_core/rust_vec.swift");
 
+mod boxed_fn_support;
+
 pub(super) fn write_core_swift_and_c(out_dir: &Path) {
     let core_swift_out = out_dir.join("SwiftBridgeCore.swift");
     let mut swift = core_swift();
     swift += "\n";
     swift += &RUST_STRING_SWIFT;
+    swift += "\n";
+    swift += &SWIFT_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN;
 
     std::fs::write(core_swift_out, swift).unwrap();
 
@@ -18,6 +25,8 @@ pub(super) fn write_core_swift_and_c(out_dir: &Path) {
     let mut c_header = core_c_header().to_string();
     c_header += "\n";
     c_header += &RUST_STRING_C;
+    c_header += "\n";
+    c_header += &C_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN;
 
     std::fs::write(core_c_header_out, c_header).unwrap();
 }

--- a/crates/swift-bridge-build/src/generate_core/boxed_fn_support.rs
+++ b/crates/swift-bridge-build/src/generate_core/boxed_fn_support.rs
@@ -1,0 +1,33 @@
+/// Declares support types for callbacks that have no arguments and don't return a value.
+///
+/// Support types for callbacks that have arguments or return a value are generated dynamically
+/// when generating code for bridged functions.
+pub const SWIFT_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN: &'static str = r#"
+public class __private__RustFnOnceCallbackNoArgsNoRet {
+    var ptr: UnsafeMutableRawPointer
+    var called = false
+
+    init(ptr: UnsafeMutableRawPointer) {
+        self.ptr = ptr
+    }
+
+    deinit {
+        if !called {
+            __swift_bridge__$free_boxed_fn_once_no_args_no_return(ptr)
+        }
+    }
+
+    func call() {
+        if called {
+            fatalError("Cannot call a Rust FnOnce function twice")
+        }
+        called = true
+        return __swift_bridge__$call_boxed_fn_once_no_args_no_return(ptr)
+    }
+}
+"#;
+
+pub const C_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN: &'static str = r#"
+void __swift_bridge__$call_boxed_fn_once_no_args_no_return(void* boxed_fnonce);
+void __swift_bridge__$free_boxed_fn_once_no_args_no_return(void* boxed_fnonce);
+"#;

--- a/crates/swift-bridge-ir/src/bridged_type/boxed_fn.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/boxed_fn.rs
@@ -1,0 +1,288 @@
+use crate::bridged_type::{BridgedType, StdLibType, TypePosition};
+use crate::parse::HostLang;
+use crate::TypeDeclarations;
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::{quote, ToTokens};
+use std::str::FromStr;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{Path, Type};
+
+/// Box<dyn FnOnce(A, B, C) -> ()>
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) struct BuiltInBoxedFnOnce {
+    /// The functions parameters.
+    pub params: Vec<BridgedType>,
+    /// The functions return type.
+    pub ret: Box<BridgedType>,
+}
+
+/// example: Vec<SomeType, AnotherType, u32>
+pub(crate) struct FunctionArguments(pub Vec<Type>);
+impl Parse for FunctionArguments {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let args: Punctuated<Type, syn::Token![,]> = Punctuated::parse_terminated(input)?;
+        Ok(Self(args.into_iter().collect()))
+    }
+}
+
+impl BuiltInBoxedFnOnce {
+    pub fn does_not_have_params_or_return(&self) -> bool {
+        self.params.is_empty() && self.ret.is_null()
+    }
+
+    /// Box<dyn FnOnce(A, B) -> C>
+    pub fn to_rust_type_path(&self) -> TokenStream {
+        let args: Vec<TokenStream> = self.params.iter().map(|a| a.to_rust_type_path()).collect();
+        let ret = &self.ret.to_rust_type_path();
+        quote! {
+            Box<dyn FnOnce(#(#args),*) -> #ret>
+        }
+    }
+
+    pub fn convert_rust_value_to_ffi_compatible_value(
+        &self,
+        expression: &TokenStream,
+    ) -> TokenStream {
+        let args: Vec<TokenStream> = self.params.iter().map(|a| a.to_rust_type_path()).collect();
+        let ret = &self.ret.to_rust_type_path();
+
+        quote! {
+            Box::into_raw(Box::new(#expression)) as *mut Box<dyn FnOnce(#(#args),*) -> #ret>
+        }
+    }
+
+    pub fn to_ffi_compatible_rust_type(&self) -> TokenStream {
+        let params: Vec<TokenStream> = self.params.iter().map(|a| a.to_rust_type_path()).collect();
+        let ret = &self.ret.to_rust_type_path();
+        quote! {
+            *mut Box<dyn FnOnce(#(#params),*) -> #ret>
+        }
+    }
+
+    /// Returns each of the parameters as an FFI friendly type.
+    ///
+    /// For example, `Box<dyn FnOnce(u8, SomeType)>` would give us:
+    /// arg0: u8, arg1: *mut super::SomeType
+    pub fn params_to_ffi_compatible_rust_types(
+        &self,
+        swift_bridge_path: &Path,
+        types: &TypeDeclarations,
+    ) -> Vec<TokenStream> {
+        self.params
+            .iter()
+            .enumerate()
+            .map(|(idx, ty)| {
+                let param_name = Ident::new(&format!("arg{}", idx), Span::call_site());
+                let param_ty = ty.to_ffi_compatible_rust_type(swift_bridge_path, types);
+
+                quote! {
+                    #param_name: #param_ty
+                }
+            })
+            .collect()
+    }
+
+    /// arg0: UInt8, arg1: SomeType, ...
+    pub fn params_to_swift_types(&self, types: &TypeDeclarations) -> String {
+        self.params
+            .iter()
+            .enumerate()
+            .map(|(idx, ty)| {
+                let ty = ty.to_swift_type(TypePosition::FnArg(HostLang::Rust, idx), types);
+
+                format!("_ arg{idx}: {ty}")
+            })
+            .collect::<Vec<String>>()
+            .join(", ")
+    }
+
+    /// Box<dyn FnOnce(u8, SomeRustType)> becomes:
+    /// uint8_t arg0, *void arg1
+    pub fn params_to_c_types(&self) -> String {
+        self.params
+            .iter()
+            .enumerate()
+            .map(|(idx, ty)| {
+                let ty = ty.to_c();
+
+                format!("{ty} arg{idx}")
+            })
+            .collect::<Vec<String>>()
+            .join(", ")
+    }
+
+    /// Returns each `arg0, arg1, ... argN`.
+    ///
+    /// For example, `Box<dyn FnOnce(u8, SomeType)>` would give us:
+    /// arg0, unsafe { *Box::from_raw(arg1) }
+    pub fn to_rust_call_args(&self) -> Vec<TokenStream> {
+        self.params
+            .iter()
+            .enumerate()
+            .map(|(idx, ty)| {
+                let arg_name = Ident::new(&format!("arg{}", idx), Span::call_site());
+                ty.convert_ffi_value_to_rust_value(&arg_name.to_token_stream(), arg_name.span())
+            })
+            .collect()
+    }
+
+    /// Returns each `arg0, arg1, ... argN`.
+    ///
+    /// For example, `Box<dyn FnOnce(u8, SomeType)>` would give us:
+    /// "arg0, arg1"
+    pub fn to_swift_call_args(&self) -> String {
+        self.params
+            .iter()
+            .enumerate()
+            .map(|(idx, _ty)| format!("arg{}", idx))
+            .collect::<Vec<String>>()
+            .join(", ")
+    }
+
+    /// Box<dyn FnOnce(u8, SomeType)> would become:
+    /// ", arg0, { arg1.isOwned = false; arg1 }()"
+    pub fn to_from_swift_to_rust_ffi_call_args(&self) -> String {
+        let mut args = "".to_string();
+
+        if self.params.is_empty() {
+            return args;
+        }
+
+        for (idx, ty) in self.params.iter().enumerate() {
+            let arg_name = format!("arg{}", idx);
+            args += &format!(
+                ", {}",
+                ty.convert_swift_expression_to_ffi_compatible(
+                    &arg_name,
+                    TypePosition::FnArg(HostLang::Rust, idx)
+                )
+            );
+        }
+
+        args
+    }
+
+    pub fn to_swift_type(&self) -> &'static str {
+        "UnsafeMutableRawPointer"
+    }
+
+    pub fn convert_ffi_value_to_swift_value(&self, type_pos: TypePosition) -> String {
+        match type_pos {
+            TypePosition::FnArg(_, param_idx) => {
+                if self.does_not_have_params_or_return() {
+                    format!("{{ cb{param_idx}.call() }}")
+                } else if self.params.len() > 0 {
+                    let args = self.to_swift_call_args();
+                    format!("{{ {args} in cb{param_idx}.call({args}) }}")
+                } else {
+                    format!("{{ cb{param_idx}.call() }}")
+                }
+            }
+            _ => todo!("Not yet supported"),
+        }
+    }
+}
+
+impl BuiltInBoxedFnOnce {
+    pub fn from_str_tokens(string: &str, types: &TypeDeclarations) -> Option<Self> {
+        // ( A , B , C ) -> D >
+        //   OR
+        // ( A , B , C ) >
+        let signature = string.trim_start_matches("Box < dyn FnOnce");
+
+        let open_parens = signature.find("(").unwrap();
+        let closing_parens = signature.find(")").unwrap();
+        // A, B, C
+        let args = &signature[open_parens + 1..closing_parens];
+
+        let return_idx = signature.rfind("->");
+
+        // D
+        let ret = return_idx.map(|idx| &signature[(idx + 3)..signature.len() - 2]);
+
+        let args = TokenStream::from_str(args).unwrap();
+        let args: FunctionArguments = syn::parse2(args).unwrap();
+
+        let ret = if let Some(ret) = ret {
+            let ret = syn::parse2::<Type>(TokenStream::from_str(ret).unwrap()).unwrap();
+            BridgedType::new_with_type(&ret, types)?
+        } else {
+            BridgedType::StdLib(StdLibType::Null)
+        };
+
+        let mut args_bridged_tys = Vec::with_capacity(args.0.len());
+        for arg in args.0 {
+            args_bridged_tys.push(BridgedType::new_with_type(&arg, types)?);
+        }
+
+        return Some(BuiltInBoxedFnOnce {
+            params: args_bridged_tys,
+            ret: Box::new(ret),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that we can parse a boxed fn once that does not have an `->` token
+    #[test]
+    fn boxed_fn_once_from_string_no_arrow() {
+        let tokens = quote! {Box<dyn FnOnce()>}.to_token_stream().to_string();
+
+        assert!(
+            BuiltInBoxedFnOnce::from_str_tokens(&tokens, &TypeDeclarations::default())
+                .unwrap()
+                .ret
+                .is_null()
+        );
+    }
+
+    /// Verify that we can parse a boxed fn once that has an `->` token
+    #[test]
+    fn boxed_fn_once_from_string_with_arrow() {
+        let tokens = quote! {Box<dyn FnOnce() -> u8>}
+            .to_token_stream()
+            .to_string();
+
+        assert!(matches!(
+            *BuiltInBoxedFnOnce::from_str_tokens(&tokens, &TypeDeclarations::default())
+                .unwrap()
+                .ret,
+            BridgedType::StdLib(StdLibType::U8)
+        ));
+    }
+
+    /// Verify that we can parse a boxed fn once that explicitly returns the null type.
+    #[test]
+    fn boxed_fn_once_from_string_returns_null() {
+        let tokens = quote! {Box<dyn FnOnce() -> ()>}
+            .to_token_stream()
+            .to_string();
+
+        assert!(
+            BuiltInBoxedFnOnce::from_str_tokens(&tokens, &TypeDeclarations::default())
+                .unwrap()
+                .ret
+                .is_null(),
+        );
+    }
+
+    /// Verify that we can parse a boxed fn that does not have a space before the argument
+    /// parentheses.
+    /// Not sure what leads to this case.. but if we don't handle it the test suite will fail so
+    /// we can always figure out what leads to not having the space before the parens in the future.
+    #[test]
+    fn no_space_before_arg_parens() {
+        let tokens = "Box < dyn FnOnce() -> () >";
+
+        assert!(
+            BuiltInBoxedFnOnce::from_str_tokens(tokens, &TypeDeclarations::default())
+                .unwrap()
+                .ret
+                .is_null(),
+        );
+    }
+}

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_option.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_option.rs
@@ -103,6 +103,9 @@ impl BridgedOption {
                 StdLibType::Option(_) => {
                     todo!("Support Option<Option<T>>")
                 }
+                StdLibType::BoxedFnOnce(_) => {
+                    todo!("Option<Box<dyn FnOnce(A, B) -> C>> is not yet supported")
+                }
             },
             BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Struct(shared_struct))) => {
                 let option_name = shared_struct.ffi_option_name_tokens();
@@ -194,6 +197,9 @@ impl BridgedOption {
                 StdLibType::Option(_) => {
                     todo!("Option<Option<T>> is not yet supported")
                 }
+                StdLibType::BoxedFnOnce(_) => {
+                    todo!("Option<Box<dyn FnOnce(A, B) -> C>> is not yet supported")
+                }
             },
             BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Struct(_shared_struct))) => {
                 quote! {
@@ -269,6 +275,9 @@ impl BridgedOption {
                 StdLibType::Option(_) => {
                     todo!("Support Option<Option<T>>")
                 }
+                StdLibType::BoxedFnOnce(_) => {
+                    todo!("Option<Box<dyn FnOnce(A, B) -> C>> is not yet supported")
+                }
             },
             BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Struct(_shared_struct))) => {
                 format!("{expression}.intoSwiftRepr()", expression = expression)
@@ -338,7 +347,7 @@ impl BridgedOption {
                     format!("{expression}AsRustStr", expression = expression)
                 }
                 StdLibType::String => match type_pos {
-                    TypePosition::FnArg(_func_host_lang) => {
+                    TypePosition::FnArg(_func_host_lang, _) => {
                         format!(
                                 "{{ if let rustString = optionalStringIntoRustString({expression}) {{ rustString.isOwned = false; return rustString.ptr }} else {{ return nil }} }}()",
                                 expression = expression
@@ -359,6 +368,9 @@ impl BridgedOption {
                 }
                 StdLibType::Option(_) => {
                     todo!("Option<Option<T> is not yet supported")
+                }
+                StdLibType::BoxedFnOnce(_) => {
+                    todo!("Option<Box<dyn FnOnce(A, B) -> C>> is not yet supported")
                 }
             },
             BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Struct(shared_struct))) => {
@@ -427,6 +439,9 @@ impl BridgedOption {
                 }
                 StdLibType::Option(_) => {
                     todo!("Option<Option<T>> is not yet supported")
+                }
+                StdLibType::BoxedFnOnce(_) => {
+                    todo!("Option<Box<dyn FnOnce(A, B) -> C>> is not yet supported")
                 }
             },
             BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Struct(shared_struct))) => {

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests.rs
@@ -29,6 +29,7 @@ use crate::test_utils::{
 
 mod already_declared_attribute_codegen_tests;
 mod async_function_codegen_tests;
+mod boxed_fnonce_tests;
 mod conditional_compilation_codegen_tests;
 mod extern_rust_function_opaque_rust_type_argument_codegen_tests;
 mod extern_rust_function_opaque_rust_type_return_codegen_tests;

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/boxed_fnonce_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/boxed_fnonce_tests.rs
@@ -1,0 +1,884 @@
+//! Tests for passing Box<dyn FnOnce(A, B) -> C> between languages.
+//!
+//! `*mut dyn FnOnce(A, B) -> C` is not FFI safe, so we pass `*mut Box dyn FnOnce(A, B) -> C`
+//! over FFI instead.
+//!
+//! This means that passing a boxed fn from Rust -> Swift involves a tiny allocation where we
+//! call a `Box::new` on a `Box<dyn FnOnce>`.
+//!
+//! Ideally we'd just pass the `*mut dyn FnOnce` pointer from Rust -> Swift in order to avoid this
+//! tiny allocation entirely, but we ran into issues when trying that.
+//! We're assuming that it's because `*mut dyn FnOnce` is not FFI safe, but we should research and
+//! confirm this.
+//! Given that Swift does nothing with the pointer other than eventually pass it back to Rust,
+//! there may be a way to simply pass the `Box::into_raw(Box<dyn FnOnce>))` pointer transmuted into
+//! some FFI safe type, as opposed to needing to do a `Box::into_raw(Box::new(Box<dyn FnOnce>))`
+//! as we do now.
+
+use super::{CodegenTest, ExpectedCHeader, ExpectedRustTokens, ExpectedSwiftCode};
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Verify that we can pass a callback that has no args or return value from Rust to Swift.
+mod test_swift_takes_no_args_no_return_callback {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            mod ffi {
+                extern "Swift" {
+                    fn some_function(callback: Box<dyn FnOnce() -> ()>);
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::ContainsMany(vec![
+            quote! {
+                pub fn some_function (callback: Box<dyn FnOnce() -> ()>) {
+                    unsafe {
+                        __swift_bridge__some_function(
+                            Box::into_raw(Box::new(callback)) as *mut Box<dyn FnOnce() -> ()>
+                        )
+                    }
+                }
+            },
+            quote! {
+                #[link_name = "__swift_bridge__$some_function"]
+                fn __swift_bridge__some_function(callback: *mut Box<dyn FnOnce() ->()>);
+            },
+        ])
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(
+            r#"
+@_cdecl("__swift_bridge__$some_function")
+func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
+    { let cb0 = __private__RustFnOnceCallbackNoArgsNoRet(ptr: callback); let _ = some_function(callback: { cb0.call() }) }()
+}
+"#,
+        )
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ExactAfterTrim("")
+    }
+
+    #[test]
+    fn test_swift_takes_no_args_no_return_callback() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}
+
+/// Verify that we can pass a callback with primitive arg from Rust to Swift.
+mod test_swift_takes_callback_one_primitive_arg {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            mod ffi {
+                extern "Swift" {
+                    fn some_function(callback: Box<dyn FnOnce(u8) -> ()>);
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::ContainsMany(vec![
+            quote! {
+                pub fn some_function (callback: Box<dyn FnOnce(u8) -> ()>) {
+                    unsafe {
+                        __swift_bridge__some_function(
+                            Box::into_raw(Box::new(callback)) as *mut Box<dyn FnOnce(u8) -> ()>
+                        )
+                    }
+                }
+            },
+            quote! {
+                #[export_name = "__swift_bridge__$some_function$param0"]
+                pub extern "C" fn some_function_param0(some_function_callback: *mut Box<dyn FnOnce(u8) -> ()>, arg0: u8) {
+                    unsafe { Box::from_raw(some_function_callback)(arg0) }
+                }
+
+                #[export_name = "__swift_bridge__$some_function$_free$param0"]
+                pub extern "C" fn free_some_function_param0(some_function_callback: *mut Box<dyn FnOnce(u8) -> ()>) {
+                    let _ = unsafe { Box::from_raw(some_function_callback) };
+                }
+            },
+            quote! {
+                #[link_name = "__swift_bridge__$some_function"]
+                fn __swift_bridge__some_function(callback: *mut Box<dyn FnOnce(u8) -> ()>);
+            },
+        ])
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsManyAfterTrim(vec![
+            r#"
+class __private__RustFnOnceCallback$some_function$param0 {
+    var ptr: UnsafeMutableRawPointer
+    var called = false
+
+    init(ptr: UnsafeMutableRawPointer) {
+        self.ptr = ptr
+    }
+
+    deinit {
+        if !called {
+            __swift_bridge__$some_function$_free$param0(ptr)
+        }
+    }
+
+    func call(_ arg0: UInt8) {
+        if called {
+            fatalError("Cannot call a Rust FnOnce function twice")
+        }
+        called = true
+        return __swift_bridge__$some_function$param0(ptr, arg0)
+    }
+}
+            "#,
+            r#"
+@_cdecl("__swift_bridge__$some_function")
+func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
+    { let cb0 = __private__RustFnOnceCallback$some_function$param0(ptr: callback); let _ = some_function(callback: { arg0 in cb0.call(arg0) }) }()
+}
+"#,
+        ])
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ContainsAfterTrim(
+            r#"
+void __swift_bridge__$some_function$param0(void* some_function_callback, uint8_t arg0);
+void __swift_bridge__$some_function$_free$param0(void* some_function_callback);
+"#,
+        )
+    }
+
+    #[test]
+    fn test_swift_takes_callback_one_primitive_arg() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}
+
+/// Verify that we can pass a callback with a primitive return value from Rust to Swift.
+mod test_swift_takes_callback_primitive_return {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            mod ffi {
+                extern "Swift" {
+                    fn some_function(callback: Box<dyn FnOnce() -> u8>);
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::ContainsMany(vec![
+            quote! {
+                pub fn some_function (callback: Box<dyn FnOnce() -> u8>) {
+                    unsafe {
+                        __swift_bridge__some_function(
+                            Box::into_raw(Box::new(callback)) as *mut Box<dyn FnOnce() -> u8>
+                        )
+                    }
+                }
+            },
+            quote! {
+                #[export_name = "__swift_bridge__$some_function$param0"]
+                pub extern "C" fn some_function_param0(some_function_callback: *mut Box<dyn FnOnce() -> u8>) -> u8 {
+                    unsafe { Box::from_raw(some_function_callback)() }
+                }
+
+                #[export_name = "__swift_bridge__$some_function$_free$param0"]
+                pub extern "C" fn free_some_function_param0(some_function_callback: *mut Box<dyn FnOnce() -> u8>) {
+                    let _ = unsafe { Box::from_raw(some_function_callback) };
+                }
+            },
+            quote! {
+                #[link_name = "__swift_bridge__$some_function"]
+                fn __swift_bridge__some_function(callback: *mut Box<dyn FnOnce() -> u8>);
+            },
+        ])
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsManyAfterTrim(vec![
+            r#"
+class __private__RustFnOnceCallback$some_function$param0 {
+    var ptr: UnsafeMutableRawPointer
+    var called = false
+
+    init(ptr: UnsafeMutableRawPointer) {
+        self.ptr = ptr
+    }
+
+    deinit {
+        if !called {
+            __swift_bridge__$some_function$_free$param0(ptr)
+        }
+    }
+
+    func call() -> UInt8 {
+        if called {
+            fatalError("Cannot call a Rust FnOnce function twice")
+        }
+        called = true
+        return __swift_bridge__$some_function$param0(ptr)
+    }
+}
+            "#,
+            r#"
+@_cdecl("__swift_bridge__$some_function")
+func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
+    { let cb0 = __private__RustFnOnceCallback$some_function$param0(ptr: callback); let _ = some_function(callback: { cb0.call() }) }()
+}
+"#,
+        ])
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ContainsAfterTrim(
+            r#"
+uint8_t __swift_bridge__$some_function$param0(void* some_function_callback);
+void __swift_bridge__$some_function$_free$param0(void* some_function_callback);
+"#,
+        )
+    }
+
+    #[test]
+    fn test_swift_takes_callback_primitive_return() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}
+
+/// Verify that we can pass a callback with an opaque Rust arg from Rust to Swift.
+mod test_swift_takes_callback_one_opaque_rust_arg {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            mod ffi {
+                extern "Swift" {
+                    fn some_function(callback: Box<dyn FnOnce(ARustType) -> ()>);
+                }
+
+                extern "Rust" {
+                    type ARustType;
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::ContainsMany(vec![
+            quote! {
+                pub fn some_function (callback: Box<dyn FnOnce(super::ARustType) -> ()>) {
+                    unsafe {
+                        __swift_bridge__some_function(
+                            Box::into_raw(Box::new(callback)) as *mut Box<dyn FnOnce(super::ARustType) -> ()>
+                        )
+                    }
+                }
+            },
+            quote! {
+                #[export_name = "__swift_bridge__$some_function$param0"]
+                pub extern "C" fn some_function_param0(some_function_callback: *mut Box<dyn FnOnce(super::ARustType) -> ()>, arg0: *mut super::ARustType) {
+                    unsafe { Box::from_raw(some_function_callback)(unsafe { *Box::from_raw(arg0) }) }
+                }
+
+                #[export_name = "__swift_bridge__$some_function$_free$param0"]
+                pub extern "C" fn free_some_function_param0(some_function_callback: *mut Box<dyn FnOnce(super::ARustType) -> ()>) {
+                    let _ = unsafe { Box::from_raw(some_function_callback) };
+                }
+            },
+            quote! {
+                #[link_name = "__swift_bridge__$some_function"]
+                fn __swift_bridge__some_function(callback: *mut Box<dyn FnOnce(super::ARustType) -> ()>);
+            },
+        ])
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsManyAfterTrim(vec![
+            r#"
+class __private__RustFnOnceCallback$some_function$param0 {
+    var ptr: UnsafeMutableRawPointer
+    var called = false
+
+    init(ptr: UnsafeMutableRawPointer) {
+        self.ptr = ptr
+    }
+
+    deinit {
+        if !called {
+            __swift_bridge__$some_function$_free$param0(ptr)
+        }
+    }
+
+    func call(_ arg0: ARustType) {
+        if called {
+            fatalError("Cannot call a Rust FnOnce function twice")
+        }
+        called = true
+        return __swift_bridge__$some_function$param0(ptr, {arg0.isOwned = false; return arg0.ptr;}())
+    }
+}
+            "#,
+            r#"
+@_cdecl("__swift_bridge__$some_function")
+func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
+    { let cb0 = __private__RustFnOnceCallback$some_function$param0(ptr: callback); let _ = some_function(callback: { arg0 in cb0.call(arg0) }) }()
+}
+"#,
+        ])
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ContainsAfterTrim(
+            r#"
+void __swift_bridge__$some_function$param0(void* some_function_callback, void* arg0);
+void __swift_bridge__$some_function$_free$param0(void* some_function_callback);
+"#,
+        )
+    }
+
+    #[test]
+    fn test_swift_takes_callback_one_opaque_rust_arg() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}
+
+/// Verify that we can pass a callback with an opaque Rust arg from Rust to Swift.
+mod test_swift_takes_callback_return_opaque_rust_type {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            mod ffi {
+                extern "Swift" {
+                    fn some_function(callback: Box<dyn FnOnce() -> ARustType>);
+                }
+
+                extern "Rust" {
+                    type ARustType;
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::ContainsMany(vec![
+            quote! {
+                pub fn some_function (callback: Box<dyn FnOnce() -> super::ARustType>) {
+                    unsafe {
+                        __swift_bridge__some_function(
+                            Box::into_raw(Box::new(callback)) as *mut Box<dyn FnOnce() -> super::ARustType>
+                        )
+                    }
+                }
+            },
+            quote! {
+                #[export_name = "__swift_bridge__$some_function$param0"]
+                pub extern "C" fn some_function_param0(some_function_callback: *mut Box<dyn FnOnce() -> super::ARustType>) -> *mut super::ARustType {
+                    Box::into_raw(Box::new(unsafe { Box::from_raw(some_function_callback)() })) as *mut super::ARustType
+                }
+
+                #[export_name = "__swift_bridge__$some_function$_free$param0"]
+                pub extern "C" fn free_some_function_param0(some_function_callback: *mut Box<dyn FnOnce() -> super::ARustType>) {
+                    let _ = unsafe { Box::from_raw(some_function_callback) };
+                }
+            },
+            quote! {
+                #[link_name = "__swift_bridge__$some_function"]
+                fn __swift_bridge__some_function(callback: *mut Box<dyn FnOnce() -> super::ARustType>);
+            },
+        ])
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsManyAfterTrim(vec![
+            r#"
+class __private__RustFnOnceCallback$some_function$param0 {
+    var ptr: UnsafeMutableRawPointer
+    var called = false
+
+    init(ptr: UnsafeMutableRawPointer) {
+        self.ptr = ptr
+    }
+
+    deinit {
+        if !called {
+            __swift_bridge__$some_function$_free$param0(ptr)
+        }
+    }
+
+    func call() -> ARustType {
+        if called {
+            fatalError("Cannot call a Rust FnOnce function twice")
+        }
+        called = true
+        return ARustType(ptr: __swift_bridge__$some_function$param0(ptr))
+    }
+}
+            "#,
+            r#"
+@_cdecl("__swift_bridge__$some_function")
+func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
+    { let cb0 = __private__RustFnOnceCallback$some_function$param0(ptr: callback); let _ = some_function(callback: { cb0.call() }) }()
+}
+"#,
+        ])
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ContainsAfterTrim(
+            r#"
+void* __swift_bridge__$some_function$param0(void* some_function_callback);
+void __swift_bridge__$some_function$_free$param0(void* some_function_callback);
+"#,
+        )
+    }
+
+    #[test]
+    fn test_swift_takes_callback_return_opaque_rust_type() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}
+
+/// Verify that we can pass two callbacks from Rust to Swift.
+///
+/// We put a callback that takes arguments in the second position to ensure that our codegen
+/// factors in the callbacks position when generating the FFI glue.
+///
+/// We also put a third callback with no arguments or return values. Callbacks with no args or
+/// return value are handled slightly differently
+/// (we don't generate new types to handle them and instead use a pre-defined type for this special
+///  case), so we confirm that we generate the correct code.
+///
+/// This all helps ensure that if a function has multiple callbacks our generated code calls
+/// the right one.
+mod test_swift_takes_multiple_callbacks {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            mod ffi {
+                extern "Swift" {
+                    fn some_function(
+                        arg0: Box<dyn FnOnce() -> ()>,
+                        arg1: Box<dyn FnOnce(u8) -> ()>,
+                        arg2: Box<dyn FnOnce() -> ()>,
+                    );
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::ContainsMany(vec![
+            quote! {
+                pub fn some_function (
+                    arg0: Box<dyn FnOnce() -> ()>,
+                    arg1: Box<dyn FnOnce(u8) -> ()>,
+                    arg2: Box<dyn FnOnce() -> ()>
+                ) {
+                    unsafe {
+                        __swift_bridge__some_function(
+                            Box::into_raw(Box::new(arg0)) as *mut Box<dyn FnOnce() -> ()>,
+                            Box::into_raw(Box::new(arg1)) as *mut Box<dyn FnOnce(u8) -> ()>,
+                            Box::into_raw(Box::new(arg2)) as *mut Box<dyn FnOnce() -> ()>
+                        )
+                    }
+                }
+            },
+            quote! {
+                #[export_name = "__swift_bridge__$some_function$param1"]
+                pub extern "C" fn some_function_param1(some_function_arg1: *mut Box<dyn FnOnce(u8) -> ()>, arg0: u8) {
+                    unsafe { Box::from_raw(some_function_arg1)(arg0) }
+                }
+
+                #[export_name = "__swift_bridge__$some_function$_free$param1"]
+                pub extern "C" fn free_some_function_param1(some_function_arg1: *mut Box<dyn FnOnce(u8) -> ()>) {
+                    let _ = unsafe { Box::from_raw(some_function_arg1) };
+                }
+            },
+            quote! {
+                #[link_name = "__swift_bridge__$some_function"]
+                fn __swift_bridge__some_function(
+                    arg0: *mut Box<dyn FnOnce() -> ()>,
+                    arg1: *mut Box<dyn FnOnce(u8) -> ()>,
+                    arg2: *mut Box<dyn FnOnce() -> ()>
+                );
+            },
+        ])
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsManyAfterTrim(vec![
+            r#"
+class __private__RustFnOnceCallback$some_function$param1 {
+    var ptr: UnsafeMutableRawPointer
+    var called = false
+
+    init(ptr: UnsafeMutableRawPointer) {
+        self.ptr = ptr
+    }
+
+    deinit {
+        if !called {
+            __swift_bridge__$some_function$_free$param1(ptr)
+        }
+    }
+
+    func call(_ arg0: UInt8) {
+        if called {
+            fatalError("Cannot call a Rust FnOnce function twice")
+        }
+        called = true
+        return __swift_bridge__$some_function$param1(ptr, arg0)
+    }
+}
+            "#,
+            r#"
+@_cdecl("__swift_bridge__$some_function")
+func __swift_bridge__some_function (_ arg0: UnsafeMutableRawPointer, _ arg1: UnsafeMutableRawPointer, _ arg2: UnsafeMutableRawPointer) {
+    { let cb0 = __private__RustFnOnceCallbackNoArgsNoRet(ptr: arg0); let cb1 = __private__RustFnOnceCallback$some_function$param1(ptr: arg1); let cb2 = __private__RustFnOnceCallbackNoArgsNoRet(ptr: arg2); let _ = some_function(arg0: { cb0.call() }, arg1: { arg0 in cb1.call(arg0) }, arg2: { cb2.call() }) }()
+}
+"#,
+        ])
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ContainsAfterTrim(
+            r#"
+void __swift_bridge__$some_function$param1(void* some_function_arg1, uint8_t arg0);
+void __swift_bridge__$some_function$_free$param1(void* some_function_arg1);
+"#,
+        )
+    }
+
+    #[test]
+    fn test_swift_takes_multiple_callbacks() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}
+
+/// Verify that we can pass a callback that takes multiple arguments from Rust to Swift.
+mod test_swift_takes_callback_multiple_args {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            mod ffi {
+                extern "Swift" {
+                    fn some_function(callback: Box<dyn FnOnce(ARustType, u32) -> ()>);
+                }
+
+                extern "Rust" {
+                    type ARustType;
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::ContainsMany(vec![
+            quote! {
+                pub fn some_function (callback: Box<dyn FnOnce(super::ARustType, u32) -> ()>) {
+                    unsafe {
+                        __swift_bridge__some_function(
+                            Box::into_raw(Box::new(callback)) as *mut Box<dyn FnOnce(super::ARustType, u32) -> ()>
+                        )
+                    }
+                }
+            },
+            quote! {
+                #[export_name = "__swift_bridge__$some_function$param0"]
+                pub extern "C" fn some_function_param0(some_function_callback: *mut Box<dyn FnOnce(super::ARustType, u32) -> ()>, arg0: *mut super::ARustType, arg1: u32) {
+                    unsafe { Box::from_raw(some_function_callback)(unsafe { *Box::from_raw(arg0) }, arg1) }
+                }
+
+                #[export_name = "__swift_bridge__$some_function$_free$param0"]
+                pub extern "C" fn free_some_function_param0(some_function_callback: *mut Box<dyn FnOnce(super::ARustType, u32) -> ()>) {
+                    let _ = unsafe { Box::from_raw(some_function_callback) };
+                }
+            },
+            quote! {
+                #[link_name = "__swift_bridge__$some_function"]
+                fn __swift_bridge__some_function(callback: *mut Box<dyn FnOnce(super::ARustType, u32) -> ()>);
+            },
+        ])
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsManyAfterTrim(vec![
+            r#"
+class __private__RustFnOnceCallback$some_function$param0 {
+    var ptr: UnsafeMutableRawPointer
+    var called = false
+
+    init(ptr: UnsafeMutableRawPointer) {
+        self.ptr = ptr
+    }
+
+    deinit {
+        if !called {
+            __swift_bridge__$some_function$_free$param0(ptr)
+        }
+    }
+
+    func call(_ arg0: ARustType, _ arg1: UInt32) {
+        if called {
+            fatalError("Cannot call a Rust FnOnce function twice")
+        }
+        called = true
+        return __swift_bridge__$some_function$param0(ptr, {arg0.isOwned = false; return arg0.ptr;}(), arg1)
+    }
+}
+            "#,
+            r#"
+@_cdecl("__swift_bridge__$some_function")
+func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
+    { let cb0 = __private__RustFnOnceCallback$some_function$param0(ptr: callback); let _ = some_function(callback: { arg0, arg1 in cb0.call(arg0, arg1) }) }()
+}
+"#,
+        ])
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ContainsAfterTrim(
+            r#"
+void __swift_bridge__$some_function$param0(void* some_function_callback, void* arg0, uint32_t arg1);
+void __swift_bridge__$some_function$_free$param0(void* some_function_callback);
+"#,
+        )
+    }
+
+    #[test]
+    fn test_swift_takes_callback_multiple_args() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}
+
+/// Verify that we can pass a callback that has no args or return value from Rust to Swift.
+mod test_swift_method_takes_no_args_no_return_callback {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            mod ffi {
+                extern "Swift" {
+                    type SomeType;
+
+                    fn some_method(&self, callback: Box<dyn FnOnce() -> ()>);
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::ContainsMany(vec![
+            quote! {
+                impl SomeType {
+                    pub fn some_method (&self, callback: Box<dyn FnOnce() -> ()>) {
+                        unsafe {
+                            __swift_bridge__SomeType_some_method(
+                                swift_bridge::PointerToSwiftType(self.0),
+                                Box::into_raw(Box::new(callback)) as *mut Box<dyn FnOnce() -> ()>
+                            )
+                        }
+                    }
+                }
+            },
+            quote! {
+                #[link_name = "__swift_bridge__$SomeType$some_method"]
+                fn __swift_bridge__SomeType_some_method(
+                    this: swift_bridge::PointerToSwiftType,
+                    callback: *mut Box<dyn FnOnce() ->()>
+                );
+            },
+        ])
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(
+            r#"
+@_cdecl("__swift_bridge__$SomeType$some_method")
+func __swift_bridge__SomeType_some_method (_ this: UnsafeMutableRawPointer, _ callback: UnsafeMutableRawPointer) {
+    { let cb1 = __private__RustFnOnceCallbackNoArgsNoRet(ptr: callback); let _ = Unmanaged<SomeType>.fromOpaque(this).takeUnretainedValue().some_method(callback: { cb1.call() }) }()
+}
+"#,
+        )
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ExactAfterTrim("")
+    }
+
+    #[test]
+    fn test_swift_method_takes_no_args_no_return_callback() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}
+
+/// Verify that we can pass a callback with primitive arg from Rust to Swift.
+mod test_swift_method_takes_callback_one_primitive_arg {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            mod ffi {
+                extern "Swift" {
+                    type SomeType;
+
+                    fn some_method(&self, callback: Box<dyn FnOnce(u8) -> ()>);
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::ContainsMany(vec![
+            quote! {
+                impl SomeType {
+                    pub fn some_method (&self, callback: Box<dyn FnOnce(u8) -> ()>) {
+                        unsafe {
+                            __swift_bridge__SomeType_some_method(
+                                swift_bridge::PointerToSwiftType(self.0),
+                                Box::into_raw(Box::new(callback)) as *mut Box<dyn FnOnce(u8) -> ()>
+                            )
+                        }
+                    }
+                }
+            },
+            quote! {
+                #[export_name = "__swift_bridge__$SomeType$some_method$param1"]
+                pub extern "C" fn SomeType_some_method_param1(some_method_callback: *mut Box<dyn FnOnce(u8) -> ()>, arg0: u8) {
+                    unsafe { Box::from_raw(some_method_callback)(arg0) }
+                }
+
+                #[export_name = "__swift_bridge__$SomeType$some_method$_free$param1"]
+                pub extern "C" fn free_SomeType_some_method_param1(some_method_callback: *mut Box<dyn FnOnce(u8) -> ()>) {
+                    let _ = unsafe { Box::from_raw(some_method_callback) };
+                }
+            },
+            quote! {
+                #[link_name = "__swift_bridge__$SomeType$some_method"]
+                fn __swift_bridge__SomeType_some_method(
+                    this: swift_bridge::PointerToSwiftType,
+                    callback: *mut Box<dyn FnOnce(u8) ->()>
+                );
+            },
+        ])
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsManyAfterTrim(vec![
+            r#"
+class __private__RustFnOnceCallback$SomeType$some_method$param1 {
+    var ptr: UnsafeMutableRawPointer
+    var called = false
+
+    init(ptr: UnsafeMutableRawPointer) {
+        self.ptr = ptr
+    }
+
+    deinit {
+        if !called {
+            __swift_bridge__$SomeType$some_method$_free$param1(ptr)
+        }
+    }
+
+    func call(_ arg0: UInt8) {
+        if called {
+            fatalError("Cannot call a Rust FnOnce function twice")
+        }
+        called = true
+        return __swift_bridge__$SomeType$some_method$param1(ptr, arg0)
+    }
+}
+            "#,
+            r#"
+@_cdecl("__swift_bridge__$SomeType$some_method")
+func __swift_bridge__SomeType_some_method (_ this: UnsafeMutableRawPointer, _ callback: UnsafeMutableRawPointer) {
+    { let cb1 = __private__RustFnOnceCallback$SomeType$some_method$param1(ptr: callback); let _ = Unmanaged<SomeType>.fromOpaque(this).takeUnretainedValue().some_method(callback: { arg0 in cb1.call(arg0) }) }()
+}
+"#,
+        ])
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ContainsAfterTrim(
+            r#"
+void __swift_bridge__$SomeType$some_method$param1(void* some_method_callback, uint8_t arg0);
+void __swift_bridge__$SomeType$some_method$_free$param1(void* some_method_callback);
+"#,
+        )
+    }
+
+    #[test]
+    fn test_swift_method_takes_callback_one_primitive_arg() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -221,12 +221,21 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
             }
         }
 
-        for function in self.functions.iter() {
-            if function.host_lang.is_swift() {
+        for func in self.functions.iter() {
+            if func.host_lang.is_swift() {
+                for (idx, boxed_fn) in func.args_filtered_to_boxed_fns(&self.types) {
+                    if boxed_fn.params.is_empty() && boxed_fn.ret.is_null() {
+                        continue;
+                    }
+
+                    let fns = func.boxed_fn_to_c_header_fns(idx, &boxed_fn);
+                    header += &format!("{fns}");
+                    header += "\n";
+                }
                 continue;
             }
 
-            header += &declare_func(&function, &mut bookkeeping, &self.types);
+            header += &declare_func(&func, &mut bookkeeping, &self.types);
         }
 
         for slice_ty in bookkeeping.slice_types.iter() {

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
@@ -27,6 +27,7 @@ impl ToTokens for SwiftBridgeModule {
         let mut shared_struct_definitions = vec![];
         let mut shared_enum_definitions = vec![];
         let mut impl_fn_tokens: HashMap<String, Vec<TokenStream>> = HashMap::new();
+        let mut callbacks_support = vec![];
         let mut freestanding_rust_call_swift_fn_tokens = vec![];
         let mut extern_swift_fn_tokens = vec![];
 
@@ -40,6 +41,8 @@ impl ToTokens for SwiftBridgeModule {
                 HostLang::Swift => {
                     let tokens = func
                         .to_rust_fn_that_calls_a_swift_extern(&self.swift_bridge_path, &self.types);
+                    callbacks_support
+                        .push(func.callbacks_support(&self.swift_bridge_path, &self.types));
 
                     if let Some(ty) = func.associated_type.as_ref() {
                         match ty {
@@ -245,6 +248,8 @@ impl ToTokens for SwiftBridgeModule {
             #(#structs_for_swift_classes)*
 
             #extern_swift_fn_tokens
+
+            #(#callbacks_support)*
         };
 
         let t = quote! {

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_swift_func.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_swift_func.rs
@@ -13,7 +13,7 @@ impl ParsedExternFn {
     ) -> String {
         let mut params: Vec<String> = vec![];
 
-        for arg in &self.func.sig.inputs {
+        for (arg_idx, arg) in self.func.sig.inputs.iter().enumerate() {
             let param = match arg {
                 FnArg::Receiver(_receiver) => {
                     if include_receiver_if_present {
@@ -34,7 +34,7 @@ impl ParsedExternFn {
                     let arg_name = pat_ty.pat.to_token_stream().to_string();
 
                     let ty = if let Some(built_in) = BridgedType::new_with_type(&pat_ty.ty, types) {
-                        built_in.to_swift_type(TypePosition::FnArg(self.host_lang), types)
+                        built_in.to_swift_type(TypePosition::FnArg(self.host_lang, arg_idx), types)
                     } else {
                         todo!("Push to ParsedErrors")
                     };
@@ -64,7 +64,7 @@ impl ParsedExternFn {
     ) -> String {
         let mut args = vec![];
         let inputs = &self.func.sig.inputs;
-        for arg in inputs {
+        for (arg_idx, arg) in inputs.iter().enumerate() {
             match arg {
                 FnArg::Receiver(receiver) => {
                     if include_receiver_if_present {
@@ -94,12 +94,12 @@ impl ParsedExternFn {
                             if self.host_lang.is_rust() {
                                 bridged_ty.convert_swift_expression_to_ffi_compatible(
                                     &arg,
-                                    TypePosition::FnArg(self.host_lang),
+                                    TypePosition::FnArg(self.host_lang, arg_idx),
                                 )
                             } else {
                                 bridged_ty.convert_ffi_value_to_swift_value(
                                     &arg,
-                                    TypePosition::FnArg(self.host_lang),
+                                    TypePosition::FnArg(self.host_lang, arg_idx),
                                     types,
                                 )
                             }

--- a/crates/swift-integration-tests/build.rs
+++ b/crates/swift-integration-tests/build.rs
@@ -4,34 +4,24 @@ fn main() {
     let out_dir = "../../SwiftRustIntegrationTestRunner/Generated";
     let out_dir = PathBuf::from(out_dir);
 
-    let bridges = vec![
-        "src/async_function.rs",
-        "src/expose_opaque_rust_type.rs",
-        "src/import_opaque_swift_class.rs",
-        "src/bool.rs",
-        "src/generics.rs",
-        "src/option.rs",
-        "src/pointer.rs",
-        "src/string.rs",
-        "src/vec.rs",
-        "src/slice.rs",
-        "src/shared_types/shared_struct.rs",
-        "src/shared_types/shared_enum.rs",
-        "src/rust_function_uses_opaque_swift_type.rs",
-        "src/swift_function_uses_opaque_rust_type.rs",
-        "src/swift_function_uses_opaque_swift_type.rs",
-        "src/conditional_compilation.rs",
-        "src/opaque_type_attributes/already_declared.rs",
-        "src/opaque_type_attributes/copy.rs",
-        "src/function_attributes/get.rs",
-        "src/function_attributes/identifiable.rs",
-        "src/struct_attributes/already_declared.rs",
-        "src/struct_attributes/swift_name.rs",
-    ];
+    let mut bridges = vec![];
+    read_files_recursive(PathBuf::from("src"), &mut bridges);
+
     for path in &bridges {
-        println!("cargo:rerun-if-changed={}", path);
+        println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
     }
 
     swift_bridge_build::parse_bridges(bridges)
         .write_all_concatenated(out_dir, env!("CARGO_PKG_NAME"));
+}
+
+fn read_files_recursive(dir: PathBuf, files: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_dir() {
+            read_files_recursive(path, files);
+        } else {
+            files.push(path)
+        }
+    }
 }

--- a/crates/swift-integration-tests/src/boxed_functions.rs
+++ b/crates/swift-integration-tests/src/boxed_functions.rs
@@ -1,0 +1,131 @@
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Swift" {
+        fn swift_takes_fnonce_callback_no_args_no_return(arg: Box<dyn FnOnce() -> ()>);
+        fn swift_takes_fnonce_callback_primitive(arg: Box<dyn FnOnce(u8) -> u8>) -> u8;
+        fn swift_takes_fnonce_callback_opaque_rust(
+            arg: Box<dyn FnOnce(CallbackTestOpaqueRustType) -> CallbackTestOpaqueRustType>,
+        );
+
+        fn swift_takes_two_fnonce_callbacks(
+            arg1: Box<dyn FnOnce()>,
+            arg2: Box<dyn FnOnce(u8) -> u16>,
+        ) -> u16;
+        fn swift_takes_fnonce_callback_with_two_params(arg: Box<dyn FnOnce(u8, u16) -> u16>)
+            -> u16;
+
+        fn swift_calls_rust_fnonce_callback_twice(arg: Box<dyn FnOnce() -> ()>);
+    }
+
+    extern "Swift" {
+        type SwiftMethodCallbackTester;
+
+        #[swift_bridge(init)]
+        fn new() -> SwiftMethodCallbackTester;
+
+        fn method_with_fnonce_callback(&self, callback: Box<dyn FnOnce() -> ()>);
+        fn method_with_fnonce_callback_primitive(
+            &self,
+            callback: Box<dyn FnOnce(u16) -> u16>,
+        ) -> u16;
+    }
+
+    // TODO
+    // extern "Rust" {
+    //     fn rust_takes_callback_fnonce_no_args_no_return(arg: Box<dyn FnOnce() -> ()>);
+    //     fn rust_takes_callback_fnonce_primitive(doubling_fn: Box<dyn FnOnce(u8) -> u8>);
+    //     fn rust_takes_callback_fnonce_opaque_rust(
+    //         doubling_fn: Box<dyn FnOnce(CallbackTestOpaqueRustType) -> CallbackTestOpaqueRustType>,
+    //     );
+    //
+    //     fn rust_takes_callback_fnonce_two_params(
+    //         arg: Box<dyn FnOnce(i16, CallbackTestOpaqueRustType)>,
+    //     );
+    //
+    //     fn rust_takes_two_callbacks_fnonce_noop(
+    //         arg1: Box<dyn FnOnce()>,
+    //         arg2: Box<dyn FnOnce() -> ()>,
+    //     );
+    // }
+
+    extern "Rust" {
+        type CallbackTestOpaqueRustType;
+
+        #[swift_bridge(init)]
+        fn new(val: u32) -> CallbackTestOpaqueRustType;
+        fn val(&self) -> u32;
+        fn double(&mut self);
+    }
+
+    extern "Rust" {
+        fn test_callbacks_rust_calls_swift();
+    }
+}
+
+// TODO
+// fn rust_takes_callback_fnonce_no_args_no_return(arg: Box<dyn FnOnce() -> ()>) {
+//     (arg)()
+// }
+// fn rust_takes_callback_fnonce_primitive(doubling_fn: Box<dyn FnOnce(u8) -> u8>) {
+//     let doubling_fn = (doubling_fn)(2);
+//     assert_eq!(doubled, 4)
+// }
+//
+// fn rust_takes_callback_fnonce_opaque_rust(
+//     doubling_fn: Box<dyn FnOnce(CallbackTestOpaqueRustType) -> CallbackTestOpaqueRustType>,
+// ) {
+//     let start = CallbackTestOpaqueRustType { val: 100 };
+//
+//     let doubled = (doubling_fn)(start);
+//     assert_eq!(doubled.val(), 200);
+// }
+//
+// fn rust_takes_callback_fnonce_two_params(arg: Box<dyn FnOnce(i16, CallbackTestOpaqueRustType)>) {
+//     (arg)(123, CallbackTestOpaqueRustType { val: 222 })
+// }
+// fn rust_takes_two_callbacks_fnonce_noop(arg: Box<dyn FnOnce(i16, CallbackTestOpaqueRustType)>) {
+//     (arg)(123, CallbackTestOpaqueRustType { val: 222 })
+// }
+
+pub struct CallbackTestOpaqueRustType {
+    val: u32,
+}
+impl CallbackTestOpaqueRustType {
+    pub fn new(val: u32) -> Self {
+        Self { val }
+    }
+
+    pub fn val(&self) -> u32 {
+        self.val
+    }
+
+    pub fn double(&mut self) {
+        self.val *= 2
+    }
+}
+
+fn test_callbacks_rust_calls_swift() {
+    let swift_callback_tester = ffi::SwiftMethodCallbackTester::new();
+
+    ffi::swift_takes_fnonce_callback_no_args_no_return(Box::new(|| {}));
+
+    let four_times_two = ffi::swift_takes_fnonce_callback_primitive(Box::new(|num| num * 2));
+    assert_eq!(four_times_two, 8);
+
+    ffi::swift_takes_fnonce_callback_opaque_rust(Box::new(|mut rust_ty| {
+        rust_ty.double();
+        rust_ty
+    }));
+
+    ffi::swift_takes_fnonce_callback_with_two_params(Box::new(|_num1, num2| num2 * 2));
+
+    let three_times_two =
+        ffi::swift_takes_two_fnonce_callbacks(Box::new(|| {}), Box::new(|num| (num * 2) as u16));
+    assert_eq!(three_times_two, 6);
+
+    swift_callback_tester.method_with_fnonce_callback(Box::new(|| {}));
+
+    let five_times_two =
+        swift_callback_tester.method_with_fnonce_callback_primitive(Box::new(|num| num * 2));
+    assert_eq!(five_times_two, 10);
+}

--- a/crates/swift-integration-tests/src/function_attributes/args_into.rs
+++ b/crates/swift-integration-tests/src/function_attributes/args_into.rs
@@ -1,7 +1,7 @@
 #[swift_bridge::bridge]
 mod ffi {
     #[swift_bridge(swift_repr = "struct")]
-    struct SomeStruct {
+    struct ArgsIntoSomeStruct {
         field: u64,
     }
 
@@ -11,12 +11,13 @@ mod ffi {
     }
 
     extern "Rust" {
-        // The `test_args_into` function declaration here accepts `SomeStruct` and `AnotherStruct`,
+        // The `test_args_into` function declaration here accepts `ArgsIntoSomeStruct`
+        // and `AnotherStruct`,
         // but the real definition outside this module accepts different types that each of these
         // types impl Into for.
         // So.. if this compiles then we know that our `args_into` attribute is working.
         #[swift_bridge(args_into = (some_arg, another_arg))]
-        fn test_args_into(some_arg: SomeStruct, another_arg: AnotherStruct);
+        fn test_args_into(some_arg: ArgsIntoSomeStruct, another_arg: AnotherStruct);
     }
 }
 
@@ -28,7 +29,7 @@ enum TypeB {
     Foo(u8),
 }
 
-impl Into<TypeA> for ffi::SomeStruct {
+impl Into<TypeA> for ffi::ArgsIntoSomeStruct {
     fn into(self) -> TypeA {
         TypeA
     }

--- a/crates/swift-integration-tests/src/function_attributes/return_into.rs
+++ b/crates/swift-integration-tests/src/function_attributes/return_into.rs
@@ -2,7 +2,7 @@ use ffi2::AlreadyDeclaredStruct;
 
 #[swift_bridge::bridge]
 mod ffi {
-    struct SomeStruct;
+    struct ReturnIntoSomeStruct;
 
     #[swift_bridge(already_declared, swift_repr = "struct")]
     struct AlreadyDeclaredStruct;
@@ -22,7 +22,7 @@ mod ffi {
 
         // Verify that our code compiles when we use `return_into` on a shared struct.
         #[swift_bridge(return_into)]
-        fn get_struct() -> SomeStruct;
+        fn get_struct() -> ReturnIntoSomeStruct;
 
         // Verify that our code compiles when we use `return_into` on an already declared
         // shared struct.
@@ -71,9 +71,9 @@ impl Into<SomeType> for AnotherType {
     }
 }
 
-impl Into<ffi::SomeStruct> for SomeType {
-    fn into(self) -> ffi::SomeStruct {
-        ffi::SomeStruct
+impl Into<ffi::ReturnIntoSomeStruct> for SomeType {
+    fn into(self) -> ffi::ReturnIntoSomeStruct {
+        ffi::ReturnIntoSomeStruct
     }
 }
 impl Into<ffi2::AlreadyDeclaredStruct> for SomeType {

--- a/crates/swift-integration-tests/src/lib.rs
+++ b/crates/swift-integration-tests/src/lib.rs
@@ -3,6 +3,7 @@ mod import_opaque_swift_class;
 
 mod async_function;
 mod bool;
+mod boxed_functions;
 mod conditional_compilation;
 mod generics;
 mod option;

--- a/src/boxed_fn_support.rs
+++ b/src/boxed_fn_support.rs
@@ -1,0 +1,17 @@
+#![allow(non_snake_case)]
+
+#[export_name = "__swift_bridge__$call_boxed_fn_once_no_args_no_return"]
+pub extern "C" fn __swift_bridge__call_boxed_fn_once_no_args_no_return(
+    boxed_fn: *mut Box<dyn FnOnce() -> ()>,
+) {
+    unsafe { Box::from_raw(boxed_fn)() };
+}
+
+#[export_name = "__swift_bridge__$free_boxed_fn_once_no_args_no_return"]
+pub extern "C" fn __swift_bridge__free_boxed_fn_once_no_args_no_return(
+    boxed_fn: *mut Box<dyn FnOnce() -> ()>,
+) {
+    unsafe {
+        let _ = Box::from_raw(boxed_fn);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ pub use self::std_bridge::{option, string};
 pub mod async_support;
 
 #[doc(hidden)]
+pub mod boxed_fn_support;
+
+#[doc(hidden)]
 #[repr(C)]
 pub struct FfiSlice<T> {
     pub start: *const T,


### PR DESCRIPTION
This commit adds support for passing a Box<dyn FnOnce> from
Rust to Swift.

For example, the following is now possible:

```rust
#[swift_bridge::bridge]
mod ffi {
    extern "Swift" {
        type StripeTerminalSingleton;

        #[swift_bridge(init)]
        fn new() -> StripeTerminalSingleton;

        fn retrieve_payment_intent(
            &self,
            client_secret: &str,
            callback: Box<dyn FnOnce(Result<PaymentIntentWrapper, String>)>,
        );

        fn collect_payment_method(
            &self,
            payment_intent: PaymentIntentWrapper,
            callback: Box<dyn FnOnce(Result<PaymentIntentWrapper, String>)>,
        );

        fn process_payment(
            &self,
            payment_intent: PaymentIntentWrapper,
            callback: Box<dyn FnOnce(Result<PaymentIntentWrapper, ProcessPaymentError)>,
        );
    }
}
```

Note that we also have support for calling an async Rust function from
Swift.
Introducing support for passing callbacks from Rust -> Swift helps us
continue to support more flavors of asynchronous code.
