### PR TITLE
Add UI test for missing argument in args_into

### DIFF
--- a/crates/swift-bridge-ir/src/errors/parse_error.rs
+++ b/crates/swift-bridge-ir/src/errors/parse_error.rs
@@ -75,12 +75,9 @@ impl Into<syn::Error> for ParseError {
             ParseError::ArgsIntoArgNotFound { func, missing_arg } => Error::new_spanned(
                 missing_arg.clone(),
                 format!(
-                    r#"{}: Unknown argument
-Could not find "{}" in "{}".
-"#,
+                    r#"Argument "{}" was not found in the "fn {}(..)""#,
                     missing_arg,
-                    missing_arg,
-                    func.sig.to_token_stream().to_string()
+                    func.sig.ident.to_token_stream().to_string()
                 ),
             ),
             ParseError::AbiNameMissing {

--- a/crates/swift-bridge-ir/src/errors/parse_error.rs
+++ b/crates/swift-bridge-ir/src/errors/parse_error.rs
@@ -1,10 +1,14 @@
 use proc_macro2::Ident;
 use quote::ToTokens;
 use syn::{Error, FnArg, Item, Receiver};
-use syn::{ForeignItemType, LitStr};
+use syn::{ForeignItemFn, ForeignItemType, LitStr};
 use syn::{Token, Type};
 
 pub(crate) enum ParseError {
+    ArgsIntoArgNotFound {
+        func: ForeignItemFn,
+        missing_arg: Ident,
+    },
     /// `extern {}`
     AbiNameMissing {
         /// `extern {}`
@@ -68,6 +72,17 @@ pub(crate) enum IdentifiableParseError {
 impl Into<syn::Error> for ParseError {
     fn into(self) -> Error {
         match self {
+            ParseError::ArgsIntoArgNotFound { func, missing_arg } => Error::new_spanned(
+                missing_arg.clone(),
+                format!(
+                    r#"{}: Unknown argument
+Could not find "{}" in "{}".
+"#,
+                    missing_arg,
+                    missing_arg,
+                    func.sig.to_token_stream().to_string()
+                ),
+            ),
             ParseError::AbiNameMissing {
                 extern_token: extern_ident,
             } => Error::new_spanned(

--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod.rs
@@ -905,7 +905,7 @@ mod tests {
 
         let errors = parse_errors(tokens);
 
-        /// Only "bar" should be missing argument.
+        // Only "bar" should be missing argument.
         assert_eq!(errors.len(), 1);
     }
 

--- a/crates/swift-bridge-macro/tests/ui/args-into-argument-not-found.rs
+++ b/crates/swift-bridge-macro/tests/ui/args-into-argument-not-found.rs
@@ -1,0 +1,18 @@
+//! # To Run
+//! cargo test -p swift-bridge-macro -- ui trybuild=args-into-argument-not-found.rs
+
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        #[swift_bridge(args_into = (arg, arg_typo))]
+        fn some_function(arg: u8);
+    }
+}
+
+fn some_function(arg: u8){
+
+}
+
+fn main() {
+
+}

--- a/crates/swift-bridge-macro/tests/ui/args-into-argument-not-found.rs
+++ b/crates/swift-bridge-macro/tests/ui/args-into-argument-not-found.rs
@@ -7,10 +7,24 @@ mod ffi {
         #[swift_bridge(args_into = (arg, arg_typo))]
         fn some_function(arg: u8);
     }
+    extern "Rust" {
+        type SomeType;
+    
+        #[swift_bridge(args_into = (foo, bar))]
+        fn some_method(&self, foo: u8);
+    }
 }
 
 fn some_function(arg: u8){
 
+}
+
+struct SomeType;
+
+impl SomeType {
+    fn some_method(&self, foo: u8){
+
+    }
 }
 
 fn main() {

--- a/crates/swift-bridge-macro/tests/ui/args-into-argument-not-found.stderr
+++ b/crates/swift-bridge-macro/tests/ui/args-into-argument-not-found.stderr
@@ -1,6 +1,11 @@
-error: arg_typo: Unknown argument
-       Could not find "arg_typo" in "fn some_function(arg : u8)".
+error: Argument "arg_typo" was not found in the "fn some_function(..)"
  --> tests/ui/args-into-argument-not-found.rs:7:42
   |
 7 |         #[swift_bridge(args_into = (arg, arg_typo))]
   |                                          ^^^^^^^^
+
+error: Argument "bar" was not found in the "fn some_method(..)"
+  --> tests/ui/args-into-argument-not-found.rs:13:42
+   |
+13 |         #[swift_bridge(args_into = (foo, bar))]
+   |                                          ^^^

--- a/crates/swift-bridge-macro/tests/ui/args-into-argument-not-found.stderr
+++ b/crates/swift-bridge-macro/tests/ui/args-into-argument-not-found.stderr
@@ -1,0 +1,6 @@
+error: arg_typo: Unknown argument
+       Could not find "arg_typo" in "fn some_function(arg : u8)".
+ --> tests/ui/args-into-argument-not-found.rs:7:42
+  |
+7 |         #[swift_bridge(args_into = (arg, arg_typo))]
+  |                                          ^^^^^^^^


### PR DESCRIPTION
This PR addresses #11 and Introduces a compile error when using missing argument in `args_into`.

Here's an example:
```rust
#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        #[swift_bridge(args_into = (arg, arg_typo))]
        fn some_function(arg: u8);
    }
}
```

```
error: arg_typo: Unknown argument
       Could not find "arg_typo" in "fn some_function(arg : u8)".
 --> tests/ui/args-into-argument-not-found.rs:7:42
  |
7 |         #[swift_bridge(args_into = (arg, arg_typo))]
  |                                          ^^^^^^^^

```