### PR TITLE
Add UI test for invalid module items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swift-bridge"
-version = "0.1.41"
+version = "0.1.42"
 edition = "2021"
 keywords = ["swift", "ffi", "bindings", "ios", "mac"]
 description = "Generate FFI bindings for safe interop between Rust and Swift."
@@ -14,10 +14,10 @@ default = []
 async = ["tokio", "once_cell"]
 
 [build-dependencies]
-swift-bridge-build = {version = "0.1.41", path = "crates/swift-bridge-build"}
+swift-bridge-build = {version = "0.1.42", path = "crates/swift-bridge-build"}
 
 [dependencies]
-swift-bridge-macro = {version = "0.1.41", path = "crates/swift-bridge-macro"}
+swift-bridge-macro = {version = "0.1.42", path = "crates/swift-bridge-macro"}
 
 ################################################################################
 # Optional features used for async function support.

--- a/crates/swift-bridge-build/Cargo.toml
+++ b/crates/swift-bridge-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swift-bridge-build"
-version = "0.1.41"
+version = "0.1.42"
 edition = "2021"
 keywords = ["swift", "ffi", "bindings", "ios", "mac"]
 description = "Parse Rust files for swift-bridge modules and generate the corresponding Swift and C code for them."
@@ -9,6 +9,6 @@ license = "Apache-2.0/MIT"
 
 [dependencies]
 proc-macro2 = "1"
-swift-bridge-ir = {version = "0.1.41", path = "../swift-bridge-ir"}
+swift-bridge-ir = {version = "0.1.42", path = "../swift-bridge-ir"}
 syn = {version = "1"}
 tempfile = "3.3"

--- a/crates/swift-bridge-cli/Cargo.toml
+++ b/crates/swift-bridge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swift-bridge-cli"
-version = "0.1.41"
+version = "0.1.42"
 edition = "2021"
 keywords = ["swift", "ffi", "bindings", "ios", "mac"]
 description = "Parse Rust files for swift-bridge modules and generate the corresponding Swift and C code for them."
@@ -9,4 +9,4 @@ license = "Apache-2.0/MIT"
 
 [dependencies]
 clap = "3"
-swift-bridge-build = { version = "0.1.41", path = "../swift-bridge-build" }
+swift-bridge-build = { version = "0.1.42", path = "../swift-bridge-build" }

--- a/crates/swift-bridge-ir/Cargo.toml
+++ b/crates/swift-bridge-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swift-bridge-ir"
-version = "0.1.41"
+version = "0.1.42"
 edition = "2021"
 keywords = ["swift", "ffi", "bindings", "ios", "mac"]
 description = "Holds the data structures and logic for bridge module parsing and code generation."

--- a/crates/swift-bridge-macro/Cargo.toml
+++ b/crates/swift-bridge-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swift-bridge-macro"
-version = "0.1.41"
+version = "0.1.42"
 edition = "2021"
 keywords = ["swift", "ffi", "bindings", "ios", "mac"]
 description = "Powers swift-bridge module code generation."
@@ -14,7 +14,7 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ["full"] }
-swift-bridge-ir = {version = "0.1.41", path = "../swift-bridge-ir"}
+swift-bridge-ir = {version = "0.1.42", path = "../swift-bridge-ir"}
 
 [dev-dependencies]
 swift-bridge = {path = "../../"}

--- a/crates/swift-bridge-macro/tests/ui/invalid-module-item.rs
+++ b/crates/swift-bridge-macro/tests/ui/invalid-module-item.rs
@@ -1,0 +1,10 @@
+//! # To Run
+//! cargo test -p swift-bridge-macro -- ui trybuild=invalid-module-item.rs
+
+#[swift_bridge::bridge]
+mod ffi {
+    use std;
+    fn foo() {}
+}
+
+fn main() {}

--- a/crates/swift-bridge-macro/tests/ui/invalid-module-item.stderr
+++ b/crates/swift-bridge-macro/tests/ui/invalid-module-item.stderr
@@ -1,0 +1,11 @@
+error: Only `extern` blocks, structs and enums are supported.
+ --> tests/ui/invalid-module-item.rs:6:5
+  |
+6 |     use std;
+  |     ^^^^^^^^
+
+error: Only `extern` blocks, structs and enums are supported.
+ --> tests/ui/invalid-module-item.rs:7:5
+  |
+7 |     fn foo() {}
+  |     ^^^^^^^^^^^


### PR DESCRIPTION
This commit introduces a compile time error for invalid module items.

For example, the following will not give a descriptive compile time
error:

```rust
#[swift_bridge::bridge]
mod ffi {
    use std;
    fn foo() {}
}

// error: Only `extern` blocks, structs and enums are supported.
//  --> tests/ui/invalid-module-item.rs:6:5
//   |
// 3 |     use std;
//   |     ^^^^^^^^
//
// error: Only `extern` blocks, structs and enums are supported.
//  --> tests/ui/invalid-module-item.rs:7:5
//   |
// 4 |     fn foo() {}
//   |     ^^^^^^^^^^^
//
```