### PR TITLE
Support enums with unnamed data

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
@@ -34,7 +34,7 @@ class SharedEnumTests: XCTestCase {
 
     func testEnumWithUnnamedData() {
         let enumWithUnnamedData1 = EnumWithUnnamedData.Variant1(create_string("hello"), 0)
-        switch enumWithUnnamedData1 {
+        switch reflect_enum_with_unnamed_data(enumWithUnnamedData1) {
         case .Variant1(let rustString, let valueUInt32):
             XCTAssertEqual(rustString.toString(), "hello")
             XCTAssertEqual(valueUInt32, 0)
@@ -43,7 +43,7 @@ class SharedEnumTests: XCTestCase {
         }
         
         let enumWithUnnamedData2 = EnumWithUnnamedData.Variant2(1000, 10)
-        switch enumWithUnnamedData2 {
+        switch reflect_enum_with_unnamed_data(enumWithUnnamedData2) {
         case .Variant2(let valueInt32, let valueUInt8):
             XCTAssertEqual(valueInt32, 1000)
             XCTAssertEqual(valueUInt8, 10)
@@ -52,7 +52,7 @@ class SharedEnumTests: XCTestCase {
         }
 
         let enumWithUnnamedData3 = EnumWithUnnamedData.Variant3
-        switch enumWithUnnamedData3 {
+        switch reflect_enum_with_unnamed_data(enumWithUnnamedData3) {
         case .Variant3:
             break
         default:

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
@@ -31,4 +31,33 @@ class SharedEnumTests: XCTestCase {
             XCTFail()
         }
     }
+
+    func testEnumWithUnnamedData() {
+        let enumWithUnnamedData1 = EnumWithUnnamedData.Variant1(create_string("hello"), 0)
+        switch enumWithUnnamedData1 {
+        case .Variant1(let rustString, let valueUInt32):
+            XCTAssertEqual(rustString.toString(), "hello")
+            XCTAssertEqual(valueUInt32, 0)
+        default:
+            XCTFail()
+        }
+        
+        let enumWithUnnamedData2 = EnumWithUnnamedData.Variant2(1000, 10)
+        switch enumWithUnnamedData2 {
+        case .Variant2(let valueInt32, let valueUInt8):
+            XCTAssertEqual(valueInt32, 1000)
+            XCTAssertEqual(valueUInt8, 10)
+        default:
+            XCTFail()
+        }
+
+        let enumWithUnnamedData3 = EnumWithUnnamedData.Variant3
+        switch enumWithUnnamedData3 {
+        case .Variant3:
+            break
+        default:
+            XCTFail()
+        }
+
+    }
 }

--- a/crates/swift-bridge-ir/src/bridged_type/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_enum.rs
@@ -7,6 +7,8 @@ use syn::LitStr;
 mod enum_variant;
 pub(crate) use self::enum_variant::EnumVariant;
 
+use super::{shared_struct::StructField, StructFields};
+
 #[derive(Clone)]
 pub(crate) struct SharedEnum {
     pub name: Ident,
@@ -53,13 +55,18 @@ impl SharedEnum {
         quote! { #name }
     }
 
+    /// __swift_bridge__$SomeEnumFields
     pub fn ffi_union_name_string(&self) -> String {
         format!("{}Fields", self.ffi_name_string())
     }
 
+    /// { __swift_bridge__$SomeEnum$FieldOfVariant1 Variant1; __swift_bridge__$SomeEnum$FieldOfVariant2 Variant2;}
     pub fn ffi_union_field_names_string(&self) -> String {
         let mut union_fields = "{".to_string();
         for variant in self.variants.iter() {
+            if let StructFields::Unit = variant.fields {
+                continue;
+            }
             let union_field = format!(
                 " {} {};",
                 variant.union_name_string(&self.ffi_name_string()),

--- a/crates/swift-bridge-ir/src/bridged_type/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_enum.rs
@@ -7,7 +7,7 @@ use syn::LitStr;
 mod enum_variant;
 pub(crate) use self::enum_variant::EnumVariant;
 
-use super::{shared_struct::StructField, StructFields};
+use super::StructFields;
 
 #[derive(Clone)]
 pub(crate) struct SharedEnum {

--- a/crates/swift-bridge-ir/src/bridged_type/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_enum.rs
@@ -53,6 +53,24 @@ impl SharedEnum {
         quote! { #name }
     }
 
+    pub fn ffi_union_name_string(&self) -> String {
+        format!("{}Fields", self.ffi_name_string())
+    }
+
+    pub fn ffi_union_field_names_string(&self) -> String {
+        let mut union_fields = "{".to_string();
+        for variant in self.variants.iter() {
+            let union_field = format!(
+                " {} {};",
+                variant.union_name_string(&self.ffi_name_string()),
+                variant.name
+            );
+            union_fields += &union_field;
+        }
+        union_fields += "}";
+        union_fields
+    }
+
     /// __swift_bridge__$Option$SomeEnum
     pub fn ffi_option_name_string(&self) -> String {
         format!(

--- a/crates/swift-bridge-ir/src/bridged_type/shared_enum/enum_variant.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_enum/enum_variant.rs
@@ -1,13 +1,227 @@
-use crate::bridged_type::StructFields;
+use crate::bridged_type::{BridgedType, StructFields, TypePosition};
+use crate::parse::TypeDeclarations;
 use proc_macro2::Ident;
+use proc_macro2::TokenStream;
+use quote::quote;
 use std::fmt::{Debug, Formatter};
+use syn::spanned::Spanned;
+use syn::Path;
 
 #[derive(Clone)]
 pub(crate) struct EnumVariant {
     pub name: Ident,
-    // Will be used in a future commit.
     #[allow(unused)]
     pub fields: StructFields,
+}
+
+impl EnumVariant {
+    pub(crate) fn convert_rust_expression_to_ffi_repr(
+        &self,
+        types: &TypeDeclarations,
+        swift_bridge_path: &Path,
+        enum_name: &Ident,
+        ffi_enum_name: &Ident,
+    ) -> TokenStream {
+        let variant_name = &self.name;
+        let rust_fields: Vec<TokenStream> = self
+            .fields
+            .normalized_fields()
+            .iter()
+            .map(|norm_field| norm_field.to_enum_field(&quote! {value}))
+            .collect();
+        let converted_fields: Vec<TokenStream> = self
+            .fields
+            .normalized_fields()
+            .iter()
+            .map(|norm_field| {
+                let maybe_name_and_colon = norm_field.maybe_name_and_colon();
+                let access_field = norm_field.to_enum_field(&quote! {value});
+                let ty = BridgedType::new_with_type(&norm_field.ty, types).unwrap();
+                let converted_field = ty.convert_rust_expression_to_ffi_type(
+                    &access_field,
+                    swift_bridge_path,
+                    types,
+                    norm_field.ty.span(),
+                );
+
+                quote! {
+                    #maybe_name_and_colon #converted_field
+                }
+            })
+            .collect();
+
+        let rust_fields = self.wrap_fields(&rust_fields);
+        let converted_fields = self.wrap_fields(&converted_fields);
+
+        if self.fields.is_empty() {
+            quote! {
+                #enum_name :: #variant_name => #ffi_enum_name :: #variant_name (123)
+            }
+        } else {
+            quote! {
+                #enum_name :: #variant_name #rust_fields => #ffi_enum_name :: #variant_name #converted_fields
+            }
+        }
+    }
+    pub(crate) fn convert_ffi_repr_to_rust(
+        &self,
+        swift_bridge_path: &Path,
+        types: &TypeDeclarations,
+        enum_name: &Ident,
+        ffi_enum_name: &Ident,
+    ) -> TokenStream {
+        let variant_name = &self.name;
+        let ffi_fields: Vec<TokenStream> = self
+            .fields
+            .normalized_fields()
+            .iter()
+            .map(|norm_field| norm_field.to_enum_field(&quote! {value}))
+            .collect();
+        let converted_fields: Vec<TokenStream> = self
+            .fields
+            .normalized_fields()
+            .iter()
+            .map(|norm_field| {
+                let maybe_name_and_colon = norm_field.maybe_name_and_colon();
+                let access_field = norm_field.to_enum_field(&quote!(value));
+
+                let ty = BridgedType::new_with_type(&norm_field.ty, types).unwrap();
+                let converted_field = ty.convert_ffi_expression_to_rust_type(
+                    &access_field,
+                    norm_field.ty.span(),
+                    swift_bridge_path,
+                    types,
+                );
+
+                quote! {
+                    #maybe_name_and_colon #converted_field
+                }
+            })
+            .collect();
+
+        let ffi_fields = self.wrap_fields(&ffi_fields);
+        let converted_fields = self.wrap_fields(&converted_fields);
+
+        if converted_fields.is_empty() {
+            quote! {
+                #ffi_enum_name :: #variant_name (_) => #enum_name :: #variant_name
+            }
+        } else {
+            quote! {
+                #ffi_enum_name :: #variant_name #ffi_fields => #enum_name :: #variant_name #converted_fields
+            }
+        }
+    }
+    pub(crate) fn convert_ffi_expression_to_swift(
+        &self,
+        types: &TypeDeclarations,
+        enum_name: String,
+    ) -> String {
+        let converted_fields: Vec<String> = self
+            .fields
+            .normalized_fields()
+            .iter()
+            .map(|norm_field| {
+                let field_name = norm_field.ffi_field_name();
+
+                let ty = BridgedType::new_with_type(&norm_field.ty, types).unwrap();
+                ty.convert_ffi_value_to_swift_value(
+                    &format!(
+                        "self.payload.{variant_name}.{field_name}",
+                        variant_name = self.name,
+                        field_name = field_name
+                    ),
+                    TypePosition::SharedStructField,
+                    types,
+                )
+            })
+            .collect();
+        let converted_fields = converted_fields.join(", ");
+
+        if self.fields.is_empty() {
+            format!(
+                "            case __swift_bridge__${enum_name}${variant_name}:
+                return {enum_name}.{variant_name}\n",
+                enum_name = enum_name,
+                variant_name = self.name
+            )
+        } else {
+            format!(
+                "            case __swift_bridge__${enum_name}${variant_name}:
+                return {enum_name}.{variant_name}({converted_fields})\n",
+                enum_name = enum_name,
+                variant_name = self.name,
+                converted_fields = converted_fields
+            )
+        }
+    }
+
+    pub(crate) fn convert_swift_to_ffi_repr(
+        &self,
+        types: &TypeDeclarations,
+        enum_name: String,
+        ffi_enum_name: String,
+    ) -> String {
+        let converted_fields: Vec<String> = self
+            .fields
+            .normalized_fields()
+            .iter()
+            .map(|norm_field| {
+                let field_name = norm_field.ffi_field_name();
+                let ty = BridgedType::new_with_type(&norm_field.ty, types).unwrap();
+                let enum_field = ty.convert_swift_expression_to_ffi_type(
+                    &format!("value{field_name}", field_name = field_name),
+                    TypePosition::SharedStructField,
+                );
+                format!(
+                    "{field_name}: {enum_field}",
+                    field_name = field_name,
+                    enum_field = enum_field
+                )
+            })
+            .collect();
+        let converted_fields = converted_fields.join(", ");
+
+        let associated_values: Vec<String> = self
+            .fields
+            .normalized_fields()
+            .iter()
+            .map(|norm_field| {
+                let ffi_field_name = norm_field.ffi_field_name();
+                format!("let value{ffi_field_name}", ffi_field_name = ffi_field_name)
+            })
+            .collect();
+        let associated_values = associated_values.join(", ");
+
+        if self.fields.is_empty() {
+            format!("            case {enum_name}.{variant_name}:
+                return {ffi_enum_name}(tag: {ffi_enum_name}${variant_name}, payload: {ffi_enum_name}Fields({variant_name}: {ffi_enum_name}$FieldOf{variant_name}(_private: 123)))\n", enum_name = enum_name, variant_name = self.name, ffi_enum_name = ffi_enum_name)
+        } else {
+            format!("            case {enum_name}.{variant_name}({associated_values}):
+                return {ffi_enum_name}(tag: {ffi_enum_name}${variant_name}, payload: {ffi_enum_name}Fields({variant_name}: {ffi_enum_name}$FieldOf{variant_name}({converted_fields})))\n", ffi_enum_name = ffi_enum_name, associated_values = associated_values, enum_name = enum_name, variant_name = self.name, converted_fields = converted_fields)
+        }
+    }
+
+    fn wrap_fields(&self, fields: &[TokenStream]) -> TokenStream {
+        match &self.fields {
+            StructFields::Named(_) => {
+                todo!();
+            }
+            StructFields::Unnamed(_) => {
+                quote! {
+                    ( #(#fields),* )
+                }
+            }
+            StructFields::Unit => {
+                debug_assert_eq!(fields.len(), 0);
+                quote! {}
+            }
+        }
+    }
+
+    pub(crate) fn union_name_string(&self, parent_enum_ffi_name: &String) -> String {
+        format!("{}$FieldOf{}", parent_enum_ffi_name, self.name.to_string())
+    }
 }
 
 impl PartialEq for EnumVariant {

--- a/crates/swift-bridge-ir/src/bridged_type/shared_enum/enum_variant.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_enum/enum_variant.rs
@@ -219,7 +219,6 @@ impl EnumVariant {
                 }
             }
             StructFields::Unit => {
-                debug_assert_eq!(fields.len(), 0);
                 quote! {}
             }
         }

--- a/crates/swift-bridge-ir/src/bridged_type/shared_enum/enum_variant.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_enum/enum_variant.rs
@@ -52,10 +52,10 @@ impl EnumVariant {
 
         let rust_fields = self.wrap_fields(&rust_fields);
         let converted_fields = self.wrap_fields(&converted_fields);
-
+        
         if self.fields.is_empty() {
             quote! {
-                #enum_name :: #variant_name => #ffi_enum_name :: #variant_name (123)
+                #enum_name :: #variant_name => #ffi_enum_name :: #variant_name
             }
         } else {
             quote! {
@@ -104,7 +104,7 @@ impl EnumVariant {
 
         if converted_fields.is_empty() {
             quote! {
-                #ffi_enum_name :: #variant_name (_) => #enum_name :: #variant_name
+                #ffi_enum_name :: #variant_name => #enum_name :: #variant_name
             }
         } else {
             quote! {
@@ -117,6 +117,7 @@ impl EnumVariant {
         types: &TypeDeclarations,
         enum_name: String,
     ) -> String {
+
         let converted_fields: Vec<String> = self
             .fields
             .normalized_fields()
@@ -137,7 +138,7 @@ impl EnumVariant {
             })
             .collect();
         let converted_fields = converted_fields.join(", ");
-
+        
         if self.fields.is_empty() {
             format!(
                 "            case __swift_bridge__${enum_name}${variant_name}:
@@ -161,7 +162,12 @@ impl EnumVariant {
         types: &TypeDeclarations,
         enum_name: String,
         ffi_enum_name: String,
+        is_enum_has_variants_with_no_data: bool,
     ) -> String {
+        if is_enum_has_variants_with_no_data {
+            return format!("            case {enum_name}.{variant_name}:
+                return {ffi_enum_name}(tag: {ffi_enum_name}${variant_name})\n", enum_name = enum_name, variant_name = self.name, ffi_enum_name = ffi_enum_name)
+        }
         let converted_fields: Vec<String> = self
             .fields
             .normalized_fields()
@@ -195,7 +201,7 @@ impl EnumVariant {
 
         if self.fields.is_empty() {
             format!("            case {enum_name}.{variant_name}:
-                return {ffi_enum_name}(tag: {ffi_enum_name}${variant_name}, payload: {ffi_enum_name}Fields({variant_name}: {ffi_enum_name}$FieldOf{variant_name}(_private: 123)))\n", enum_name = enum_name, variant_name = self.name, ffi_enum_name = ffi_enum_name)
+                return {{var val = {ffi_enum_name}(); val.tag = {ffi_enum_name}${variant_name}; return val }}()\n", enum_name = enum_name, variant_name = self.name, ffi_enum_name = ffi_enum_name)
         } else {
             format!("            case {enum_name}.{variant_name}({associated_values}):
                 return {ffi_enum_name}(tag: {ffi_enum_name}${variant_name}, payload: {ffi_enum_name}Fields({variant_name}: {ffi_enum_name}$FieldOf{variant_name}({converted_fields})))\n", ffi_enum_name = ffi_enum_name, associated_values = associated_values, enum_name = enum_name, variant_name = self.name, converted_fields = converted_fields)

--- a/crates/swift-bridge-ir/src/bridged_type/shared_enum/enum_variant.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_enum/enum_variant.rs
@@ -52,7 +52,7 @@ impl EnumVariant {
 
         let rust_fields = self.wrap_fields(&rust_fields);
         let converted_fields = self.wrap_fields(&converted_fields);
-        
+
         if self.fields.is_empty() {
             quote! {
                 #enum_name :: #variant_name => #ffi_enum_name :: #variant_name
@@ -117,7 +117,6 @@ impl EnumVariant {
         types: &TypeDeclarations,
         enum_name: String,
     ) -> String {
-
         let converted_fields: Vec<String> = self
             .fields
             .normalized_fields()
@@ -138,7 +137,7 @@ impl EnumVariant {
             })
             .collect();
         let converted_fields = converted_fields.join(", ");
-        
+
         if self.fields.is_empty() {
             format!(
                 "            case __swift_bridge__${enum_name}${variant_name}:
@@ -165,8 +164,13 @@ impl EnumVariant {
         is_enum_has_variants_with_no_data: bool,
     ) -> String {
         if is_enum_has_variants_with_no_data {
-            return format!("            case {enum_name}.{variant_name}:
-                return {ffi_enum_name}(tag: {ffi_enum_name}${variant_name})\n", enum_name = enum_name, variant_name = self.name, ffi_enum_name = ffi_enum_name)
+            return format!(
+                "            case {enum_name}.{variant_name}:
+                return {ffi_enum_name}(tag: {ffi_enum_name}${variant_name})\n",
+                enum_name = enum_name,
+                variant_name = self.name,
+                ffi_enum_name = ffi_enum_name
+            );
         }
         let converted_fields: Vec<String> = self
             .fields

--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct/struct_field/normalized_field.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct/struct_field/normalized_field.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Ident, TokenStream};
-use quote::quote;
+use quote::{format_ident, quote};
 use std::str::FromStr;
 use syn::Type;
 
@@ -52,6 +52,19 @@ impl NormalizedStructField {
             NormalizedStructFieldAccessor::Unnamed(idx) => {
                 let idx = TokenStream::from_str(&idx.to_string()).unwrap();
                 quote! { #expression.#idx }
+            }
+        }
+    }
+
+    pub fn to_enum_field(&self, expression: &TokenStream) -> TokenStream {
+        match &self.accessor {
+            NormalizedStructFieldAccessor::Named(_) => {
+                todo!()
+            }
+            NormalizedStructFieldAccessor::Unnamed(idx) => {
+                let idx = TokenStream::from_str(&idx.to_string()).unwrap();
+                let expression = format_ident!("{}_{}", expression.to_string(), idx.to_string());
+                quote! { #expression }
             }
         }
     }

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
@@ -30,8 +30,8 @@ mod generates_enum_to_and_from_ffi_conversions_no_data {
             #[repr(C)]
             #[doc(hidden)]
             pub enum __swift_bridge__SomeEnum {
-                Variant1,
-                Variant2
+                Variant1(u8),
+                Variant2(u8)
             }
 
             impl swift_bridge::SharedEnum for SomeEnum {
@@ -43,8 +43,8 @@ mod generates_enum_to_and_from_ffi_conversions_no_data {
                 #[inline(always)]
                 pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
                     match self {
-                        SomeEnum::Variant1 => __swift_bridge__SomeEnum::Variant1,
-                        SomeEnum::Variant2 => __swift_bridge__SomeEnum::Variant2
+                        SomeEnum::Variant1 => __swift_bridge__SomeEnum::Variant1(123),
+                        SomeEnum::Variant2 => __swift_bridge__SomeEnum::Variant2(123)
                     }
                 }
             }
@@ -54,8 +54,8 @@ mod generates_enum_to_and_from_ffi_conversions_no_data {
                 #[inline(always)]
                 pub fn into_rust_repr(self) -> SomeEnum {
                     match self {
-                        __swift_bridge__SomeEnum::Variant1 => SomeEnum::Variant1,
-                        __swift_bridge__SomeEnum::Variant2 => SomeEnum::Variant2
+                        __swift_bridge__SomeEnum::Variant1(_) => SomeEnum::Variant1,
+                        __swift_bridge__SomeEnum::Variant2(_) => SomeEnum::Variant2
                     }
                 }
             }
@@ -73,9 +73,9 @@ extension SomeEnum {
     func intoFfiRepr() -> __swift_bridge__$SomeEnum {
         switch self {
             case SomeEnum.Variant1:
-                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant1)
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant1, payload: __swift_bridge__$SomeEnumFields(Variant1: __swift_bridge__$SomeEnum$FieldOfVariant1(_private: 123)))
             case SomeEnum.Variant2:
-                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant2)
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant2, payload: __swift_bridge__$SomeEnumFields(Variant2: __swift_bridge__$SomeEnum$FieldOfVariant2(_private: 123)))
         }
     }
 }
@@ -99,8 +99,13 @@ extension __swift_bridge__$SomeEnum {
         ExpectedCHeader::ContainsAfterTrim(
             r#"
 #include <stdbool.h>
+#include <stdint.h>
+typedef struct __swift_bridge__$SomeEnum$FieldOfVariant1 {uint8_t _private;} __swift_bridge__$SomeEnum$FieldOfVariant1;
+typedef struct __swift_bridge__$SomeEnum$FieldOfVariant2 {uint8_t _private;} __swift_bridge__$SomeEnum$FieldOfVariant2;
+
+union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfVariant1 Variant1; __swift_bridge__$SomeEnum$FieldOfVariant2 Variant2;};
 typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$Variant1, __swift_bridge__$SomeEnum$Variant2, } __swift_bridge__$SomeEnumTag;
-typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; } __swift_bridge__$SomeEnum;
+typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; union __swift_bridge__$SomeEnumFields payload;} __swift_bridge__$SomeEnum;
 typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__$SomeEnum val; } __swift_bridge__$Option$SomeEnum;
 "#,
         )
@@ -278,8 +283,13 @@ func some_function(_ arg: Optional<SomeEnum>) -> Optional<SomeEnum> {
         ExpectedCHeader::ContainsManyAfterTrim(vec![
             r#"
 #include <stdbool.h>
+#include <stdint.h>
+typedef struct __swift_bridge__$SomeEnum$FieldOfVariant1 {uint8_t _private;} __swift_bridge__$SomeEnum$FieldOfVariant1;
+typedef struct __swift_bridge__$SomeEnum$FieldOfVariant2 {uint8_t _private;} __swift_bridge__$SomeEnum$FieldOfVariant2;
+
+union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfVariant1 Variant1; __swift_bridge__$SomeEnum$FieldOfVariant2 Variant2;};
 typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$Variant1, __swift_bridge__$SomeEnum$Variant2, } __swift_bridge__$SomeEnumTag;
-typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; } __swift_bridge__$SomeEnum;
+typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; union __swift_bridge__$SomeEnumFields payload;} __swift_bridge__$SomeEnum;
 typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__$SomeEnum val; } __swift_bridge__$Option$SomeEnum;
 "#,
             r#"
@@ -337,6 +347,246 @@ mod shared_enum_swift_name_attribute {
 
     #[test]
     fn shared_enum_swift_name_attribute() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}
+
+/// Verify that we generate an enum type that has a variant with one unnamed field and one with no fields.
+mod generates_enum_to_and_from_ffi_conversions_one_unnamed_data_and_no_fields {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            #[swift_bridge::bridge]
+            mod ffi {
+                enum SomeEnum {
+                    Variant1(i32),
+                    Variant2,
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::Contains(quote! {
+            #[derive ()]
+            pub enum SomeEnum {
+                Variant1(i32),
+                Variant2
+            }
+
+            #[repr(C)]
+            #[doc(hidden)]
+            pub enum __swift_bridge__SomeEnum {
+                Variant1(i32),
+                Variant2(u8)
+            }
+
+            impl swift_bridge::SharedEnum for SomeEnum {
+                type FfiRepr = __swift_bridge__SomeEnum;
+            }
+
+            impl SomeEnum {
+                #[doc(hidden)]
+                #[inline(always)]
+                pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
+                    match self {
+                        SomeEnum::Variant1(value_0) => __swift_bridge__SomeEnum::Variant1(value_0),
+                        SomeEnum::Variant2 => __swift_bridge__SomeEnum::Variant2(123)
+                    }
+                }
+            }
+
+            impl __swift_bridge__SomeEnum {
+                #[doc(hidden)]
+                #[inline(always)]
+                pub fn into_rust_repr(self) -> SomeEnum {
+                    match self {
+                        __swift_bridge__SomeEnum::Variant1(value_0) => SomeEnum::Variant1(value_0),
+                        __swift_bridge__SomeEnum::Variant2(_) => SomeEnum::Variant2
+                    }
+                }
+            }
+        })
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(
+            r#"
+public enum SomeEnum {
+    case Variant1(Int32)
+    case Variant2
+}
+extension SomeEnum {
+    func intoFfiRepr() -> __swift_bridge__$SomeEnum {
+        switch self {
+            case SomeEnum.Variant1(let value_0):
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant1, payload: __swift_bridge__$SomeEnumFields(Variant1: __swift_bridge__$SomeEnum$FieldOfVariant1(_0: value_0)))
+            case SomeEnum.Variant2:
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant2, payload: __swift_bridge__$SomeEnumFields(Variant2: __swift_bridge__$SomeEnum$FieldOfVariant2(_private: 123)))
+        }
+    }
+}
+extension __swift_bridge__$SomeEnum {
+    func intoSwiftRepr() -> SomeEnum {
+        switch self.tag {
+            case __swift_bridge__$SomeEnum$Variant1:
+                return SomeEnum.Variant1(self.payload.Variant1._0)
+            case __swift_bridge__$SomeEnum$Variant2:
+                return SomeEnum.Variant2
+            default:
+                fatalError("Unreachable")
+        }
+    }
+}
+"#,
+        )
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ContainsAfterTrim(
+            r#"
+#include <stdbool.h>
+#include <stdint.h>
+typedef struct __swift_bridge__$SomeEnum$FieldOfVariant1 {int32_t _0;} __swift_bridge__$SomeEnum$FieldOfVariant1;
+typedef struct __swift_bridge__$SomeEnum$FieldOfVariant2 {uint8_t _private;} __swift_bridge__$SomeEnum$FieldOfVariant2;
+
+union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfVariant1 Variant1; __swift_bridge__$SomeEnum$FieldOfVariant2 Variant2;};
+typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$Variant1, __swift_bridge__$SomeEnum$Variant2, } __swift_bridge__$SomeEnumTag;
+typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; union __swift_bridge__$SomeEnumFields payload;} __swift_bridge__$SomeEnum;
+typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__$SomeEnum val; } __swift_bridge__$Option$SomeEnum;
+"#,
+        )
+    }
+
+    #[test]
+    fn generates_enum_to_and_from_ffi_conversions_no_data() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}
+
+/// Verify that we generate an enum type that has a variant with one unnamed field and one with two unnamed fields.
+mod generates_enum_to_and_from_ffi_conversions_unnamed_data_case_and_two_unnamed_data {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            #[swift_bridge::bridge]
+            mod ffi {
+                enum SomeEnum {
+                    A(i32, u32),
+                    B(String),
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::Contains(quote! {
+            #[derive ()]
+            pub enum SomeEnum {
+                A(i32, u32),
+                B(String)
+            }
+
+            #[repr(C)]
+            #[doc(hidden)]
+            pub enum __swift_bridge__SomeEnum {
+                A(i32, u32),
+                B(*mut swift_bridge::string::RustString)
+            }
+
+            impl swift_bridge::SharedEnum for SomeEnum {
+                type FfiRepr = __swift_bridge__SomeEnum;
+            }
+
+            impl SomeEnum {
+                #[doc(hidden)]
+                #[inline(always)]
+                pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
+                    match self {
+                        SomeEnum::A(value_0, value_1) => __swift_bridge__SomeEnum::A(value_0, value_1),
+                        SomeEnum::B(value_0) => __swift_bridge__SomeEnum::B(swift_bridge::string::RustString(value_0).box_into_raw())
+                    }
+                }
+            }
+
+            impl __swift_bridge__SomeEnum {
+                #[doc(hidden)]
+                #[inline(always)]
+                pub fn into_rust_repr(self) -> SomeEnum {
+                    match self {
+                        __swift_bridge__SomeEnum::A(value_0, value_1) => SomeEnum::A(value_0, value_1),
+                        __swift_bridge__SomeEnum::B(value_0) => SomeEnum::B(unsafe { Box::from_raw(value_0).0 })
+                    }
+                }
+            }
+        })
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(
+            r#"
+public enum SomeEnum {
+    case A(Int32, UInt32)
+    case B(RustString)
+}
+extension SomeEnum {
+    func intoFfiRepr() -> __swift_bridge__$SomeEnum {
+        switch self {
+            case SomeEnum.A(let value_0, let value_1):
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$A, payload: __swift_bridge__$SomeEnumFields(A: __swift_bridge__$SomeEnum$FieldOfA(_0: value_0, _1: value_1)))
+            case SomeEnum.B(let value_0):
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$B, payload: __swift_bridge__$SomeEnumFields(B: __swift_bridge__$SomeEnum$FieldOfB(_0: { let rustString = value_0.intoRustString(); rustString.isOwned = false; return rustString.ptr }())))
+        }
+    }
+}
+extension __swift_bridge__$SomeEnum {
+    func intoSwiftRepr() -> SomeEnum {
+        switch self.tag {
+            case __swift_bridge__$SomeEnum$A:
+                return SomeEnum.A(self.payload.A._0, self.payload.A._1)
+            case __swift_bridge__$SomeEnum$B:
+                return SomeEnum.B(RustString(ptr: self.payload.B._0))
+            default:
+                fatalError("Unreachable")
+        }
+    }
+}
+"#,
+        )
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ContainsAfterTrim(
+            r#"
+#include <stdbool.h>
+#include <stdint.h>
+typedef struct __swift_bridge__$SomeEnum$FieldOfA {int32_t _0; uint32_t _1;} __swift_bridge__$SomeEnum$FieldOfA;
+typedef struct __swift_bridge__$SomeEnum$FieldOfB {void* _0;} __swift_bridge__$SomeEnum$FieldOfB;
+
+union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfA A; __swift_bridge__$SomeEnum$FieldOfB B;};
+typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$A, __swift_bridge__$SomeEnum$B, } __swift_bridge__$SomeEnumTag;
+typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; union __swift_bridge__$SomeEnumFields payload;} __swift_bridge__$SomeEnum;
+typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__$SomeEnum val; } __swift_bridge__$Option$SomeEnum;
+"#,
+        )
+    }
+
+    #[test]
+    fn generates_enum_to_and_from_ffi_conversions_no_data() {
         CodegenTest {
             bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
@@ -255,6 +255,7 @@ extension __swift_bridge__$Option$SomeEnum {
             return nil
         }
     }
+
     @inline(__always)
     static func fromSwiftRepr(_ val: Optional<SomeEnum>) -> __swift_bridge__$Option$SomeEnum {
         if let v = val {
@@ -445,7 +446,7 @@ extension __swift_bridge__$SomeEnum {
 #include <stdbool.h>
 typedef struct __swift_bridge__$SomeEnum$FieldOfVariant1 {int32_t _0;} __swift_bridge__$SomeEnum$FieldOfVariant1;
 
-union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfVariant1;};
+union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfVariant1 Variant1;};
 typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$Variant1, __swift_bridge__$SomeEnum$Variant2, } __swift_bridge__$SomeEnumTag;
 typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; union __swift_bridge__$SomeEnumFields payload;} __swift_bridge__$SomeEnum;
 typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__$SomeEnum val; } __swift_bridge__$Option$SomeEnum;

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
@@ -455,7 +455,7 @@ typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__
     }
 
     #[test]
-    fn generates_enum_to_and_from_ffi_conversions_no_data() {
+    fn generates_enum_to_and_from_ffi_conversions_one_unnamed_data_and_no_fields() {
         CodegenTest {
             bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),
@@ -467,7 +467,7 @@ typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__
 }
 
 /// Verify that we generate an enum type that has a variant with one unnamed field and one with two unnamed fields.
-mod generates_enum_to_and_from_ffi_conversions_unnamed_data_case_and_two_unnamed_data {
+mod generates_enum_to_and_from_ffi_conversions_unnamed_data_and_two_unnamed_data {
     use super::*;
 
     fn bridge_module_tokens() -> TokenStream {
@@ -575,7 +575,7 @@ typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__
     }
 
     #[test]
-    fn generates_enum_to_and_from_ffi_conversions_no_data() {
+    fn generates_enum_to_and_from_ffi_conversions_unnamed_data_and_two_unnamed_data() {
         CodegenTest {
             bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
@@ -30,8 +30,8 @@ mod generates_enum_to_and_from_ffi_conversions_no_data {
             #[repr(C)]
             #[doc(hidden)]
             pub enum __swift_bridge__SomeEnum {
-                Variant1(u8),
-                Variant2(u8)
+                Variant1,
+                Variant2
             }
 
             impl swift_bridge::SharedEnum for SomeEnum {
@@ -43,8 +43,8 @@ mod generates_enum_to_and_from_ffi_conversions_no_data {
                 #[inline(always)]
                 pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
                     match self {
-                        SomeEnum::Variant1 => __swift_bridge__SomeEnum::Variant1(123),
-                        SomeEnum::Variant2 => __swift_bridge__SomeEnum::Variant2(123)
+                        SomeEnum::Variant1 => __swift_bridge__SomeEnum::Variant1,
+                        SomeEnum::Variant2 => __swift_bridge__SomeEnum::Variant2
                     }
                 }
             }
@@ -54,8 +54,8 @@ mod generates_enum_to_and_from_ffi_conversions_no_data {
                 #[inline(always)]
                 pub fn into_rust_repr(self) -> SomeEnum {
                     match self {
-                        __swift_bridge__SomeEnum::Variant1(_) => SomeEnum::Variant1,
-                        __swift_bridge__SomeEnum::Variant2(_) => SomeEnum::Variant2
+                        __swift_bridge__SomeEnum::Variant1 => SomeEnum::Variant1,
+                        __swift_bridge__SomeEnum::Variant2 => SomeEnum::Variant2
                     }
                 }
             }
@@ -73,9 +73,9 @@ extension SomeEnum {
     func intoFfiRepr() -> __swift_bridge__$SomeEnum {
         switch self {
             case SomeEnum.Variant1:
-                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant1, payload: __swift_bridge__$SomeEnumFields(Variant1: __swift_bridge__$SomeEnum$FieldOfVariant1(_private: 123)))
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant1)
             case SomeEnum.Variant2:
-                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant2, payload: __swift_bridge__$SomeEnumFields(Variant2: __swift_bridge__$SomeEnum$FieldOfVariant2(_private: 123)))
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant2)
         }
     }
 }
@@ -98,14 +98,9 @@ extension __swift_bridge__$SomeEnum {
     fn expected_c_header() -> ExpectedCHeader {
         ExpectedCHeader::ContainsAfterTrim(
             r#"
-#include <stdint.h>
 #include <stdbool.h>
-typedef struct __swift_bridge__$SomeEnum$FieldOfVariant1 {uint8_t _private;} __swift_bridge__$SomeEnum$FieldOfVariant1;
-typedef struct __swift_bridge__$SomeEnum$FieldOfVariant2 {uint8_t _private;} __swift_bridge__$SomeEnum$FieldOfVariant2;
-
-union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfVariant1 Variant1; __swift_bridge__$SomeEnum$FieldOfVariant2 Variant2;};
 typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$Variant1, __swift_bridge__$SomeEnum$Variant2, } __swift_bridge__$SomeEnumTag;
-typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; union __swift_bridge__$SomeEnumFields payload;} __swift_bridge__$SomeEnum;
+typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; } __swift_bridge__$SomeEnum;
 typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__$SomeEnum val; } __swift_bridge__$Option$SomeEnum;
 "#,
         )
@@ -260,7 +255,6 @@ extension __swift_bridge__$Option$SomeEnum {
             return nil
         }
     }
-
     @inline(__always)
     static func fromSwiftRepr(_ val: Optional<SomeEnum>) -> __swift_bridge__$Option$SomeEnum {
         if let v = val {
@@ -282,14 +276,9 @@ func some_function(_ arg: Optional<SomeEnum>) -> Optional<SomeEnum> {
     fn expected_c_header() -> ExpectedCHeader {
         ExpectedCHeader::ContainsManyAfterTrim(vec![
             r#"
-#include <stdint.h>
 #include <stdbool.h>
-typedef struct __swift_bridge__$SomeEnum$FieldOfVariant1 {uint8_t _private;} __swift_bridge__$SomeEnum$FieldOfVariant1;
-typedef struct __swift_bridge__$SomeEnum$FieldOfVariant2 {uint8_t _private;} __swift_bridge__$SomeEnum$FieldOfVariant2;
-
-union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfVariant1 Variant1; __swift_bridge__$SomeEnum$FieldOfVariant2 Variant2;};
 typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$Variant1, __swift_bridge__$SomeEnum$Variant2, } __swift_bridge__$SomeEnumTag;
-typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; union __swift_bridge__$SomeEnumFields payload;} __swift_bridge__$SomeEnum;
+typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; } __swift_bridge__$SomeEnum;
 typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__$SomeEnum val; } __swift_bridge__$Option$SomeEnum;
 "#,
             r#"
@@ -385,7 +374,7 @@ mod generates_enum_to_and_from_ffi_conversions_one_unnamed_data_and_no_fields {
             #[doc(hidden)]
             pub enum __swift_bridge__SomeEnum {
                 Variant1(i32),
-                Variant2(u8)
+                Variant2
             }
 
             impl swift_bridge::SharedEnum for SomeEnum {
@@ -398,7 +387,7 @@ mod generates_enum_to_and_from_ffi_conversions_one_unnamed_data_and_no_fields {
                 pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
                     match self {
                         SomeEnum::Variant1(value_0) => __swift_bridge__SomeEnum::Variant1(value_0),
-                        SomeEnum::Variant2 => __swift_bridge__SomeEnum::Variant2(123)
+                        SomeEnum::Variant2 => __swift_bridge__SomeEnum::Variant2
                     }
                 }
             }
@@ -409,7 +398,7 @@ mod generates_enum_to_and_from_ffi_conversions_one_unnamed_data_and_no_fields {
                 pub fn into_rust_repr(self) -> SomeEnum {
                     match self {
                         __swift_bridge__SomeEnum::Variant1(value_0) => SomeEnum::Variant1(value_0),
-                        __swift_bridge__SomeEnum::Variant2(_) => SomeEnum::Variant2
+                        __swift_bridge__SomeEnum::Variant2 => SomeEnum::Variant2
                     }
                 }
             }
@@ -429,7 +418,7 @@ extension SomeEnum {
             case SomeEnum.Variant1(let value_0):
                 return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant1, payload: __swift_bridge__$SomeEnumFields(Variant1: __swift_bridge__$SomeEnum$FieldOfVariant1(_0: value_0)))
             case SomeEnum.Variant2:
-                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant2, payload: __swift_bridge__$SomeEnumFields(Variant2: __swift_bridge__$SomeEnum$FieldOfVariant2(_private: 123)))
+                return {var val = __swift_bridge__$SomeEnum(); val.tag = __swift_bridge__$SomeEnum$Variant2; return val }()
         }
     }
 }
@@ -455,9 +444,8 @@ extension __swift_bridge__$SomeEnum {
 #include <stdint.h>
 #include <stdbool.h>
 typedef struct __swift_bridge__$SomeEnum$FieldOfVariant1 {int32_t _0;} __swift_bridge__$SomeEnum$FieldOfVariant1;
-typedef struct __swift_bridge__$SomeEnum$FieldOfVariant2 {uint8_t _private;} __swift_bridge__$SomeEnum$FieldOfVariant2;
 
-union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfVariant1 Variant1; __swift_bridge__$SomeEnum$FieldOfVariant2 Variant2;};
+union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfVariant1;};
 typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$Variant1, __swift_bridge__$SomeEnum$Variant2, } __swift_bridge__$SomeEnumTag;
 typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; union __swift_bridge__$SomeEnumFields payload;} __swift_bridge__$SomeEnum;
 typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__$SomeEnum val; } __swift_bridge__$Option$SomeEnum;

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
@@ -98,8 +98,8 @@ extension __swift_bridge__$SomeEnum {
     fn expected_c_header() -> ExpectedCHeader {
         ExpectedCHeader::ContainsAfterTrim(
             r#"
-#include <stdbool.h>
 #include <stdint.h>
+#include <stdbool.h>
 typedef struct __swift_bridge__$SomeEnum$FieldOfVariant1 {uint8_t _private;} __swift_bridge__$SomeEnum$FieldOfVariant1;
 typedef struct __swift_bridge__$SomeEnum$FieldOfVariant2 {uint8_t _private;} __swift_bridge__$SomeEnum$FieldOfVariant2;
 
@@ -282,8 +282,8 @@ func some_function(_ arg: Optional<SomeEnum>) -> Optional<SomeEnum> {
     fn expected_c_header() -> ExpectedCHeader {
         ExpectedCHeader::ContainsManyAfterTrim(vec![
             r#"
-#include <stdbool.h>
 #include <stdint.h>
+#include <stdbool.h>
 typedef struct __swift_bridge__$SomeEnum$FieldOfVariant1 {uint8_t _private;} __swift_bridge__$SomeEnum$FieldOfVariant1;
 typedef struct __swift_bridge__$SomeEnum$FieldOfVariant2 {uint8_t _private;} __swift_bridge__$SomeEnum$FieldOfVariant2;
 
@@ -452,8 +452,8 @@ extension __swift_bridge__$SomeEnum {
     fn expected_c_header() -> ExpectedCHeader {
         ExpectedCHeader::ContainsAfterTrim(
             r#"
-#include <stdbool.h>
 #include <stdint.h>
+#include <stdbool.h>
 typedef struct __swift_bridge__$SomeEnum$FieldOfVariant1 {int32_t _0;} __swift_bridge__$SomeEnum$FieldOfVariant1;
 typedef struct __swift_bridge__$SomeEnum$FieldOfVariant2 {uint8_t _private;} __swift_bridge__$SomeEnum$FieldOfVariant2;
 
@@ -572,8 +572,8 @@ extension __swift_bridge__$SomeEnum {
     fn expected_c_header() -> ExpectedCHeader {
         ExpectedCHeader::ContainsAfterTrim(
             r#"
-#include <stdbool.h>
 #include <stdint.h>
+#include <stdbool.h>
 typedef struct __swift_bridge__$SomeEnum$FieldOfA {int32_t _0; uint32_t _1;} __swift_bridge__$SomeEnum$FieldOfA;
 typedef struct __swift_bridge__$SomeEnum$FieldOfB {void* _0;} __swift_bridge__$SomeEnum$FieldOfB;
 

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -133,6 +133,8 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                         let ffi_name = ty_enum.ffi_name_string();
                         let ffi_tag_name = ty_enum.ffi_tag_name_string();
                         let option_ffi_name = ty_enum.ffi_option_name_string();
+                        let ffi_union_name = ty_enum.ffi_union_name_string();
+                        let ffi_union_field_names = ty_enum.ffi_union_field_names_string();
 
                         // Used for `Option<T>` ...
                         // typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; ...
@@ -141,8 +143,8 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                         let mut variants = "".to_string();
 
                         for variant in ty_enum.variants.iter() {
-                            let v = format!("{}${}, ", ffi_name, variant.name);
-                            variants += &v;
+                            let variant = format!("{}${}, ", ffi_name, variant.name);
+                            variants += &variant;
                         }
 
                         let maybe_vec_support = if ty_enum.has_one_or_more_variants_with_data() {
@@ -150,15 +152,52 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                         } else {
                             vec_transparent_enum_c_support(&ty_enum.swift_name_string())
                         };
-
+                        let mut variant_fields = "".to_string();
+                        for variant in ty_enum.variants.iter() {
+                            match &variant.fields {
+                                StructFields::Named(_) => {
+                                    todo!();
+                                }
+                                StructFields::Unnamed(unnamed_fields) => {
+                                    let mut params = vec![];
+                                    for unnamed_field in unnamed_fields.iter() {
+                                        let variant_field = BridgedType::new_with_type(
+                                            &unnamed_field.ty,
+                                            &self.types,
+                                        )
+                                        .unwrap();
+                                        let variant_field = variant_field.to_c();
+                                        params.push(format!(
+                                            "{} _{};",
+                                            variant_field, unnamed_field.idx
+                                        ));
+                                    }
+                                    let params = params.join(" ");
+                                    let variant_field = format!("typedef struct {ffi_name}$FieldOf{variant_name} {{{params}}} {ffi_name}$FieldOf{variant_name};", ffi_name = ffi_name, variant_name = variant.name, params = params);
+                                    variant_fields += &variant_field;
+                                    variant_fields += "\n";
+                                }
+                                StructFields::Unit => {
+                                    let variant_field = format!("typedef struct {ffi_name}$FieldOf{variant_name} {{uint8_t _private;}} {ffi_name}$FieldOf{variant_name};", ffi_name = ffi_name, variant_name = variant.name);
+                                    variant_fields += &variant_field;
+                                    variant_fields += "\n";
+                                }
+                            }
+                        }
                         let enum_decl = format!(
-                            r#"typedef enum {ffi_tag_name} {{ {variants}}} {ffi_tag_name};
-typedef struct {ffi_name} {{ {ffi_tag_name} tag; }} {ffi_name};
+                            r#"#include <stdint.h>
+{variant_fields}
+union {ffi_union_name} {union_fields};
+typedef enum {ffi_tag_name} {{ {variants}}} {ffi_tag_name};
+typedef struct {ffi_name} {{ {ffi_tag_name} tag; union {ffi_union_name} payload;}} {ffi_name};
 typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi_name};{maybe_vec_support}"#,
+                            union_fields = ffi_union_field_names,
+                            variant_fields = variant_fields,
                             ffi_name = ffi_name,
                             ffi_tag_name = ffi_tag_name,
                             option_ffi_name = option_ffi_name,
-                            variants = variants
+                            variants = variants,
+                            ffi_union_name = ffi_union_name,
                         );
 
                         header += &enum_decl;

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -129,13 +129,16 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                         if ty_enum.already_declared {
                             continue;
                         }
-                        let is_enum_has_variants_with_no_data: bool = ty_enum.variants.iter().map(|variant|{
-                            match &variant.fields {
-                                StructFields::Named(_) => 0, 
+                        let is_enum_has_variants_with_no_data: bool = ty_enum
+                            .variants
+                            .iter()
+                            .map(|variant| match &variant.fields {
+                                StructFields::Named(_) => 0,
                                 StructFields::Unnamed(_) => 0,
                                 StructFields::Unit => 1,
-                            }
-                        }).fold(0, |sum, x|sum+x) == ty_enum.variants.len();
+                            })
+                            .fold(0, |sum, x| sum + x)
+                            == ty_enum.variants.len();
 
                         let ffi_name = ty_enum.ffi_name_string();
                         let ffi_tag_name = ty_enum.ffi_tag_name_string();
@@ -162,17 +165,16 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                         let mut variant_fields = "".to_string();
                         if is_enum_has_variants_with_no_data {
                             let enum_decl = format!(
-                            r#"typedef enum {ffi_tag_name} {{ {variants}}} {ffi_tag_name};
+                                r#"typedef enum {ffi_tag_name} {{ {variants}}} {ffi_tag_name};
 typedef struct {ffi_name} {{ {ffi_tag_name} tag; }} {ffi_name};
 typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi_name};{maybe_vec_support}"#,
-                                    ffi_name = ffi_name,
-                                    ffi_tag_name = ffi_tag_name,
-                                    option_ffi_name = option_ffi_name,
-                                    variants = variants
-                                );
-                                header += &enum_decl;
-                                header += "\n";
-
+                                ffi_name = ffi_name,
+                                ffi_tag_name = ffi_tag_name,
+                                option_ffi_name = option_ffi_name,
+                                variants = variants
+                            );
+                            header += &enum_decl;
+                            header += "\n";
                         } else {
                             for variant in ty_enum.variants.iter() {
                                 match &variant.fields {
@@ -201,11 +203,11 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                                         variant_fields += &variant_field;
                                         variant_fields += "\n";
                                     }
-                                    StructFields::Unit => {},
+                                    StructFields::Unit => {}
                                 }
                             }
                             let enum_decl = format!(
-                            r#"{variant_fields}
+                                r#"{variant_fields}
 union {ffi_union_name} {union_fields};
 typedef enum {ffi_tag_name} {{ {variants}}} {ffi_tag_name};
 typedef struct {ffi_name} {{ {ffi_tag_name} tag; union {ffi_union_name} payload;}} {ffi_name};
@@ -218,7 +220,7 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                                 variants = variants,
                                 ffi_union_name = ffi_union_name,
                             );
-    
+
                             header += &enum_decl;
                             header += "\n";
                         }

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -166,6 +166,9 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                                             &self.types,
                                         )
                                         .unwrap();
+                                        if let Some(include) = variant_field.to_c_include() {
+                                            bookkeeping.includes.insert(include);
+                                        }
                                         let variant_field = variant_field.to_c();
                                         params.push(format!(
                                             "{} _{};",
@@ -178,6 +181,7 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                                     variant_fields += "\n";
                                 }
                                 StructFields::Unit => {
+                                    bookkeeping.includes.insert("stdint.h");
                                     let variant_field = format!("typedef struct {ffi_name}$FieldOf{variant_name} {{uint8_t _private;}} {ffi_name}$FieldOf{variant_name};", ffi_name = ffi_name, variant_name = variant.name);
                                     variant_fields += &variant_field;
                                     variant_fields += "\n";
@@ -185,8 +189,7 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                             }
                         }
                         let enum_decl = format!(
-                            r#"#include <stdint.h>
-{variant_fields}
+                            r#"{variant_fields}
 union {ffi_union_name} {union_fields};
 typedef enum {ffi_tag_name} {{ {variants}}} {ffi_tag_name};
 typedef struct {ffi_name} {{ {ffi_tag_name} tag; union {ffi_union_name} payload;}} {ffi_name};

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
@@ -74,7 +74,7 @@ impl SwiftBridgeModule {
                 }
                 StructFields::Unit => {
                     quote! {
-                        #variant_name (u8)
+                        #variant_name
                     }
                 }
             };

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
@@ -1,4 +1,4 @@
-use crate::bridged_type::{BridgedType, SharedEnum, StructFields, TypePosition, EnumVariant};
+use crate::bridged_type::{BridgedType, SharedEnum, StructFields, TypePosition};
 use crate::SwiftBridgeModule;
 
 impl SwiftBridgeModule {

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
@@ -15,13 +15,16 @@ impl SwiftBridgeModule {
         let mut variants = "".to_string();
         let mut convert_swift_to_ffi_repr = "\n".to_string();
         let mut convert_ffi_repr_to_swift = "\n".to_string();
-        let is_enum_has_variants_with_no_data: bool = shared_enum.variants.iter().map(|variant|{
-            match &variant.fields {
-                StructFields::Named(_) => 0, 
+        let is_enum_has_variants_with_no_data: bool = shared_enum
+            .variants
+            .iter()
+            .map(|variant| match &variant.fields {
+                StructFields::Named(_) => 0,
                 StructFields::Unnamed(_) => 0,
                 StructFields::Unit => 1,
-            }
-        }).fold(0, |sum, x|sum+x) == shared_enum.variants.len();
+            })
+            .fold(0, |sum, x| sum + x)
+            == shared_enum.variants.len();
         for variant in shared_enum.variants.iter() {
             let v = match &variant.fields {
                 StructFields::Named(_) => {

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
@@ -1,4 +1,4 @@
-use crate::bridged_type::{BridgedType, SharedEnum, StructFields, TypePosition};
+use crate::bridged_type::{BridgedType, SharedEnum, StructFields, TypePosition, EnumVariant};
 use crate::SwiftBridgeModule;
 
 impl SwiftBridgeModule {
@@ -15,7 +15,13 @@ impl SwiftBridgeModule {
         let mut variants = "".to_string();
         let mut convert_swift_to_ffi_repr = "\n".to_string();
         let mut convert_ffi_repr_to_swift = "\n".to_string();
-
+        let is_enum_has_variants_with_no_data: bool = shared_enum.variants.iter().map(|variant|{
+            match &variant.fields {
+                StructFields::Named(_) => 0, 
+                StructFields::Unnamed(_) => 0,
+                StructFields::Unit => 1,
+            }
+        }).fold(0, |sum, x|sum+x) == shared_enum.variants.len();
         for variant in shared_enum.variants.iter() {
             let v = match &variant.fields {
                 StructFields::Named(_) => {
@@ -56,6 +62,7 @@ impl SwiftBridgeModule {
                 &self.types,
                 format!("{}", enum_name),
                 format!("{}", enum_ffi_name),
+                is_enum_has_variants_with_no_data,
             );
             convert_swift_to_ffi_repr += &convert_swift_variant_to_ffi_repr;
         }

--- a/crates/swift-integration-tests/src/shared_types/shared_enum.rs
+++ b/crates/swift-integration-tests/src/shared_types/shared_enum.rs
@@ -8,8 +8,22 @@ mod ffi {
     extern "Rust" {
         fn reflect_enum_with_no_data(arg: EnumWithNoData) -> EnumWithNoData;
     }
+
+    enum EnumWithUnnamedData {
+        Variant1(String, u32),
+        Variant2(i32, u8),
+        Variant3,
+    }
+
+    extern "Rust" {
+        fn reflect_enum_with_unnamed_data(arg: EnumWithUnnamedData) -> EnumWithUnnamedData;
+    }
 }
 
 fn reflect_enum_with_no_data(arg: ffi::EnumWithNoData) -> ffi::EnumWithNoData {
+    arg
+}
+
+fn reflect_enum_with_unnamed_data(arg: ffi::EnumWithUnnamedData) -> ffi::EnumWithUnnamedData {
     arg
 }


### PR DESCRIPTION
This PR addresses #160 and adds support for enums with unnamed data. This PR doesn't implement enums with named data.

Here's an example of using this.

```rust
//Rust
#[swift_bridge::bridge]
mod ffi {
    enum EnumWithUnnamedData {
        Variant1(String, u32),
        Variant2(i32, u8),
        Variant3,
    }
}
```

```Swift
//Swift
let enumWithUnnamedData = EnumWithUnnamedData.Variant1(create_string("hello"), 0)
switch enumWithUnnamedData {
case .Variant1(let rustString, let valueUInt32):
    XCTAssertEqual(rustString.toString(), "hello")
    XCTAssertEqual(valueUInt32, 0)
default:
    XCTFail()
}

```