### PR TITLE
Support Hashable

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OpaqueRustStructTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OpaqueRustStructTests.swift
@@ -89,5 +89,46 @@ class OpaqueRustStructTests: XCTestCase {
             XCTAssertNotEqual(val1, val2)
         }
     }
+
+    func testOpaqueRustTypeImplHashable() throws {
+        XCTContext.runActivity(named: "Same hash value"){
+            _ in
+            let val1 = RustHashableType(10)
+            let val2 = RustHashableType(10)
+
+            var table: [RustHashableType: String] = [:]
+            table[val1] = "hello"
+            table[val2] = "world"
+
+            //Should be overwritten.
+            if let element = table[val1] {
+                XCTAssertEqual(element, "world")
+            }else {
+                XCTFail()
+            }
+        }
+
+        XCTContext.runActivity(named: "Not same hash value"){
+            _ in
+            let val1 = RustHashableType(10)
+            let val2 = RustHashableType(100)
+
+            var table: [RustHashableType: String] = [:]
+            table[val1] = "hello"
+            table[val2] = "world"
+
+            //Should not be overwritten
+            if let element = table[val1] {
+                XCTAssertEqual(element, "hello")
+            }else {
+                XCTFail()
+            }
+            if let element = table[val2] {
+                XCTAssertEqual(element, "world")
+            }else {
+                XCTFail()
+            }
+        }
+    }
 }
 

--- a/book/src/bridge-module/opaque-types/README.md
+++ b/book/src/bridge-module/opaque-types/README.md
@@ -213,27 +213,19 @@ mod ffi {
     extern "Rust" {
         #[swift_bridge(Equatable)]
         type RustPartialEqType;
-
-        #[swift_bridge(init)]
-        fn new(num: u32) -> RustEquatableType;
     }
 }
 
 #[derive(PartialEq)]
-struct RustPartialEqType(u32);
+struct RustPartialEqType;
 
-impl RustPartialEqType {
-    fn new(num: u32) {
-        Self(num) 
-    }
-}
 ```
 
 ```swift
 // In Swift
 
-let val1 = RustPartialEqType(5)
-let val2 = RustPartialEqType(10)
+let val1 = RustPartialEqType()
+let val2 = RustPartialEqType()
 
 if val1 == val2 {
     print("Equal")
@@ -244,7 +236,7 @@ if val1 == val2 {
 
 #### #[swift_bridge(Hashable)]
 
-The `Hashable` attribute allows you to expose a Rust `Hash` trait via Swift's
+The `Hashable` attribute allows you to expose Rust's `Hash` trait via Swift's
 `Hashable` protocol.
 
 ```rust
@@ -253,26 +245,17 @@ mod ffi {
     extern "Rust" {
         #[swift_bridge(Hashable)]
         type RustHashType;
-
-        #[swift_bridge(init)]
-        fn new(num: u32) -> RustHashType;
     }
 }
 
 #[derive(Hash, PartialEq)]
-struct RustHashType(u32);
-
-impl RustHashType {
-    fn new(num: u32) {
-        Self(num) 
-    }
-}
+struct RustHashType;
 ```
 
 ```swift
 // In Swift
 
-let val = RustHashType(10)
+let val = RustHashType()
 
 let table: [RustHashType: String] = [:]
 

--- a/book/src/bridge-module/opaque-types/README.md
+++ b/book/src/bridge-module/opaque-types/README.md
@@ -236,7 +236,7 @@ if val1 == val2 {
 
 #### #[swift_bridge(Hashable)]
 
-The `Hashable` attribute allows you to expose Rust's `Hash` trait via Swift's
+The `Hashable` attribute allows you to expose a Rust `Hash` trait implementation via Swift's
 `Hashable` protocol.
 
 ```rust

--- a/book/src/bridge-module/opaque-types/README.md
+++ b/book/src/bridge-module/opaque-types/README.md
@@ -241,3 +241,44 @@ if val1 == val2 {
     print("Not equal")
 }
 ```
+
+#### #[swift_bridge(Hashable)]
+
+The `Hashable` attribute allows you to expose a Rust `Hash` trait via Swift's
+`Hashable` protocol.
+
+```rust
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        #[swift_bridge(Hashable)]
+        type RustHashType;
+
+        #[swift_bridge(init)]
+        fn new(num: u32) -> RustHashType;
+    }
+}
+
+#[derive(Hash, PartialEq)]
+struct RustHashType(u32);
+
+impl RustHashType {
+    fn new(num: u32) {
+        Self(num) 
+    }
+}
+```
+
+```swift
+// In Swift
+
+let val = RustHashType(10)
+
+let table: [RustHashType: String] = [:]
+
+table[val] = "hello"
+table[val] = "world"
+
+//Should print "world"
+print(table[val])
+```

--- a/book/src/bridge-module/opaque-types/README.md
+++ b/book/src/bridge-module/opaque-types/README.md
@@ -217,15 +217,15 @@ mod ffi {
 }
 
 #[derive(PartialEq)]
-struct RustPartialEqType;
+struct RustPartialEqType(u32);
 
 ```
 
 ```swift
 // In Swift
 
-let val1 = RustPartialEqType()
-let val2 = RustPartialEqType()
+let val1 = RustPartialEqType(5)
+let val2 = RustPartialEqType(10)
 
 if val1 == val2 {
     print("Equal")
@@ -249,13 +249,13 @@ mod ffi {
 }
 
 #[derive(Hash, PartialEq)]
-struct RustHashType;
+struct RustHashType(u32);
 ```
 
 ```swift
 // In Swift
 
-let val = RustHashType()
+let val = RustHashType(10);
 
 let table: [RustHashType: String] = [:]
 

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_rust_type_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_rust_type_codegen_tests.rs
@@ -98,13 +98,13 @@ mod extern_rust_hashable_type {
 
     fn expected_rust_tokens() -> ExpectedRustTokens {
         ExpectedRustTokens::Contains(quote! {
-        use std::hash::Hash;
-        use std::hash::Hasher;
-        use std::collections::hash_map::DefaultHasher;
         #[export_name = "__swift_bridge__$HashableType$_hash"]
         pub extern "C" fn __swift_bridge__HashableType__hash (
             this: *const super::HashableType,
         ) -> u64 {
+            use std::hash::Hash;
+            use std::hash::Hasher;
+            use std::collections::hash_map::DefaultHasher;
             let mut s = DefaultHasher::new();
             (unsafe {&*this}).hash(&mut s);
             s.finish()

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_rust_type_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_rust_type_codegen_tests.rs
@@ -102,8 +102,7 @@ mod extern_rust_hashable_type {
         pub extern "C" fn __swift_bridge__HashableType__hash (
             this: *const super::HashableType,
         ) -> u64 {
-            use std::hash::Hash;
-            use std::hash::Hasher;
+            use std::hash::{Hash, Hasher};
             use std::collections::hash_map::DefaultHasher;
             let mut s = DefaultHasher::new();
             (unsafe {&*this}).hash(&mut s);

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -177,6 +177,12 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                     if ty.attributes.declare_generic {
                         continue;
                     }
+                    if ty.attributes.hashable {
+                        let ty_name = ty.ty_name_ident();
+                        let hash_ty =
+                            format!("uint64_t __swift_bridge__${}$_hash(void* self);", ty_name);
+                        header += &hash_ty;
+                    }
                     if ty.attributes.equatable {
                         let ty_name = ty.ty_name_ident();
                         let equal_ty = format!(

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
@@ -93,6 +93,27 @@ impl ToTokens for SwiftBridgeModule {
 
                     match ty.host_lang {
                         HostLang::Rust => {
+                            if ty.attributes.hashable {
+                                let export_name = format!("__swift_bridge__${}$_hash", ty_name);
+                                let function_name = syn::Ident::new(
+                                    &format!("__swift_bridge__{}__hash", ty_name),
+                                    ty.ty.span(),
+                                );
+                                let tokens = quote! {
+                                use std::hash::Hash;
+                                use std::hash::Hasher;
+                                use std::collections::hash_map::DefaultHasher;
+                                #[export_name = #export_name]
+                                pub extern "C" fn #function_name (
+                                    this: *const super::#ty_name,
+                                ) -> u64 {
+                                    let mut s = DefaultHasher::new();
+                                    (unsafe {&*this}).hash(&mut s);
+                                    s.finish()
+                                }
+                                };
+                                extern_rust_fn_tokens.push(tokens);
+                            }
                             if ty.attributes.equatable {
                                 let export_name =
                                     format!("__swift_bridge__${}$_partial_eq", ty_name);

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
@@ -100,13 +100,12 @@ impl ToTokens for SwiftBridgeModule {
                                     ty.ty.span(),
                                 );
                                 let tokens = quote! {
-                                use std::hash::Hash;
-                                use std::hash::Hasher;
-                                use std::collections::hash_map::DefaultHasher;
                                 #[export_name = #export_name]
                                 pub extern "C" fn #function_name (
                                     this: *const super::#ty_name,
                                 ) -> u64 {
+                                    use std::hash::{Hash, Hasher};
+                                    use std::collections::hash_map::DefaultHasher;
                                     let mut s = DefaultHasher::new();
                                     (unsafe {&*this}).hash(&mut s);
                                     s.finish()

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/swift_class.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/swift_class.rs
@@ -213,9 +213,25 @@ extension {ty_name}Ref: Equatable {{
             "".to_string()
         }
     };
+    let hashable_method: String = {
+        if ty.attributes.hashable {
+            let ty_name = ty.ty_name_ident();
+            format!(
+                r#"
+extension {ty_name}Ref: Hashable{{
+    public func hash(into hasher: inout Hasher){{
+        hasher.combine(__swift_bridge__${ty_name}$_hash(self.ptr))
+    }}
+}}
+"#,
+            )
+        } else {
+            "".to_string()
+        }
+    };
     let class = format!(
         r#"
-{class_decl}{initializers}{owned_instance_methods}{class_ref_decl}{ref_mut_instance_methods}{class_ref_mut_decl}{ref_instance_methods}{generic_freer}{equatable_method}"#,
+{class_decl}{initializers}{owned_instance_methods}{class_ref_decl}{ref_mut_instance_methods}{class_ref_mut_decl}{ref_instance_methods}{generic_freer}{equatable_method}{hashable_method}"#,
         class_decl = class_decl,
         class_ref_decl = class_ref_mut_decl,
         class_ref_mut_decl = class_ref_decl,
@@ -223,7 +239,8 @@ extension {ty_name}Ref: Equatable {{
         owned_instance_methods = owned_instance_methods,
         ref_mut_instance_methods = ref_mut_instance_methods,
         ref_instance_methods = ref_instance_methods,
-        equatable_method = equatable_method
+        equatable_method = equatable_method,
+        hashable_method = hashable_method,
     );
 
     return class;

--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod.rs
@@ -345,7 +345,7 @@ mod tests {
     use crate::test_utils::{parse_errors, parse_ok};
     use crate::SwiftBridgeModule;
     use quote::{quote, ToTokens};
-    use syn::parse_quote;
+    use syn::{parse_quote, token};
 
     /// Verify that we can parse a SwiftBridgeModule from an empty module.
     #[test]
@@ -736,6 +736,32 @@ mod tests {
                 .unwrap_opaque()
                 .attributes
                 .already_declared
+        );
+    }
+
+    //Verify that we can parse the `hashable` attribute.
+    #[test]
+    fn parse_hashable_attribute() {
+        let tokens = quote! {
+            mod foo {
+                extern "Rust" {
+                    #[swift_bridge(Hashable)]
+                    type SomeType;
+                }
+            }
+        };
+
+        let module = parse_ok(tokens);
+
+        assert_eq!(
+            module
+                .types
+                .get("SomeType")
+                .unwrap()
+                .unwrap_opaque()
+                .attributes
+                .hashable,
+            true
         );
     }
 

--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod.rs
@@ -345,7 +345,7 @@ mod tests {
     use crate::test_utils::{parse_errors, parse_ok};
     use crate::SwiftBridgeModule;
     use quote::{quote, ToTokens};
-    use syn::{parse_quote};
+    use syn::parse_quote;
 
     /// Verify that we can parse a SwiftBridgeModule from an empty module.
     #[test]

--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod.rs
@@ -345,7 +345,7 @@ mod tests {
     use crate::test_utils::{parse_errors, parse_ok};
     use crate::SwiftBridgeModule;
     use quote::{quote, ToTokens};
-    use syn::{parse_quote, token};
+    use syn::{parse_quote};
 
     /// Verify that we can parse a SwiftBridgeModule from an empty module.
     #[test]

--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod/opaque_type_attributes.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod/opaque_type_attributes.rs
@@ -29,6 +29,9 @@ pub(crate) struct OpaqueTypeSwiftBridgeAttributes {
     /// `#[swift_bridge(Equatable)]`
     /// Used to determine if Equatable need to be implemented.
     pub equatable: bool,
+    /// `#[swift_bridge(Hashable)]`
+    /// Used to determine if Hashable need to be implemented.
+    pub hashable: bool,
 }
 
 impl OpaqueTypeAllAttributes {
@@ -73,6 +76,7 @@ impl OpaqueTypeSwiftBridgeAttributes {
             OpaqueTypeAttr::Copy { size } => self.copy = Some(OpaqueCopy { size_bytes: size }),
             OpaqueTypeAttr::DeclareGeneric => self.declare_generic = true,
             OpaqueTypeAttr::Equatable => self.equatable = true,
+            OpaqueTypeAttr::Hashable => self.hashable = true,
         }
     }
 }
@@ -82,6 +86,7 @@ pub(crate) enum OpaqueTypeAttr {
     Copy { size: usize },
     DeclareGeneric,
     Equatable,
+    Hashable,
 }
 
 impl Parse for OpaqueTypeSwiftBridgeAttributes {
@@ -118,6 +123,7 @@ impl Parse for OpaqueTypeAttr {
             }
             "declare_generic" => OpaqueTypeAttr::DeclareGeneric,
             "Equatable" => OpaqueTypeAttr::Equatable,
+            "Hashable" => OpaqueTypeAttr::Hashable,
             _ => {
                 let attrib = key.to_string();
                 Err(syn::Error::new_spanned(

--- a/crates/swift-integration-tests/src/opaque_type_attributes.rs
+++ b/crates/swift-integration-tests/src/opaque_type_attributes.rs
@@ -1,3 +1,4 @@
 mod already_declared;
 mod copy;
 mod equatable;
+mod hashable;

--- a/crates/swift-integration-tests/src/opaque_type_attributes/hashable.rs
+++ b/crates/swift-integration-tests/src/opaque_type_attributes/hashable.rs
@@ -1,0 +1,19 @@
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        #[swift_bridge(Hashable, Equatable)]
+        type RustHashableType;
+
+        #[swift_bridge(init)]
+        fn new(num: isize) -> RustHashableType;
+    }
+}
+
+#[derive(Hash, PartialEq)]
+pub struct RustHashableType(isize);
+
+impl RustHashableType {
+    fn new(num: isize) -> Self {
+        RustHashableType(num)
+    }
+}


### PR DESCRIPTION
This PR addresses #77 and introduces the #[swift_bridge(Hashable)] attribute, which is used to generate a type that conforms to ```Hashable``` protocol.

Somthing like: 
```rust
// Rust 
mod ffi {
    extern "Rust" {
        #[swift_bridge(Hashable)]
        type SomeType;
    }
}
```

```Swift
// Generated Swift
class SomeType {
    // ...
}

// SomeType inherits SomeTypeRef. So, SomeType also conforms to Hashable protocol.
extension SomeTypeRef: Hashable {
    public func hash(into hasher: inout Hasher) {
        hasher.combine(__swift_bridge__$SomeType$_hash(rhs.ptr))
    }
}
```