### PR TITLE
Make enums support the `swift_name` attrib

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		22BC10F62799283100A0D046 /* SharedStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC10F52799283100A0D046 /* SharedStruct.swift */; };
 		22BC10F82799A3A000A0D046 /* SharedStructAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC10F72799A3A000A0D046 /* SharedStructAttributes.swift */; };
 		22BC4BBA294B8CCD0032B8A8 /* SharedEnumAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC4BB9294B8CCD0032B8A8 /* SharedEnumAttributeTests.swift */; };
+		22BC4BBC294BA0EC0032B8A8 /* SharedEnumAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC4BBB294BA0EC0032B8A8 /* SharedEnumAttributes.swift */; };
 		22BCAAB927A2607700686A21 /* FunctionAttributeIdentifiableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BCAAB827A2607700686A21 /* FunctionAttributeIdentifiableTests.swift */; };
 		22C0625328CE699D007A6F67 /* Callbacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C0625228CE699D007A6F67 /* Callbacks.swift */; };
 		22C0625528CE6C9A007A6F67 /* CallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C0625428CE6C9A007A6F67 /* CallbackTests.swift */; };
@@ -101,6 +102,7 @@
 		22BC10F52799283100A0D046 /* SharedStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStruct.swift; sourceTree = "<group>"; };
 		22BC10F72799A3A000A0D046 /* SharedStructAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStructAttributes.swift; sourceTree = "<group>"; };
 		22BC4BB9294B8CCD0032B8A8 /* SharedEnumAttributeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedEnumAttributeTests.swift; sourceTree = "<group>"; };
+		22BC4BBB294BA0EC0032B8A8 /* SharedEnumAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedEnumAttributes.swift; sourceTree = "<group>"; };
 		22BCAAB827A2607700686A21 /* FunctionAttributeIdentifiableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionAttributeIdentifiableTests.swift; sourceTree = "<group>"; };
 		22C0625228CE699D007A6F67 /* Callbacks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Callbacks.swift; sourceTree = "<group>"; };
 		22C0625428CE6C9A007A6F67 /* CallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallbackTests.swift; sourceTree = "<group>"; };
@@ -173,6 +175,7 @@
 				22EE4E0828B5388000FEC83C /* SwiftFnUsesOpaqueSwiftType.swift */,
 				22C0625228CE699D007A6F67 /* Callbacks.swift */,
 				225908FD28DA0F9F0080C737 /* Result.swift */,
+				22BC4BBB294BA0EC0032B8A8 /* SharedEnumAttributes.swift */,
 			);
 			path = SwiftRustIntegrationTestRunner;
 			sourceTree = "<group>";
@@ -370,6 +373,7 @@
 				226F944B27BF79B400243D86 /* String.swift in Sources */,
 				22043297274B0AB000BAE645 /* Option.swift in Sources */,
 				220432EA2753092C00BAE645 /* RustFnUsesOpaqueSwiftType.swift in Sources */,
+				22BC4BBC294BA0EC0032B8A8 /* SharedEnumAttributes.swift in Sources */,
 				22FD1C542753CB2A00F64281 /* SwiftFnUsesOpaqueRustType.swift in Sources */,
 				220432A9274D31DC00BAE645 /* Pointer.swift in Sources */,
 				225908FE28DA0F9F0080C737 /* Result.swift in Sources */,

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/SharedEnumAttributes.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/SharedEnumAttributes.swift
@@ -1,0 +1,12 @@
+//
+//  SharedEnumAttributes.swift
+//  SwiftRustIntegrationTestRunner
+//
+//  Created by Frankie Nwafili on 12/15/22.
+//
+
+import Foundation
+
+func extern_swift_enum_rename(arg: EnumRename) -> EnumRename {
+    arg
+}

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumAttributeTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumAttributeTests.swift
@@ -10,6 +10,17 @@ import XCTest
 
 /// Tests for attributes on transparent enum types.
 class SharedEnumAttributeTests: XCTestCase {
+    /// Verify that we change the Swift name of a transparent enum.
+    func testSharedEnumSwiftName() throws {
+        XCTAssertEqual(
+            extern_rust_enum_rename(
+                EnumRename.Variant1
+            ),
+            EnumRename.Variant1
+        )
+    }
+    
+    
     /// Verify that we can call a function that uses a type that was already declared in a different bridge module.
     func testSharedEnumAlreadyDeclared() throws {
         XCTAssertEqual(

--- a/crates/swift-bridge-ir/src/bridged_type/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_enum.rs
@@ -2,6 +2,7 @@ use crate::SWIFT_BRIDGE_PREFIX;
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use std::fmt::{Debug, Formatter};
+use syn::LitStr;
 
 mod enum_variant;
 pub(crate) use self::enum_variant::EnumVariant;
@@ -11,17 +12,22 @@ pub(crate) struct SharedEnum {
     pub name: Ident,
     pub variants: Vec<EnumVariant>,
     pub already_declared: bool,
+    pub swift_name: Option<LitStr>,
 }
 
 impl SharedEnum {
     /// SomeEnum
     pub fn swift_name_string(&self) -> String {
-        format!("{}", self.name)
+        if let Some(swift_name) = self.swift_name.as_ref() {
+            swift_name.value().to_string()
+        } else {
+            format!("{}", self.name)
+        }
     }
 
     /// __swift_bridge__$SomeEnum
     pub fn ffi_name_string(&self) -> String {
-        format!("{}${}", SWIFT_BRIDGE_PREFIX, self.name)
+        format!("{}${}", SWIFT_BRIDGE_PREFIX, self.swift_name_string())
     }
 
     /// __swift_bridge__$SomeEnumTag
@@ -49,7 +55,11 @@ impl SharedEnum {
 
     /// __swift_bridge__$Option$SomeEnum
     pub fn ffi_option_name_string(&self) -> String {
-        format!("{}$Option${}", SWIFT_BRIDGE_PREFIX, self.name)
+        format!(
+            "{}$Option${}",
+            SWIFT_BRIDGE_PREFIX,
+            self.swift_name_string()
+        )
     }
 }
 

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
@@ -299,3 +299,50 @@ struct __swift_bridge__$Option$SomeEnum __swift_bridge__$some_function(struct __
         .test();
     }
 }
+
+/// Verify that the original name of the enum is not present in any of the generated Swift
+/// code when we use the `swift_name` attribute..
+/// Related: crates/swift-integration-tests/src/enum_attributes/swift_name.rs
+mod shared_enum_swift_name_attribute {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            #[swift_bridge::bridge]
+            mod ffi {
+                #[swift_bridge(swift_name = "EnumRename")]
+                enum EnumName {
+                    Variant
+                }
+
+
+                extern "Rust" {
+                    fn extern_rust_enum_rename(arg: EnumName) -> EnumName;
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::SkipTest
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::DoesNotContainAfterTrim("EnumName")
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::DoesNotContainAfterTrim("EnumName")
+    }
+
+    #[test]
+    fn shared_enum_swift_name_attribute() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -148,7 +148,7 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                         let maybe_vec_support = if ty_enum.has_one_or_more_variants_with_data() {
                             "".to_string()
                         } else {
-                            vec_transparent_enum_c_support(&ty_enum.name.to_string())
+                            vec_transparent_enum_c_support(&ty_enum.swift_name_string())
                         };
 
                         let enum_decl = format!(

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
@@ -76,7 +76,7 @@ impl SwiftBridgeModule {
             // Enums with variants that contain data are not yet supported.
             quote! {}
         } else {
-            generate_vec_of_transparent_enum_functions(&shared_enum.name)
+            generate_vec_of_transparent_enum_functions(&shared_enum)
         };
 
         let definition = quote! {

--- a/crates/swift-integration-tests/src/enum_attributes.rs
+++ b/crates/swift-integration-tests/src/enum_attributes.rs
@@ -1,1 +1,2 @@
 mod already_declared;
+mod swift_name;

--- a/crates/swift-integration-tests/src/enum_attributes/swift_name.rs
+++ b/crates/swift-integration-tests/src/enum_attributes/swift_name.rs
@@ -1,0 +1,27 @@
+/// We declare an enum and rename it using the `swift_name` attribute.
+/// We then use them as function arg and return types.
+///
+/// Related: crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
+///   - shared_enum_swift_name_attribute
+#[swift_bridge::bridge]
+mod ffi {
+    #[swift_bridge(swift_name = "EnumRename")]
+    enum EnumName {
+        Variant1,
+        Variant2,
+    }
+
+    extern "Rust" {
+        fn extern_rust_enum_rename(arg: EnumName) -> EnumName;
+    }
+
+    extern "Swift" {
+        fn extern_swift_enum_rename(arg: EnumName) -> EnumName;
+    }
+}
+
+use ffi::EnumName;
+
+fn extern_rust_enum_rename(arg: EnumName) -> EnumName {
+    arg
+}


### PR DESCRIPTION
This commit makes enums support the `swift_name` attribute, which lets
you choose the name that shows up on the Swift side.

For example, the following is now possible:

```rust
#[swift_bridge::bridge]
mod ffi {
    #[swift_bridge(swift_name = "EnumRename")]
    enum EnumName {
        Variant1,
        Variant2,
    }
}
```
