### PR TITLE
Return Result<OpaqueRust, OpaqueRust>

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Result.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Result.swift
@@ -22,3 +22,6 @@ public class ResultTestOpaqueSwiftType {
         self.num
     }
 }
+
+extension ResultTestOpaqueRustType: @unchecked Sendable {}
+extension ResultTestOpaqueRustType: Error {}

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
@@ -16,12 +16,19 @@ class ResultTests: XCTestCase {
     
     /// Verify that we can pass a Result<OpaqueRust, OpaqueRust> from Swift -> Rust
     func testSwiftCallRustResultOpaqueRust() throws {
-        rust_func_takes_result_opaque_rust(
+        let reflectedOk = try! rust_func_reflect_result_opaque_rust(
             .Ok(ResultTestOpaqueRustType(111))
         )
-        rust_func_takes_result_opaque_rust(
-            .Err(ResultTestOpaqueRustType(222))
-        )
+        XCTAssertEqual(reflectedOk.val(), 111)
+        
+        do {
+            let _ = try rust_func_reflect_result_opaque_rust(
+                .Err(ResultTestOpaqueRustType(222))
+            )
+            fatalError("The function should have returned an error.")
+        } catch let error as ResultTestOpaqueRustType {
+            XCTAssertEqual(error.val(), 222)
+        }
     }
     
     /// Verify that we can pass a Result<OpaqueSwift, OpaqueSwift> from Swift -> Rust

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
@@ -12,6 +12,10 @@ impl BridgeableType for BridgedString {
         true
     }
 
+    fn is_result(&self) -> bool {
+        false
+    }
+
     fn to_rust_type_path(&self) -> TokenStream {
         // FIXME: Change to `::std::string::String`
         quote! { String }

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
@@ -22,6 +22,10 @@ impl BridgeableType for OpaqueForeignType {
         false
     }
 
+    fn is_result(&self) -> bool {
+        false
+    }
+
     fn to_rust_type_path(&self) -> TokenStream {
         let ty_name = &self.ty;
 

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_swift_func.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_swift_func.rs
@@ -1,4 +1,4 @@
-use crate::bridged_type::{pat_type_pat_is_self, BridgedType, TypePosition};
+use crate::bridged_type::{pat_type_pat_is_self, BridgeableType, BridgedType, TypePosition};
 use crate::parse::TypeDeclarations;
 use crate::parsed_extern_fn::ParsedExternFn;
 use quote::ToTokens;
@@ -126,8 +126,11 @@ impl ParsedExternFn {
             ReturnType::Default => "".to_string(),
             ReturnType::Type(_, ty) => {
                 if let Some(built_in) = BridgedType::new_with_type(&ty, types) {
+                    let maybe_throws = if built_in.is_result() { "throws " } else { "" };
+
                     format!(
-                        " -> {}",
+                        " {}-> {}",
+                        maybe_throws,
                         built_in.to_swift_type(TypePosition::FnReturn(self.host_lang,), types)
                     )
                 } else {

--- a/crates/swift-integration-tests/src/result.rs
+++ b/crates/swift-integration-tests/src/result.rs
@@ -3,13 +3,15 @@
 #[swift_bridge::bridge]
 mod ffi {
     extern "Rust" {
-        fn rust_func_takes_result_string(arg: Result<String, String>);
-        fn rust_func_takes_result_opaque_rust(
+        fn rust_func_reflect_result_opaque_rust(
             arg: Result<ResultTestOpaqueRustType, ResultTestOpaqueRustType>,
-        );
+        ) -> Result<ResultTestOpaqueRustType, ResultTestOpaqueRustType>;
+
+        fn rust_func_takes_result_string(arg: Result<String, String>);
         fn rust_func_takes_result_opaque_swift(
             arg: Result<ResultTestOpaqueSwiftType, ResultTestOpaqueSwiftType>,
         );
+
     }
 
     extern "Rust" {
@@ -17,6 +19,7 @@ mod ffi {
 
         #[swift_bridge(init)]
         fn new(val: u32) -> ResultTestOpaqueRustType;
+        fn val(&self) -> u32;
     }
 
     extern "Swift" {
@@ -37,15 +40,17 @@ fn rust_func_takes_result_string(arg: Result<String, String>) {
     }
 }
 
-fn rust_func_takes_result_opaque_rust(
+fn rust_func_reflect_result_opaque_rust(
     arg: Result<ResultTestOpaqueRustType, ResultTestOpaqueRustType>,
-) {
+) -> Result<ResultTestOpaqueRustType, ResultTestOpaqueRustType> {
     match arg {
         Ok(ok) => {
-            assert_eq!(ok.val, 111)
+            assert_eq!(ok.val, 111);
+            Ok(ok)
         }
         Err(err) => {
-            assert_eq!(err.val, 222)
+            assert_eq!(err.val, 222);
+            Err(err)
         }
     }
 }
@@ -69,5 +74,9 @@ pub struct ResultTestOpaqueRustType {
 impl ResultTestOpaqueRustType {
     fn new(val: u32) -> Self {
         Self { val }
+    }
+
+    fn val(&self) -> u32 {
+        self.val
     }
 }


### PR DESCRIPTION
This commit makes it possible to return a
`Result<OpaqueRust, OpaqueRust>` from a Rust function.

Rust functions that return results show up on the Swift side as
functions that `throw`.

For example, the following is now possible:

```rust
// Rust

#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        type TypeA;
        type TypeB;

        fn some_function() -> Result<TypeA, TypeB>;

        fn print_info(self: &TypeB);
    }
}
```

```swift
// Swift

do {
    let typeA = try some_function()
} catch let typeB as TypeB {
    typeB.print_info()
}
```
