### PR TITLE
trivial: Replace `fatalError()` with `XCTFail()`

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
@@ -198,7 +198,7 @@ class OptionTests: XCTestCase {
         case .Variant2:
             break;
         default:
-            fatalError()
+            XCTFail()
         }
         
         XCTAssertNil(reflectedNone)

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
@@ -25,7 +25,7 @@ class ResultTests: XCTestCase {
             let _ = try rust_func_reflect_result_opaque_rust(
                 .Err(ResultTestOpaqueRustType(222))
             )
-            fatalError("The function should have returned an error.")
+            XCTFail("The function should have returned an error.")
         } catch let error as ResultTestOpaqueRustType {
             XCTAssertEqual(error.val(), 222)
         }

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
@@ -28,7 +28,7 @@ class SharedEnumTests: XCTestCase {
         case (.Variant1, .Variant2):
             break;
         default:
-            fatalError()
+            XCTFail()
         }
     }
 }


### PR DESCRIPTION
This PR replaces `fatalError()` with `XCTFail()` in unit tests for Swift.

Very trivial.