### PR TITLE
Fix return into + already declared enum

### DIFF
--- a/book/src/bridge-module/transparent-types/enums/README.md
+++ b/book/src/bridge-module/transparent-types/enums/README.md
@@ -42,7 +42,7 @@ func create_bar_code(upc: Bool) -> BarCode {
 
 ### Enum Attributes
 
-#### #[swift_bridge::bridge(already_declared)]
+#### #[swift_bridge(already_declared)]
 
 ```rust
 #[swift_bridge::bridge]
@@ -63,6 +63,20 @@ mod ffi_2 {
 
     extern "Rust" {
         fn some_function() -> SomeTransparentEnum;
+    }
+}
+```
+
+#### #[swift_bridge(swift_name = "...")]
+
+Set the name that is used when generating the enum on the Swift side.
+
+```rust
+#[swift_bridge::bridge]
+mod ffi {
+    #[swift_bridge(swift_name = "RenamedEnum")]
+    enum SomeTransparentEnum {
+        Variant
     }
 }
 ```

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -1707,8 +1707,15 @@ impl BridgedType {
             }
             BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(shared_enum))) => {
                 let enum_name = &shared_enum.name;
+
+                let maybe_super = if shared_enum.already_declared {
+                    quote! { super:: }
+                } else {
+                    quote! {}
+                };
+
                 quote! {
-                    { let val: #enum_name = #expression.into(); val }
+                    { let val: #maybe_super #enum_name = #expression.into(); val }
                 }
             }
             // TODO: Instead of this catchall.. explicitly match on all variants and use

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests.rs
@@ -41,6 +41,7 @@ mod opaque_rust_type_codegen_tests;
 mod opaque_swift_type_codegen_tests;
 mod option_codegen_tests;
 mod result_codegen_tests;
+mod return_into_attribute_codegen_tests;
 mod string_codegen_tests;
 mod transparent_enum_codegen_tests;
 mod transparent_struct_codegen_tests;

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/already_declared_attribute_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/already_declared_attribute_codegen_tests.rs
@@ -153,7 +153,7 @@ mod already_declared_enum {
     fn bridge_module_tokens() -> TokenStream {
         quote! {
             mod ffi {
-                #[swift_bridge(already_declared, swift_repr = "enum")]
+                #[swift_bridge(already_declared)]
                 enum FfiSomeEnum {}
 
                 extern "Rust" {

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/return_into_attribute_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/return_into_attribute_codegen_tests.rs
@@ -1,0 +1,49 @@
+use super::{CodegenTest, ExpectedCHeader, ExpectedRustTokens, ExpectedSwiftCode};
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Verify that we can return into an already_declared enum.
+mod return_into_already_declared_enum {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            mod ffi {
+                #[swift_bridge(already_declared)]
+                enum SomeEnum { }
+
+                extern "Rust" {
+                    #[swift_bridge(return_into)]
+                    fn some_function() -> SomeEnum;
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::Contains(quote! {
+            fn __swift_bridge__some_function() -> <super::SomeEnum as swift_bridge::SharedEnum>::FfiRepr {
+                {let val: super::SomeEnum = super::some_function().into(); val}.into_ffi_repr()
+            }
+        })
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::SkipTest
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::SkipTest
+    }
+
+    #[test]
+    fn already_declared_rust_copy_type_methods() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}

--- a/crates/swift-integration-tests/src/function_attributes/return_into.rs
+++ b/crates/swift-integration-tests/src/function_attributes/return_into.rs
@@ -1,3 +1,4 @@
+use ffi2::AlreadyDeclaredEnum;
 use ffi2::AlreadyDeclaredStruct;
 
 #[swift_bridge::bridge]
@@ -10,6 +11,9 @@ mod ffi {
     enum SomeTransparentEnum {
         Variant,
     }
+
+    #[swift_bridge(already_declared)]
+    enum AlreadyDeclaredEnum {}
 
     extern "Rust" {
         type SomeType;
@@ -33,16 +37,29 @@ mod ffi {
         // shared struct.
         #[swift_bridge(return_into)]
         fn get_transparent_enum() -> SomeTransparentEnum;
+
+        // Verify that our code compiles when we use `return_into` on an already declared
+        // transparent enum.
+        #[swift_bridge(return_into)]
+        fn get_already_declared_enum() -> AlreadyDeclaredEnum;
     }
 }
 #[swift_bridge::bridge]
 mod ffi2 {
     struct AlreadyDeclaredStruct;
+
+    enum AlreadyDeclaredEnum {
+        Variant,
+    }
 }
 
 pub struct SomeType;
 
 struct AnotherType;
+
+enum SomeEnum {
+    Variant,
+}
 
 fn get_another_type() -> AnotherType {
     AnotherType
@@ -58,6 +75,9 @@ fn get_already_declared_struct() -> SomeType {
 
 fn get_transparent_enum() -> u32 {
     123
+}
+fn get_already_declared_enum() -> SomeEnum {
+    SomeEnum::Variant
 }
 impl Into<ffi::SomeTransparentEnum> for u32 {
     fn into(self) -> ffi::SomeTransparentEnum {
@@ -79,5 +99,10 @@ impl Into<ffi::ReturnIntoSomeStruct> for SomeType {
 impl Into<ffi2::AlreadyDeclaredStruct> for SomeType {
     fn into(self) -> ffi2::AlreadyDeclaredStruct {
         ffi2::AlreadyDeclaredStruct
+    }
+}
+impl Into<ffi2::AlreadyDeclaredEnum> for SomeEnum {
+    fn into(self) -> ffi2::AlreadyDeclaredEnum {
+        ffi2::AlreadyDeclaredEnum::Variant
     }
 }


### PR DESCRIPTION
This commit makes signatures like the following
work:

```rust
#[swift_bridge::bridge]
mod ffi {
    #[swift_bridge(already_declared)]
    enum SomeEnum {}

    extern "Rust" {
        #[swift_bridge(return_into)]
        fn return_into_already_declared() -> SomeEnum;
    }
}
```
