### PR TITLE
Improve memory safety documentation

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -15,7 +15,6 @@
   - [Transparent Types](./bridge-module/transparent-types/README.md)
     - [Transparent Structs](./bridge-module/transparent-types/structs/README.md)
     - [Transparent Enums](./bridge-module/transparent-types/enums/README.md)
-  - [Async Functions](./bridge-module/async-functions/README.md)
   - [Generics](./bridge-module/generics/README.md)
   - [Conditional Compilation](./bridge-module/conditional-compilation/README.md)
 

--- a/book/src/safety/README.md
+++ b/book/src/safety/README.md
@@ -4,18 +4,24 @@
 
 ## Type Safety
 
-The code that `swift-bridge` is type safe on both the Rust and Swift side,
-so all of your interfacing between the two languages is type safe.
+All of the Rust and Swift FFI code that `swift-bridge` generates
+for you is type safe.
 
 ## Memory Safety
 
-Needing to worry about memory safety should be very uncommon when using `swift-bridge`.
+You can ensure the memory safety of your Rust and Swift projects by following these rules:
 
-There are two known situations that can lead to unsafe memory access.
+- In Swift, never use a reference to a Rust type after its lifetime.
 
-#### Lifetimes
+- In Swift, pass a mutable reference to Rust that will live alongside another active reference to that type.
 
-It's possible to pass a reference from `Rust` -> `Swift` and then have `Swift` make use of that
+- In Swift, never use a type after passing ownership to Rust.
+
+Let's look at some examples of code that violates these rules:
+
+### Never use a reference after its lifetime
+
+It is possible to pass a reference from `Rust` -> `Swift` and then have `Swift` make use of that
 reference after it is no longer safe to do so.
 
 ```rust
@@ -34,6 +40,8 @@ mod ffi {
 ```
 
 ```swift
+// Swift
+
 let someType = SomeType()
 
 let name: RustStr = someType.name()
@@ -43,14 +51,78 @@ someType.drop()
 name.toString()
 ```
 
-It isn't possible for `swift-bridge` to mitigate this, so you just have to be careful with references.
+It isn't possible for `swift-bridge` to mitigate this, so be mindful when handling references.
 
-#### Using an owned value after free
+### Never pass a mutable reference to Rust that will live alongside another active reference
 
-Today, it is possible to pass ownership of a value from `Swift` to `Rust` and then
-try to use the value from `Swift`.
+Rust expects that if there is mutable reference to a value, no other references to that value are held.
 
-This mean that a user can accidentally trigger undefined behavior.
+This rule is not enforced on the Swift side, making it possible to pass aliasing pointers to Rust
+and trigger undefined behavior.
+
+```rust
+// Rust
+
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        type MyList;
+
+        #[swift_bridge(init)]
+        fn new() -> MyList;
+
+        fn extend(a: &mut self, b: &MyList);
+    }
+}
+```
+
+```swift
+// Swift
+
+let myList = MyList()
+
+// This can cause undefined behavior!
+myList.extend(myList)
+```
+
+---
+
+```rust
+// Rust
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        type MyList;
+
+        fn new() -> MyList;
+
+        fn allegedly_immutable(&self, callback: Box<dyn Fn()>);
+        fn mutate(&mut self);
+    }
+}
+```
+
+```swift
+// Swift
+
+let myList = MyList()
+
+myList.allegedly_immutable({
+    // If the `allegedly_immutable` method calls this
+    // callback we will take a mutable reference to `MyList`
+    // while there is an active immutable reference.
+    // This violates Rust's borrowing rules.
+    myList.mutate()
+})
+```
+
+To stay safe, when passing a mutable reference to a Rust value from Swift to Rust
+do not pass any other references to that same value.
+
+### Never use a value after it is dropped
+
+Today, it is possible to pass ownership of a value from `Swift` to `Rust`
+and then unsafely access the value from `Swift`.
 
 ```rust
 #[swift_bridge::bridge]


### PR DESCRIPTION
This commit adds documentation that explains that it is possible to
trigger undefined behavior by violating Rust's borrowing rules using
Swift.

Related:
- https://github.com/chinedufn/swift-bridge/issues/161
- https://github.com/chinedufn/swift-bridge/issues/162
