### PR TITLE
Add support for already_declared enums

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		228FE64A274919C600805D9E /* swift-integration-tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228FE648274919C500805D9E /* swift-integration-tests.swift */; };
 		22BC10F62799283100A0D046 /* SharedStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC10F52799283100A0D046 /* SharedStruct.swift */; };
 		22BC10F82799A3A000A0D046 /* SharedStructAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC10F72799A3A000A0D046 /* SharedStructAttributes.swift */; };
+		22BC4BBA294B8CCD0032B8A8 /* SharedEnumAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC4BB9294B8CCD0032B8A8 /* SharedEnumAttributeTests.swift */; };
 		22BCAAB927A2607700686A21 /* FunctionAttributeIdentifiableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BCAAB827A2607700686A21 /* FunctionAttributeIdentifiableTests.swift */; };
 		22C0625328CE699D007A6F67 /* Callbacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C0625228CE699D007A6F67 /* Callbacks.swift */; };
 		22C0625528CE6C9A007A6F67 /* CallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C0625428CE6C9A007A6F67 /* CallbackTests.swift */; };
@@ -99,6 +100,7 @@
 		228FE649274919C600805D9E /* swift-integration-tests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "swift-integration-tests.h"; path = "swift-integration-tests/swift-integration-tests.h"; sourceTree = "<group>"; };
 		22BC10F52799283100A0D046 /* SharedStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStruct.swift; sourceTree = "<group>"; };
 		22BC10F72799A3A000A0D046 /* SharedStructAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStructAttributes.swift; sourceTree = "<group>"; };
+		22BC4BB9294B8CCD0032B8A8 /* SharedEnumAttributeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedEnumAttributeTests.swift; sourceTree = "<group>"; };
 		22BCAAB827A2607700686A21 /* FunctionAttributeIdentifiableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionAttributeIdentifiableTests.swift; sourceTree = "<group>"; };
 		22C0625228CE699D007A6F67 /* Callbacks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Callbacks.swift; sourceTree = "<group>"; };
 		22C0625428CE6C9A007A6F67 /* CallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallbackTests.swift; sourceTree = "<group>"; };
@@ -199,6 +201,7 @@
 				222A81EA28EB5DF800D4A412 /* PrimitiveTests.swift */,
 				220432EB27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift */,
 				2202BC0727B2DD1700D43CC4 /* SharedEnumTests.swift */,
+				22BC4BB9294B8CCD0032B8A8 /* SharedEnumAttributeTests.swift */,
 				22C0AD50278ECA9E00A96469 /* SharedStructAttributeTests.swift */,
 				220432AE274E7BF800BAE645 /* SharedStructTests.swift */,
 				228FE5E62740DB6D00805D9E /* StringTests.swift */,
@@ -402,6 +405,7 @@
 				22C0AD51278ECA9E00A96469 /* SharedStructAttributeTests.swift in Sources */,
 				228FE5E72740DB6D00805D9E /* StringTests.swift in Sources */,
 				22C0625528CE6C9A007A6F67 /* CallbackTests.swift in Sources */,
+				22BC4BBA294B8CCD0032B8A8 /* SharedEnumAttributeTests.swift in Sources */,
 				228FE61227428A8D00805D9E /* OpaqueSwiftStructTests.swift in Sources */,
 				22FD1C562753CB3F00F64281 /* SwiftFnUsesOpaqueRustTypeTests.swift in Sources */,
 				228FE61027416C0300805D9E /* OpaqueRustStructTests.swift in Sources */,

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumAttributeTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumAttributeTests.swift
@@ -1,0 +1,23 @@
+//
+//  SharedEnumAttributeTests.swift
+//  SwiftRustIntegrationTestRunnerTests
+//
+//  Created by Frankie Nwafili on 12/15/22.
+//
+
+import XCTest
+@testable import SwiftRustIntegrationTestRunner
+
+/// Tests for attributes on transparent enum types.
+class SharedEnumAttributeTests: XCTestCase {
+    /// Verify that we can call a function that uses a type that was already declared in a different bridge module.
+    func testSharedEnumAlreadyDeclared() throws {
+        XCTAssertEqual(
+            reflect_already_declared_enum(
+                AlreadyDeclaredEnumTest.Variant
+            ),
+            AlreadyDeclaredEnumTest.Variant
+        )
+    }
+}
+

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -933,9 +933,14 @@ impl BridgedType {
                 prefixed_ty_name
             }
             BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(shared_enum))) => {
-                let ffi_ty_name = shared_enum.ffi_name_tokens();
+                let ty_name = &shared_enum.name;
 
-                quote! { #ffi_ty_name }
+                if shared_enum.already_declared {
+                    quote! { <super:: #ty_name as #swift_bridge_path::SharedEnum>::FfiRepr }
+                } else {
+                    let ffi_ty_name = shared_enum.ffi_name_tokens();
+                    quote! { #ffi_ty_name }
+                }
             }
         };
 

--- a/crates/swift-bridge-ir/src/bridged_type/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_enum.rs
@@ -10,6 +10,7 @@ pub(crate) use self::enum_variant::EnumVariant;
 pub(crate) struct SharedEnum {
     pub name: Ident,
     pub variants: Vec<EnumVariant>,
+    pub already_declared: bool,
 }
 
 impl SharedEnum {

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -126,6 +126,10 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                         header += "\n";
                     }
                     SharedTypeDeclaration::Enum(ty_enum) => {
+                        if ty_enum.already_declared {
+                            continue;
+                        }
+
                         let ffi_name = ty_enum.ffi_name_string();
                         let ffi_tag_name = ty_enum.ffi_tag_name_string();
                         let option_ffi_name = ty_enum.ffi_option_name_string();

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
@@ -14,6 +14,10 @@ impl SwiftBridgeModule {
         &self,
         shared_enum: &SharedEnum,
     ) -> Option<TokenStream> {
+        if shared_enum.already_declared {
+            return None;
+        }
+
         let enum_name = &shared_enum.name;
         let swift_bridge_path = &self.swift_bridge_path;
 

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
@@ -4,6 +4,10 @@ use crate::SwiftBridgeModule;
 impl SwiftBridgeModule {
     /// Generate the tokens for a shared enum.
     pub(super) fn generate_shared_enum_string(&self, shared_enum: &SharedEnum) -> Option<String> {
+        if shared_enum.already_declared {
+            return None;
+        }
+
         let enum_name = shared_enum.swift_name_string();
         let enum_ffi_name = shared_enum.ffi_name_string();
         let option_ffi_name = shared_enum.ffi_option_name_string();

--- a/crates/swift-bridge-ir/src/errors/parse_error.rs
+++ b/crates/swift-bridge-ir/src/errors/parse_error.rs
@@ -34,6 +34,8 @@ pub(crate) enum ParseError {
     StructInvalidSwiftRepr { swift_repr_attr_value: LitStr },
     /// A struct was declared with an unrecognized attribute.
     StructUnrecognizedAttribute { attribute: Ident },
+    /// An enum was declared with an unrecognized attribute.
+    EnumUnrecognizedAttribute { attribute: Ident },
     /// There is no reason to use `swift_repr = "class"` on an empty struct.
     /// It's extra overhead with no advantages.
     EmptyStructHasSwiftReprClass {
@@ -155,6 +157,10 @@ struct {struct_name};
             }
             ParseError::StructUnrecognizedAttribute { attribute } => {
                 let message = format!(r#"Did not recognize struct attribute "{}"."#, attribute);
+                Error::new_spanned(attribute, message)
+            }
+            ParseError::EnumUnrecognizedAttribute { attribute } => {
+                let message = format!(r#"Did not recognize enum attribute "{}"."#, attribute);
                 Error::new_spanned(attribute, message)
             }
             ParseError::FunctionAttribute(fn_attrib) => match fn_attrib {

--- a/crates/swift-bridge-ir/src/parse/parse_enum.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_enum.rs
@@ -1,5 +1,8 @@
 use crate::bridged_type::{EnumVariant, SharedEnum, StructFields};
-use crate::errors::ParseErrors;
+use crate::errors::{ParseError, ParseErrors};
+use crate::parse::move_input_cursor_to_next_comma;
+use proc_macro2::Ident;
+use syn::parse::{Parse, ParseStream};
 use syn::ItemEnum;
 
 pub(crate) struct SharedEnumDeclarationParser<'a> {
@@ -9,11 +12,73 @@ pub(crate) struct SharedEnumDeclarationParser<'a> {
     pub errors: &'a mut ParseErrors,
 }
 
+enum EnumAttr {
+    AlreadyDeclared,
+    Error(EnumAttrParseError),
+}
+
+enum EnumAttrParseError {
+    UnrecognizedAttribute(Ident),
+}
+
+#[derive(Default)]
+struct EnumAttribs {
+    already_declared: bool,
+}
+
+struct ParsedAttribs(Vec<EnumAttr>);
+impl Parse for ParsedAttribs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.is_empty() {
+            return Ok(ParsedAttribs(vec![]));
+        }
+
+        let opts = syn::punctuated::Punctuated::<_, syn::token::Comma>::parse_terminated(input)?;
+
+        Ok(ParsedAttribs(opts.into_iter().collect()))
+    }
+}
+
+impl Parse for EnumAttr {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let key: Ident = input.parse()?;
+
+        let attr = match key.to_string().as_str() {
+            "already_declared" => EnumAttr::AlreadyDeclared,
+            _ => {
+                move_input_cursor_to_next_comma(input);
+                EnumAttr::Error(EnumAttrParseError::UnrecognizedAttribute(key))
+            }
+        };
+
+        Ok(attr)
+    }
+}
+
 impl<'a> SharedEnumDeclarationParser<'a> {
     pub fn parse(self) -> Result<SharedEnum, syn::Error> {
         let item_enum = self.item_enum;
 
         let mut variants = vec![];
+
+        let mut attribs = EnumAttribs::default();
+        for attr in item_enum.attrs {
+            let sections: ParsedAttribs = attr.parse_args()?;
+
+            for attr in sections.0 {
+                match attr {
+                    EnumAttr::AlreadyDeclared => {
+                        attribs.already_declared = true;
+                    }
+                    EnumAttr::Error(err) => match err {
+                        EnumAttrParseError::UnrecognizedAttribute(attribute) => {
+                            self.errors
+                                .push(ParseError::EnumUnrecognizedAttribute { attribute });
+                        }
+                    },
+                }
+            }
+        }
 
         for v in item_enum.variants {
             let variant = EnumVariant {
@@ -26,6 +91,7 @@ impl<'a> SharedEnumDeclarationParser<'a> {
         let shared_enum = SharedEnum {
             name: item_enum.ident,
             variants,
+            already_declared: attribs.already_declared,
         };
 
         Ok(shared_enum)
@@ -35,7 +101,8 @@ impl<'a> SharedEnumDeclarationParser<'a> {
 #[cfg(test)]
 mod tests {
     use crate::bridged_type::StructFields;
-    use crate::test_utils::parse_ok;
+    use crate::errors::ParseError;
+    use crate::test_utils::{parse_errors, parse_ok};
     use quote::{quote, ToTokens};
 
     /// Verify that we can parse an enum with no variants.
@@ -104,5 +171,55 @@ mod tests {
             }
             _ => panic!(),
         }
+    }
+
+    /// Verify that we can parse the `#[swift_bridge(already_declared)`] attribute.
+    #[test]
+    fn already_declared_attribute() {
+        let tokens = quote! {
+            #[swift_bridge::bridge]
+            mod ffi {
+                #[swift_bridge(already_declared)]
+                enum SomeEnum {}
+            }
+        };
+
+        let module = parse_ok(tokens);
+
+        assert_eq!(module.types.types().len(), 1);
+
+        let ty = &module.types.types()[0].unwrap_shared_enum();
+        assert!(ty.already_declared);
+    }
+
+    /// Verify that we return an error if an attribute isn't recognized.
+    #[test]
+    fn error_if_attribute_unrecognized() {
+        let tokens = quote! {
+            #[swift_bridge::bridge]
+            mod ffi {
+                #[swift_bridge(unrecognized, invalid_attribute = "hi")]
+                enum SomeEnum{
+                    Variant
+                }
+            }
+        };
+
+        let errors = parse_errors(tokens);
+
+        assert_eq!(errors.len(), 2);
+
+        match &errors[0] {
+            ParseError::EnumUnrecognizedAttribute { attribute } => {
+                assert_eq!(&attribute.to_string(), "unrecognized");
+            }
+            _ => panic!(),
+        };
+        match &errors[1] {
+            ParseError::EnumUnrecognizedAttribute { attribute } => {
+                assert_eq!(&attribute.to_string(), "invalid_attribute");
+            }
+            _ => panic!(),
+        };
     }
 }

--- a/crates/swift-bridge-ir/src/parse/type_declarations.rs
+++ b/crates/swift-bridge-ir/src/parse/type_declarations.rs
@@ -36,20 +36,13 @@ impl TypeDeclaration {
         match self {
             TypeDeclaration::Shared(SharedTypeDeclaration::Struct(shared_struct)) => {
                 BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Struct(
-                    SharedStruct {
-                        name: shared_struct.name.clone(),
-                        swift_repr: shared_struct.swift_repr,
-                        fields: shared_struct.fields.clone(),
-                        swift_name: shared_struct.swift_name.clone(),
-                        already_declared: shared_struct.already_declared,
-                    },
+                    shared_struct.clone(),
                 )))
             }
             TypeDeclaration::Shared(SharedTypeDeclaration::Enum(shared_enum)) => {
-                BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(SharedEnum {
-                    name: shared_enum.name.clone(),
-                    variants: shared_enum.variants.clone(),
-                })))
+                BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(
+                    shared_enum.clone(),
+                )))
             }
             TypeDeclaration::Opaque(_o) => {
                 BridgedType::Bridgeable(Box::new(self.to_opaque_type(reference, mutable).unwrap()))

--- a/crates/swift-integration-tests/src/enum_attributes.rs
+++ b/crates/swift-integration-tests/src/enum_attributes.rs
@@ -1,0 +1,1 @@
+mod already_declared;

--- a/crates/swift-integration-tests/src/enum_attributes/already_declared.rs
+++ b/crates/swift-integration-tests/src/enum_attributes/already_declared.rs
@@ -1,0 +1,25 @@
+//! Verify that the `#[swift_bridge(already_declared)]` module prevents us from emitting the
+//! same type definitions twice.
+
+use self::ffi1::AlreadyDeclaredEnumTest;
+
+#[swift_bridge::bridge]
+mod ffi1 {
+    enum AlreadyDeclaredEnumTest {
+        Variant,
+    }
+}
+
+#[swift_bridge::bridge]
+mod ffi2 {
+    #[swift_bridge(already_declared)]
+    enum AlreadyDeclaredEnumTest {}
+
+    extern "Rust" {
+        fn reflect_already_declared_enum(arg: AlreadyDeclaredEnumTest) -> AlreadyDeclaredEnumTest;
+    }
+}
+
+fn reflect_already_declared_enum(arg: AlreadyDeclaredEnumTest) -> AlreadyDeclaredEnumTest {
+    arg
+}

--- a/crates/swift-integration-tests/src/lib.rs
+++ b/crates/swift-integration-tests/src/lib.rs
@@ -17,6 +17,7 @@ mod swift_function_uses_opaque_rust_type;
 mod swift_function_uses_opaque_swift_type;
 mod vec;
 
+mod enum_attributes;
 mod function_attributes;
 mod opaque_type_attributes;
 mod struct_attributes;

--- a/crates/swift-integration-tests/src/struct_attributes/already_declared.rs
+++ b/crates/swift-integration-tests/src/struct_attributes/already_declared.rs
@@ -1,8 +1,5 @@
 //! Verify that the `#[swift_bridge(already_declared)]` module prevents us from emitting the
 //! same type definitions twice.
-//!
-//! If the Xcode project is able to compile then we know that our attribute works,
-//! because otherwise we would get build time errors that the class was defined twice.
 
 use self::ffi1::AlreadyDeclaredStructTest;
 


### PR DESCRIPTION
This commit allows enums to use the `already_declared` attribute.

This is useful when you want to use the same enum across multiple bridge
modules.

---

For example, the following is now possible:

```rust
use some_other_bridge_module::SomeEnum;

#[swift_bridge::bridge]
mod ffi {
    #[swift_bridge(already_declared)]
    enum SomeEnum {}

    extern "Rust" {
        fn print(val: SomeEnum);
    }
}
```
