### PR TITLE
Fix README.md in swiftc-and-cargo

### DIFF
--- a/book/src/building/swiftc-and-cargo/README.md
+++ b/book/src/building/swiftc-and-cargo/README.md
@@ -60,6 +60,10 @@ run()
 
 ```swift
 // lib.swift
+func print_hello_swift() {
+    print("Hello from Swift")
+}
+
 func run() {
     print_hello_rust()
 }
@@ -124,6 +128,7 @@ swiftc -L target/x86_64-apple-darwin/debug/ -lswift_and_rust -import-objc-header
 ```
 
 ```sh
+chmod +x build-swiftc-links-rust.sh
 ./build-swiftc-links-rust.sh
 ./main
 # The output should be "Hello from Rust"


### PR DESCRIPTION
When I tried to build a project following swiftc+Cargo page of the book, I got the following error.
```
generated/swift-and-rust/swift-and-rust.swift:6:5: error: cannot find 'print_hello_swift' in scope
print_hello_swift()
^~~~~~~~~~~~~~~~~
```
To resolve the above error, I implemented a ```print_hello_swift``` function.

In addition,  I added a procedure to change the permissions of build-swiftc-links-rust.sh.
