### PR TITLE
Add swift_name attribute support

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		22EE4E0B28B538A700FEC83C /* SwiftFnUsesOpaqueSwiftTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EE4E0A28B538A700FEC83C /* SwiftFnUsesOpaqueSwiftTypeTests.swift */; };
 		22FD1C542753CB2A00F64281 /* SwiftFnUsesOpaqueRustType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD1C532753CB2A00F64281 /* SwiftFnUsesOpaqueRustType.swift */; };
 		22FD1C562753CB3F00F64281 /* SwiftFnUsesOpaqueRustTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD1C552753CB3F00F64281 /* SwiftFnUsesOpaqueRustTypeTests.swift */; };
+		C926E4DE294F07AA0027E7E2 /* FunctionAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C926E4DD294F07AA0027E7E2 /* FunctionAttributes.swift */; };
+		C926E4E0294F18C50027E7E2 /* FunctionAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C926E4DF294F18C50027E7E2 /* FunctionAttributeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -112,6 +114,8 @@
 		22EE4E0A28B538A700FEC83C /* SwiftFnUsesOpaqueSwiftTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftFnUsesOpaqueSwiftTypeTests.swift; sourceTree = "<group>"; };
 		22FD1C532753CB2A00F64281 /* SwiftFnUsesOpaqueRustType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftFnUsesOpaqueRustType.swift; sourceTree = "<group>"; };
 		22FD1C552753CB3F00F64281 /* SwiftFnUsesOpaqueRustTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftFnUsesOpaqueRustTypeTests.swift; sourceTree = "<group>"; };
+		C926E4DD294F07AA0027E7E2 /* FunctionAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionAttributes.swift; sourceTree = "<group>"; };
+		C926E4DF294F18C50027E7E2 /* FunctionAttributeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionAttributeTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -176,6 +180,7 @@
 				22C0625228CE699D007A6F67 /* Callbacks.swift */,
 				225908FD28DA0F9F0080C737 /* Result.swift */,
 				22BC4BBB294BA0EC0032B8A8 /* SharedEnumAttributes.swift */,
+				C926E4DD294F07AA0027E7E2 /* FunctionAttributes.swift */,
 			);
 			path = SwiftRustIntegrationTestRunner;
 			sourceTree = "<group>";
@@ -213,6 +218,7 @@
 				22553323281DB5FC008A3121 /* GenericTests.rs.swift */,
 				22EE4E0A28B538A700FEC83C /* SwiftFnUsesOpaqueSwiftTypeTests.swift */,
 				22C0625428CE6C9A007A6F67 /* CallbackTests.swift */,
+				C926E4DF294F18C50027E7E2 /* FunctionAttributeTests.swift */,
 			);
 			path = SwiftRustIntegrationTestRunnerTests;
 			sourceTree = "<group>";
@@ -381,6 +387,7 @@
 				222A81E928EB5BB100D4A412 /* Primitive.swift in Sources */,
 				228FE64627480E1D00805D9E /* SwiftBridgeCore.swift in Sources */,
 				228FE5D52740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift in Sources */,
+				C926E4DE294F07AA0027E7E2 /* FunctionAttributes.swift in Sources */,
 				228FE64A274919C600805D9E /* swift-integration-tests.swift in Sources */,
 				22C0625328CE699D007A6F67 /* Callbacks.swift in Sources */,
 				22BC10F82799A3A000A0D046 /* SharedStructAttributes.swift in Sources */,
@@ -396,6 +403,7 @@
 				22043293274A8FDF00BAE645 /* VecTests.swift in Sources */,
 				221E16B62786F9FF00F94AC0 /* OpaqueTypeAttributeTests.swift in Sources */,
 				220432A7274C953E00BAE645 /* PointerTests.swift in Sources */,
+				C926E4E0294F18C50027E7E2 /* FunctionAttributeTests.swift in Sources */,
 				220432AF274E7BF800BAE645 /* SharedStructTests.swift in Sources */,
 				220432EC27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift in Sources */,
 				222A81EB28EB5DF800D4A412 /* PrimitiveTests.swift in Sources */,

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/FunctionAttributes.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/FunctionAttributes.swift
@@ -1,0 +1,12 @@
+//
+//  FunctionAttributes.swift
+//  SwiftRustIntegrationTestRunner
+//
+//  Created by Erik Živković on 2022-12-17.
+//
+
+import Foundation
+
+func testCallSwiftFromRustByNameAttribute() -> RustString {
+    return "StringFromSwift".intoRustString()
+}

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/FunctionAttributeTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/FunctionAttributeTests.swift
@@ -1,0 +1,27 @@
+//
+// FunctionAttributeIdentifiableTests.swift
+// SwiftRustIntegrationTestRunnerTests
+//
+// Created by Erik Živković on 2022-12-17.
+//
+
+import Foundation
+
+import XCTest
+@testable import SwiftRustIntegrationTestRunner
+
+/// Tests the #[swift_bridge(swift_name = "x")] attribute.
+class FunctionAttributeTests: XCTestCase {
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    /// Verify that the `swift_bridge(swift_name = "x")` attribute works.
+    func testSwiftNameAttribute() throws {
+        XCTAssertEqual(testCallRustFromSwiftByNameAttribute().toString(), "StringFromRust")
+    }
+}

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/generate_function_swift_calls_rust.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/generate_function_swift_calls_rust.rs
@@ -59,7 +59,11 @@ pub(super) fn gen_func_swift_calls_rust(
             "public convenience init".to_string()
         }
     } else {
-        format!("public func {}", fn_name.as_str())
+        if let Some(swift_name) = &function.swift_name_override {
+            format!("public func {}", swift_name.value())
+        } else {
+            format!("public func {}", fn_name.as_str())
+        }
     };
 
     let indentation = if function.associated_type.is_some() {

--- a/crates/swift-integration-tests/src/function_attributes.rs
+++ b/crates/swift-integration-tests/src/function_attributes.rs
@@ -5,3 +5,4 @@ mod identifiable;
 mod return_into;
 mod return_with;
 mod rust_name;
+mod swift_name;

--- a/crates/swift-integration-tests/src/function_attributes/swift_name.rs
+++ b/crates/swift-integration-tests/src/function_attributes/swift_name.rs
@@ -1,0 +1,24 @@
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Swift" {
+        // If this compiles then we're successfully using the `rust_name` during code generation.
+        #[swift_bridge(swift_name = "testCallSwiftFromRustByNameAttribute")]
+        fn test_call_swift_from_rust_by_name_attribute() -> String;
+    }
+
+    extern "Rust" {
+        #[swift_bridge(swift_name = "testCallRustFromSwiftByNameAttribute")]
+        pub fn test_call_rust_from_swift_by_name_attribute() -> String;
+    }
+}
+
+/// The test on the Swift side will call this function, which in turn will reach into
+/// Rust, then the Rust code will call into Swift, and we assert that we got the correct
+/// string back from Swift, before returning another string back to Swift.
+fn test_call_rust_from_swift_by_name_attribute() -> String {
+    assert_eq!(
+        ffi::test_call_swift_from_rust_by_name_attribute(),
+        "StringFromSwift"
+    );
+    "StringFromRust".to_string()
+}


### PR DESCRIPTION
This commit adds support for the already existing swift_name attribute for the extern "Rust" side. This means that the following code on the Rust side:

```rust
extern "Rust" {
    #[swift_bridge(swift_name = "testCallRustFromSwiftByNameAttribute")]
    pub fn test_call_rust_from_swift_by_name_attribute() -> String;
}
```

Can be called with the following code on the Swift side:

```swift
func someFunc() {
    let stringFromRust = testCallRustFromSwiftByNameAttribute()
}
```

Solves #122 