### PR TITLE
Add support for Result<T, E>

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ In addition to allowing you to share your own custom structs, enums and classes 
 | *const T                                                        | UnsafePointer\<T>                                                |                                                                                    |
 | *mut T                                                          | UnsafeMutablePointer\<T>                                         |                                                                                    |
 | Option\<T>                                                      | Optional\<T>                                                     |                                                                                    |
-| Result\<T>                                                      |                                                                  | Not yet implemented                                                                |
+| Result\<T, E>                                                   | RustResult\<T, E>                                                |                                                                                    |
 | Have a Rust standard library type in mind?<br /> Open an issue! |                                                                  |                                                                                    |
 |                                                                 | Have a Swift standard library type in mind?<br /> Open an issue! |                                                                                    |
 <!-- ANCHOR_END: built-in-types-table -->

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		221E16B42786233600F94AC0 /* ConditionalCompilationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221E16B32786233600F94AC0 /* ConditionalCompilationTests.swift */; };
 		221E16B62786F9FF00F94AC0 /* OpaqueTypeAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221E16B52786F9FF00F94AC0 /* OpaqueTypeAttributeTests.swift */; };
 		22553324281DB5FC008A3121 /* GenericTests.rs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22553323281DB5FC008A3121 /* GenericTests.rs.swift */; };
+		225908FC28DA0E320080C737 /* ResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 225908FB28DA0E320080C737 /* ResultTests.swift */; };
+		225908FE28DA0F9F0080C737 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 225908FD28DA0F9F0080C737 /* Result.swift */; };
 		226F944B27BF79B400243D86 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226F944A27BF79B400243D86 /* String.swift */; };
 		228FE5D52740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228FE5D42740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift */; };
 		228FE5D72740DB6A00805D9E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228FE5D62740DB6A00805D9E /* ContentView.swift */; };
@@ -72,6 +74,8 @@
 		221E16B32786233600F94AC0 /* ConditionalCompilationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalCompilationTests.swift; sourceTree = "<group>"; };
 		221E16B52786F9FF00F94AC0 /* OpaqueTypeAttributeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpaqueTypeAttributeTests.swift; sourceTree = "<group>"; };
 		22553323281DB5FC008A3121 /* GenericTests.rs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericTests.rs.swift; sourceTree = "<group>"; };
+		225908FB28DA0E320080C737 /* ResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
+		225908FD28DA0F9F0080C737 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		226F944A27BF79B400243D86 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		228FE5D12740DB6A00805D9E /* SwiftRustIntegrationTestRunner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftRustIntegrationTestRunner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		228FE5D42740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftRustIntegrationTestRunnerApp.swift; sourceTree = "<group>"; };
@@ -166,6 +170,7 @@
 				228FE5D42740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift */,
 				22EE4E0828B5388000FEC83C /* SwiftFnUsesOpaqueSwiftType.swift */,
 				22C0625228CE699D007A6F67 /* Callbacks.swift */,
+				225908FD28DA0F9F0080C737 /* Result.swift */,
 			);
 			path = SwiftRustIntegrationTestRunner;
 			sourceTree = "<group>";
@@ -190,6 +195,7 @@
 				228FE61127428A8D00805D9E /* OpaqueSwiftStructTests.swift */,
 				221E16B52786F9FF00F94AC0 /* OpaqueTypeAttributeTests.swift */,
 				22043294274ADA7A00BAE645 /* OptionTests.swift */,
+				225908FB28DA0E320080C737 /* ResultTests.swift */,
 				220432A6274C953E00BAE645 /* PointerTests.swift */,
 				220432EB27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift */,
 				2202BC0727B2DD1700D43CC4 /* SharedEnumTests.swift */,
@@ -363,6 +369,7 @@
 				220432EA2753092C00BAE645 /* RustFnUsesOpaqueSwiftType.swift in Sources */,
 				22FD1C542753CB2A00F64281 /* SwiftFnUsesOpaqueRustType.swift in Sources */,
 				220432A9274D31DC00BAE645 /* Pointer.swift in Sources */,
+				225908FE28DA0F9F0080C737 /* Result.swift in Sources */,
 				228FE5D72740DB6A00805D9E /* ContentView.swift in Sources */,
 				228FE64E2749C3D700805D9E /* Boolean.swift in Sources */,
 				228FE64627480E1D00805D9E /* SwiftBridgeCore.swift in Sources */,
@@ -385,6 +392,7 @@
 				220432AF274E7BF800BAE645 /* SharedStructTests.swift in Sources */,
 				220432EC27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift in Sources */,
 				22553324281DB5FC008A3121 /* GenericTests.rs.swift in Sources */,
+				225908FC28DA0E320080C737 /* ResultTests.swift in Sources */,
 				228FE6502749C43100805D9E /* BooleanTests.swift in Sources */,
 				2202BC0827B2DD1700D43CC4 /* SharedEnumTests.swift in Sources */,
 				22BCAAB927A2607700686A21 /* FunctionAttributeIdentifiableTests.swift in Sources */,

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Result.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Result.swift
@@ -1,0 +1,12 @@
+//
+//  Result.swift
+//  SwiftRustIntegrationTestRunner
+//
+//  Created by Frankie Nwafili on 9/20/22.
+//
+
+func swift_func_takes_callback_with_result_arg(
+    arg: (RustResult<CallbackTestOpaqueRustType, String>) -> ()
+) {
+    arg(.Ok(CallbackTestOpaqueRustType(555)))
+}

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
@@ -1,0 +1,27 @@
+//
+//  ResultTests.swift
+//  SwiftRustIntegrationTestRunnerTests
+//
+//  Created by Frankie Nwafili on 9/20/22.
+//
+
+import XCTest
+@testable import SwiftRustIntegrationTestRunner
+
+class ResultTests: XCTestCase {
+    /// Verify that we can pass a Result<String, String> from Swift -> Rust
+    func testSwiftCallRustResultString() throws {
+        rust_func_takes_result_string(.Ok("Success Message"))
+        rust_func_takes_result_string(.Err("Error Message"))
+    }
+    
+    /// Verify that we can pass a Result<OpaqueRust, OpaqueRust> from Swift -> Rust
+    func testSwiftCallRustResultOpaqueRust() throws {
+        rust_func_takes_result_opaque_rust(
+            .Ok(ResultTestOpaqueRustType(111))
+        )
+        rust_func_takes_result_opaque_rust(
+            .Err(ResultTestOpaqueRustType(222))
+        )
+    }
+}

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -20,10 +20,11 @@
   - [Conditional Compilation](./bridge-module/conditional-compilation/README.md)
 
 - [Built In Types](./built-in/README.md)
-  - [Option<T> <---> Optional<T>](./built-in/option/README.md)
-  - [Vec<T> <---> RustVec<T>](./built-in/vec/README.md)
   - [String <---> String](./built-in/string/README.md)
   - [&str <---> RustStr](./built-in/str/README.md)
+  - [Vec<T> <---> RustVec<T>](./built-in/vec/README.md)
+  - [Option<T> <---> Optional<T>](./built-in/option/README.md)
+  - [Result<T, E> <---> RustResult<T, E>](./built-in/result/README.md)
   - [Box<dyn FnOnce(A, B) -> C>](./built-in/boxed-functions/README.md)
 
 - [Safety](./safety/README.md)

--- a/book/src/built-in/result/README.md
+++ b/book/src/built-in/result/README.md
@@ -1,0 +1,27 @@
+# Result
+
+Rust's `Result` is seen on the Swift side as a `RustResult`.
+
+## Example
+
+```rust,no_run
+// Rust
+
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Swift" {
+        fn run(
+            arg: Box<dyn FnOnce(Result<SomeRustType, String>)>
+        );
+    }
+
+    extern "Rust" {
+        type SomeRustType;
+    }
+```
+
+```swift
+func run(arg: (RustResult<SomeRustType, String>) -> ()) {
+    arg(.Err("Something went wrong"))
+}
+```

--- a/crates/swift-bridge-build/src/generate_core.rs
+++ b/crates/swift-bridge-build/src/generate_core.rs
@@ -1,6 +1,7 @@
 use crate::generate_core::boxed_fn_support::{
     C_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN, SWIFT_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN,
 };
+use crate::generate_core::result_support::{C_RESULT_SUPPORT, SWIFT_RUST_RESULT};
 use std::path::{Path, PathBuf};
 
 const RUST_STRING_SWIFT: &'static str = include_str!("./generate_core/rust_string.swift");
@@ -10,6 +11,7 @@ const STRING_SWIFT: &'static str = include_str!("./generate_core/string.swift");
 const RUST_VEC_SWIFT: &'static str = include_str!("./generate_core/rust_vec.swift");
 
 mod boxed_fn_support;
+mod result_support;
 
 pub(super) fn write_core_swift_and_c(out_dir: &Path) {
     let core_swift_out = out_dir.join("SwiftBridgeCore.swift");
@@ -18,6 +20,8 @@ pub(super) fn write_core_swift_and_c(out_dir: &Path) {
     swift += &RUST_STRING_SWIFT;
     swift += "\n";
     swift += &SWIFT_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN;
+    swift += "\n";
+    swift += &SWIFT_RUST_RESULT;
 
     std::fs::write(core_swift_out, swift).unwrap();
 
@@ -27,6 +31,8 @@ pub(super) fn write_core_swift_and_c(out_dir: &Path) {
     c_header += &RUST_STRING_C;
     c_header += "\n";
     c_header += &C_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN;
+    c_header += "\n";
+    c_header += &C_RESULT_SUPPORT;
 
     std::fs::write(core_c_header_out, c_header).unwrap();
 }

--- a/crates/swift-bridge-build/src/generate_core/result_support.rs
+++ b/crates/swift-bridge-build/src/generate_core/result_support.rs
@@ -1,0 +1,40 @@
+pub const SWIFT_RUST_RESULT: &'static str = r#"
+public enum RustResult<T, E> {
+    case Ok(T)
+    case Err(E)
+}
+
+extension RustResult {
+    func ok() -> T? {
+        switch self {
+        case .Ok(let ok):
+            return ok
+        case .Err(_):
+            return nil
+        }
+    }
+
+    func err() -> E? {
+        switch self {
+        case .Ok(_):
+            return nil
+        case .Err(let err):
+            return err
+        }
+    }
+    
+    func toResult() -> Result<T, E>
+    where E: Error {
+        switch self {
+        case .Ok(let ok):
+            return .success(ok)
+        case .Err(let err):
+            return .failure(err)
+        }
+    }
+}
+"#;
+
+pub const C_RESULT_SUPPORT: &'static str = r#"
+struct __private__ResultPtrAndPtr { bool is_ok; void* ok_or_err; };
+"#;

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_option.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_option.rs
@@ -103,6 +103,9 @@ impl BridgedOption {
                 StdLibType::Option(_) => {
                     todo!("Support Option<Option<T>>")
                 }
+                StdLibType::Result(_) => {
+                    todo!("Support Option<Result<T, E>>")
+                }
                 StdLibType::BoxedFnOnce(_) => {
                     todo!("Option<Box<dyn FnOnce(A, B) -> C>> is not yet supported")
                 }
@@ -197,6 +200,9 @@ impl BridgedOption {
                 StdLibType::Option(_) => {
                     todo!("Option<Option<T>> is not yet supported")
                 }
+                StdLibType::Result(_) => {
+                    todo!("Option<Result<T, E>> is not yet supported")
+                }
                 StdLibType::BoxedFnOnce(_) => {
                     todo!("Option<Box<dyn FnOnce(A, B) -> C>> is not yet supported")
                 }
@@ -274,6 +280,9 @@ impl BridgedOption {
                 }
                 StdLibType::Option(_) => {
                     todo!("Support Option<Option<T>>")
+                }
+                StdLibType::Result(_) => {
+                    todo!("Option<Result<T, E>> is not yet supported")
                 }
                 StdLibType::BoxedFnOnce(_) => {
                     todo!("Option<Box<dyn FnOnce(A, B) -> C>> is not yet supported")
@@ -369,6 +378,9 @@ impl BridgedOption {
                 StdLibType::Option(_) => {
                     todo!("Option<Option<T> is not yet supported")
                 }
+                StdLibType::Result(_) => {
+                    todo!("Option<Result<T, E>> is not yet supported")
+                }
                 StdLibType::BoxedFnOnce(_) => {
                     todo!("Option<Box<dyn FnOnce(A, B) -> C>> is not yet supported")
                 }
@@ -439,6 +451,9 @@ impl BridgedOption {
                 }
                 StdLibType::Option(_) => {
                     todo!("Option<Option<T>> is not yet supported")
+                }
+                StdLibType::Result(_) => {
+                    todo!("Option<Result<T, E>> is not yet supported")
                 }
                 StdLibType::BoxedFnOnce(_) => {
                     todo!("Option<Box<dyn FnOnce(A, B) -> C>> is not yet supported")

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_result.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_result.rs
@@ -1,0 +1,152 @@
+use crate::bridged_type::{BridgedType, TypePosition};
+use crate::TypeDeclarations;
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::Path;
+
+/// Rust: Result<T, E>
+/// Swift: RustResult<T, E>
+///
+/// We don't use Swift's `Result` type since when we tried we saw a strange error
+///  `'Sendable' class 'ResultTestOpaqueRustType' cannot inherit from another class other than 'NSObject'`
+///  which meant that we could not use the `public class ResultTestOpaqueRustType: ResultTestOpaqueRustTypeRefMut {`
+///  pattern that we use to prevent calling mutable methods on immutable references.
+///  We only saw this error after `extension: ResultTestOpaqueRustType: Error {}` .. which was
+///  necessary because Swift's Result type requires that the error implements the `Error` protocol.
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) struct BuiltInResult {
+    pub ok_ty: Box<BridgedType>,
+    pub err_ty: Box<BridgedType>,
+}
+
+impl BuiltInResult {
+    pub(super) fn to_ffi_compatible_rust_type(&self, swift_bridge_path: &Path) -> TokenStream {
+        // TODO: Choose the kind of Result representation based on whether or not the ok and error
+        //  types are primitives.
+        //  See `swift-bridge/src/std_bridge/result`
+        let result_kind = quote! {
+            ResultPtrAndPtr
+        };
+
+        quote! {
+            #swift_bridge_path::result::#result_kind
+        }
+    }
+
+    pub(super) fn convert_ffi_value_to_rust_value(
+        &self,
+        expression: &TokenStream,
+        span: Span,
+        swift_bridge_path: &Path,
+        types: &TypeDeclarations,
+    ) -> TokenStream {
+        let ok_ffi_repr = self
+            .ok_ty
+            .to_ffi_compatible_rust_type(swift_bridge_path, types);
+        let err_ffi_repr = self
+            .err_ty
+            .to_ffi_compatible_rust_type(swift_bridge_path, types);
+
+        let convert_ok = self.ok_ty.convert_ffi_value_to_rust_value(
+            &quote! { #expression.ok_or_err as #ok_ffi_repr },
+            span,
+            swift_bridge_path,
+            types,
+        );
+
+        let convert_err = self.err_ty.convert_ffi_value_to_rust_value(
+            &quote! { #expression.ok_or_err as #err_ffi_repr },
+            span,
+            swift_bridge_path,
+            types,
+        );
+
+        quote! {
+            if #expression.is_ok {
+                std::result::Result::Ok(#convert_ok)
+            } else {
+                std::result::Result::Err(#convert_err)
+            }
+        }
+    }
+
+    pub fn to_rust_type_path(&self) -> TokenStream {
+        let ok = self.ok_ty.to_rust_type_path();
+        let err = self.err_ty.to_rust_type_path();
+
+        quote! { Result<#ok, #err> }
+    }
+
+    pub fn to_swift_type(&self, type_pos: TypePosition, types: &TypeDeclarations) -> String {
+        format!(
+            "RustResult<{}, {}>",
+            self.ok_ty.to_swift_type(type_pos, types),
+            self.err_ty.to_swift_type(type_pos, types),
+        )
+    }
+
+    pub fn convert_swift_expression_to_ffi_compatible(
+        &self,
+        expression: &str,
+        type_pos: TypePosition,
+    ) -> String {
+        let convert_ok = self
+            .ok_ty
+            .convert_swift_expression_to_ffi_compatible("ok", type_pos);
+        let convert_err = self
+            .err_ty
+            .convert_swift_expression_to_ffi_compatible("err", type_pos);
+
+        format!(
+            "{{ switch {val} {{ case .Ok(let ok): return __private__ResultPtrAndPtr(is_ok: true, ok_or_err: {convert_ok}) case .Err(let err): return __private__ResultPtrAndPtr(is_ok: false, ok_or_err: {convert_err}) }} }}()",
+            val = expression
+        )
+    }
+
+    pub fn to_c(&self) -> &'static str {
+        // TODO: Choose the kind of Result representation based on whether or not the ok and error
+        //  types are primitives.
+        //  See `swift-bridge/src/std_bridge/result`
+        "struct __private__ResultPtrAndPtr"
+    }
+}
+
+impl BuiltInResult {
+    /// Go from `Result < A , B >` to a `BuiltInResult`.
+    pub fn from_str_tokens(string: &str, types: &TypeDeclarations) -> Option<Self> {
+        // A , B >
+        let trimmed = string.trim_start_matches("Result < ");
+        // A , B
+        let trimmed = trimmed.trim_end_matches(" >");
+
+        // [A, B]
+        let mut ok_and_err = trimmed.split(",");
+        let ok = ok_and_err.next()?.trim();
+        let err = ok_and_err.next()?.trim();
+
+        let ok = BridgedType::new_with_str(ok, types)?;
+        let err = BridgedType::new_with_str(err, types)?;
+
+        Some(BuiltInResult {
+            ok_ty: Box::new(ok),
+            err_ty: Box::new(err),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::ToTokens;
+
+    /// Verify that we can parse a `Result<(), ()>`
+    #[test]
+    fn result_from_null_type() {
+        let tokens = quote! { Result<(), ()> }.to_token_stream().to_string();
+
+        let result = BuiltInResult::from_str_tokens(&tokens, &TypeDeclarations::default()).unwrap();
+
+        assert!(result.ok_ty.is_null());
+        assert!(result.err_ty.is_null());
+    }
+}

--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
@@ -70,6 +70,7 @@ impl SharedStruct {
     pub(crate) fn convert_ffi_repr_to_rust(
         &self,
         rust_val: &TokenStream,
+        swift_bridge_path: &Path,
         types: &TypeDeclarations,
     ) -> TokenStream {
         let struct_name = &self.name;
@@ -83,8 +84,12 @@ impl SharedStruct {
                 let access_field = norm_field.append_field_accessor(&quote! {val});
 
                 let ty = BridgedType::new_with_type(&norm_field.ty, types).unwrap();
-                let converted_field =
-                    ty.convert_ffi_value_to_rust_value(&access_field, norm_field.ty.span());
+                let converted_field = ty.convert_ffi_value_to_rust_value(
+                    &access_field,
+                    norm_field.ty.span(),
+                    swift_bridge_path,
+                    types,
+                );
 
                 quote! {
                     #maybe_name_and_colon #converted_field

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests.rs
@@ -29,7 +29,7 @@ use crate::test_utils::{
 
 mod already_declared_attribute_codegen_tests;
 mod async_function_codegen_tests;
-mod boxed_fnonce_tests;
+mod boxed_fnonce_codegen_tests;
 mod conditional_compilation_codegen_tests;
 mod extern_rust_function_opaque_rust_type_argument_codegen_tests;
 mod extern_rust_function_opaque_rust_type_return_codegen_tests;
@@ -40,6 +40,7 @@ mod generic_opaque_rust_type_codegen_tests;
 mod opaque_rust_type_codegen_tests;
 mod opaque_swift_type_codegen_tests;
 mod option_codegen_tests;
+mod result_codegen_tests;
 mod shared_enum_codegen_tests;
 mod shared_struct_codegen_tests;
 mod string_codegen_tests;

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/result_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/result_codegen_tests.rs
@@ -1,0 +1,127 @@
+//! See also: crates/swift-integration-tests/src/result.rs
+
+use super::{CodegenTest, ExpectedCHeader, ExpectedRustTokens, ExpectedSwiftCode};
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Test code generation for Rust function that accepts and returns a Result<T, E>
+/// where T and E are Strings.
+mod extern_rust_fn_result_string {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            mod ffi {
+                extern "Rust" {
+                    fn some_function (arg: Result<String, String>);
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::Contains(quote! {
+            #[export_name = "__swift_bridge__$some_function"]
+            pub extern "C" fn __swift_bridge__some_function(
+                arg: swift_bridge::result::ResultPtrAndPtr
+            ) {
+                super::some_function(
+                    if arg.is_ok {
+                        std::result::Result::Ok(unsafe { Box::from_raw(arg.ok_or_err as *mut swift_bridge::string::RustString).0 })
+                    } else {
+                        std::result::Result::Err(unsafe { Box::from_raw(arg.ok_or_err as *mut swift_bridge::string::RustString).0 })
+                    }
+                )
+            }
+        })
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(
+            r#"
+func some_function<GenericIntoRustString: IntoRustString>(_ arg: RustResult<GenericIntoRustString, GenericIntoRustString>) {
+    __swift_bridge__$some_function({ switch arg { case .Ok(let ok): return __private__ResultPtrAndPtr(is_ok: true, ok_or_err: { let rustString = ok.intoRustString(); rustString.isOwned = false; return rustString.ptr }()) case .Err(let err): return __private__ResultPtrAndPtr(is_ok: false, ok_or_err: { let rustString = err.intoRustString(); rustString.isOwned = false; return rustString.ptr }()) } }())
+}
+"#,
+        )
+    }
+
+    const EXPECTED_C_HEADER: ExpectedCHeader = ExpectedCHeader::ExactAfterTrim(
+        r#"
+void __swift_bridge__$some_function(struct __private__ResultPtrAndPtr arg);
+    "#,
+    );
+
+    #[test]
+    fn extern_rust_fn_result_string() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: EXPECTED_C_HEADER,
+        }
+        .test();
+    }
+}
+
+/// Test code generation for Rust function that accepts and returns a Result<T, E>
+/// where T and E are opaque Rust types.
+mod extern_rust_fn_result_opaque_rust {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            mod ffi {
+                extern "Rust" {
+                    type SomeType;
+
+                    fn some_function (arg: Result<SomeType, SomeType>);
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::Contains(quote! {
+            #[export_name = "__swift_bridge__$some_function"]
+            pub extern "C" fn __swift_bridge__some_function(
+                arg: swift_bridge::result::ResultPtrAndPtr
+            ) {
+                super::some_function(
+                    if arg.is_ok {
+                        std::result::Result::Ok(unsafe { *Box::from_raw(arg.ok_or_err as *mut super::SomeType) })
+                    } else {
+                        std::result::Result::Err(unsafe { *Box::from_raw(arg.ok_or_err as *mut super::SomeType) })
+                    }
+                )
+            }
+        })
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(
+            r#"
+func some_function(_ arg: RustResult<SomeType, SomeType>) {
+    __swift_bridge__$some_function({ switch arg { case .Ok(let ok): return __private__ResultPtrAndPtr(is_ok: true, ok_or_err: {ok.isOwned = false; return ok.ptr;}()) case .Err(let err): return __private__ResultPtrAndPtr(is_ok: false, ok_or_err: {err.isOwned = false; return err.ptr;}()) } }())
+}
+"#,
+        )
+    }
+
+    const EXPECTED_C_HEADER: ExpectedCHeader = ExpectedCHeader::ContainsAfterTrim(
+        r#"
+void __swift_bridge__$some_function(struct __private__ResultPtrAndPtr arg);
+    "#,
+    );
+
+    #[test]
+    fn extern_rust_fn_result_opaque_rust() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: EXPECTED_C_HEADER,
+        }
+        .test();
+    }
+}

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_struct.rs
@@ -65,8 +65,11 @@ impl SwiftBridgeModule {
             &self.types,
             &self.swift_bridge_path,
         );
-        let convert_ffi_to_rust =
-            shared_struct.convert_ffi_repr_to_rust(&quote! { self }, &self.types);
+        let convert_ffi_to_rust = shared_struct.convert_ffi_repr_to_rust(
+            &quote! { self },
+            swift_bridge_path,
+            &self.types,
+        );
 
         let struct_ffi_repr = if shared_struct.fields.is_empty() {
             // Using a u8 is arbitrary... We just need a field since empty structs aren't FFI safe.

--- a/crates/swift-bridge-ir/src/codegen/generate_swift.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift.rs
@@ -187,21 +187,6 @@ func {fn_name} (ptr: UnsafeMutableRawPointer) {{
     )
 }
 
-#[derive(Hash, Eq, PartialEq, Ord, PartialOrd)]
-enum SwiftFuncGenerics {
-    String,
-    Str,
-}
-
-impl SwiftFuncGenerics {
-    fn as_bound(&self) -> &'static str {
-        match self {
-            SwiftFuncGenerics::String => "GenericIntoRustString: IntoRustString",
-            SwiftFuncGenerics::Str => "GenericToRustStr: ToRustStr",
-        }
-    }
-}
-
 fn gen_function_exposes_swift_to_rust(
     func: &ParsedExternFn,
     types: &TypeDeclarations,
@@ -293,6 +278,8 @@ fn gen_function_exposes_swift_to_rust(
             TypePosition::FnReturn(HostLang::Swift),
         );
 
+        let maybe_generics = boxed_fn.maybe_swift_generics();
+
         rust_fn_once_callback_classes += &format!(
             r#"
 class __private__RustFnOnceCallback{maybe_associated_ty}${fn_name}$param{idx} {{
@@ -309,7 +296,7 @@ class __private__RustFnOnceCallback{maybe_associated_ty}${fn_name}$param{idx} {{
         }}
     }}
 
-    func call({params_as_swift}){maybe_ret} {{
+    func call{maybe_generics}({params_as_swift}){maybe_ret} {{
         if called {{
             fatalError("Cannot call a Rust FnOnce function twice")
         }}

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_rust_impl_call_swift.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_rust_impl_call_swift.rs
@@ -64,7 +64,12 @@ impl ParsedExternFn {
         };
 
         if let Some(built_in) = BridgedType::new_with_return_type(&sig.output, types) {
-            inner = built_in.convert_ffi_value_to_rust_value(&inner, sig.output.span());
+            inner = built_in.convert_ffi_value_to_rust_value(
+                &inner,
+                sig.output.span(),
+                swift_bridge_path,
+                types,
+            );
         } else {
             todo!("Push to ParsedErrors")
         }
@@ -114,7 +119,7 @@ impl ParsedExternFn {
             let free_boxed_fn_name = Ident::new(&free_boxed_fn_name, fn_name.span());
 
             let params = boxed_fn.params_to_ffi_compatible_rust_types(swift_bridge_path, types);
-            let call_args = boxed_fn.to_rust_call_args();
+            let call_args = boxed_fn.to_rust_call_args(swift_bridge_path, types);
 
             let call_boxed_fn_link_name = self.call_boxed_fn_link_name(idx);
             let free_boxed_fn_link_name = self.free_boxed_fn_link_name(idx);

--- a/crates/swift-integration-tests/src/boxed_functions.rs
+++ b/crates/swift-integration-tests/src/boxed_functions.rs
@@ -15,6 +15,10 @@ mod ffi {
             -> u16;
 
         fn swift_calls_rust_fnonce_callback_twice(arg: Box<dyn FnOnce() -> ()>);
+
+        fn swift_func_takes_callback_with_result_arg(
+            arg: Box<dyn FnOnce(Result<CallbackTestOpaqueRustType, String>)>,
+        );
     }
 
     extern "Swift" {
@@ -128,4 +132,8 @@ fn test_callbacks_rust_calls_swift() {
     let five_times_two =
         swift_callback_tester.method_with_fnonce_callback_primitive(Box::new(|num| num * 2));
     assert_eq!(five_times_two, 10);
+
+    ffi::swift_func_takes_callback_with_result_arg(Box::new(|result| {
+        assert_eq!(result.unwrap().val(), 555)
+    }));
 }

--- a/crates/swift-integration-tests/src/lib.rs
+++ b/crates/swift-integration-tests/src/lib.rs
@@ -8,6 +8,7 @@ mod conditional_compilation;
 mod generics;
 mod option;
 mod pointer;
+mod result;
 mod rust_function_uses_opaque_swift_type;
 mod shared_types;
 mod slice;

--- a/crates/swift-integration-tests/src/result.rs
+++ b/crates/swift-integration-tests/src/result.rs
@@ -1,0 +1,51 @@
+//! See also: crates/swift-bridge-ir/src/codegen/codegen_tests/result_codegen_tests.rs
+
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        fn rust_func_takes_result_string(arg: Result<String, String>);
+        fn rust_func_takes_result_opaque_rust(
+            arg: Result<ResultTestOpaqueRustType, ResultTestOpaqueRustType>,
+        );
+    }
+
+    extern "Rust" {
+        type ResultTestOpaqueRustType;
+
+        #[swift_bridge(init)]
+        fn new(val: u32) -> ResultTestOpaqueRustType;
+    }
+}
+
+fn rust_func_takes_result_string(arg: Result<String, String>) {
+    match arg {
+        Ok(ok) => {
+            assert_eq!(ok, "Success Message")
+        }
+        Err(err) => {
+            assert_eq!(err, "Error Message")
+        }
+    }
+}
+
+fn rust_func_takes_result_opaque_rust(
+    arg: Result<ResultTestOpaqueRustType, ResultTestOpaqueRustType>,
+) {
+    match arg {
+        Ok(ok) => {
+            assert_eq!(ok.val, 111)
+        }
+        Err(err) => {
+            assert_eq!(err.val, 222)
+        }
+    }
+}
+
+pub struct ResultTestOpaqueRustType {
+    val: u32,
+}
+impl ResultTestOpaqueRustType {
+    fn new(val: u32) -> Self {
+        Self { val }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ pub use swift_bridge_macro::bridge;
 
 mod std_bridge;
 
-pub use self::std_bridge::{option, string};
+pub use self::std_bridge::{option, result, string};
 
 #[doc(hidden)]
 #[cfg(feature = "async")]

--- a/src/std_bridge.rs
+++ b/src/std_bridge.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 
 pub mod option;
+pub mod result;
 mod rust_vec;
 pub mod string;

--- a/src/std_bridge/result.rs
+++ b/src/std_bridge/result.rs
@@ -1,0 +1,34 @@
+#[repr(C)]
+#[doc(hidden)]
+// Bridges `Result<T, E>` where `T` and `E` are non primitive types.
+pub struct ResultPtrAndPtr {
+    pub is_ok: bool,
+    pub ok_or_err: *mut std::ffi::c_void,
+}
+
+// TODO: We need to define every combination of primitive and pointer.
+//  Probably low priority since most users are probably using non-primitive types for
+//  `Result<T, E>`.
+//
+// #[repr(C)]
+// #[doc(hidden)]
+// pub struct ResultU8AndU8 {
+//     pub is_ok: bool,
+//     pub ok_or_err: u8,
+// }
+//
+// #[repr(C)]
+// #[doc(hidden)]
+// pub struct ResultU8AndU16 {
+//     pub is_ok: bool,
+//     pub ok: u8,
+//     pub err: u16
+// }
+//
+// #[repr(C)]
+// #[doc(hidden)]
+// pub struct ResultU8AndPtr {
+//     pub is_ok: bool,
+//     pub ok: u8,
+//     pub err: *mut std::ffi::c_void,
+// }


### PR DESCRIPTION
This commit adds suppoer for passing a `Result<T, E>` as an argument
from Rust -> Swift.

For example, the following is not possible:

```rust
use some_crate::SomeRustType;

#[swift_bridge::bridge]
mod ffi {
    extern "Swift" {
        fn swift_func_takes_callback(
            arg: Box<dyn FnOnce(Result<SomeRustType, String>)>,
        );
    }

    extern "Rust" {
        type SomeRustType;

        #[swift_bridge::init]
        fn new () -> SomeRustType;
    }
}
```
