### PR TITLE
Support enums with named data

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
@@ -58,6 +58,33 @@ class SharedEnumTests: XCTestCase {
         default:
             XCTFail()
         }
+    }
+    
+    func testEnumWithNamedData() {
+        let enumWithNamedData1 = EnumWithNamedData.Variant1(hello: create_string("hello"), data_u8: 123)
+        switch reflect_enum_with_named_data(enumWithNamedData1) {
+        case .Variant1(let hello, let dataU8):
+            XCTAssertEqual(hello.toString(), "hello")
+            XCTAssertEqual(dataU8, 123)
+        default:
+            XCTFail()
+        }
+        
+        let enumWithNamedData2 = EnumWithNamedData.Variant2(data_i32: -123)
+        switch reflect_enum_with_named_data(enumWithNamedData2) {
+        case .Variant2(let dataI32):
+            XCTAssertEqual(dataI32, -123)
+        default:
+            XCTFail()
+        }
+
+        let enumWithNamedData3 = EnumWithNamedData.Variant3
+        switch reflect_enum_with_named_data(enumWithNamedData3) {
+        case .Variant3:
+            break
+        default:
+            XCTFail()
+        }
 
     }
 }

--- a/crates/swift-bridge-ir/src/bridged_type/shared_enum/enum_variant.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_enum/enum_variant.rs
@@ -127,8 +127,6 @@ impl EnumVariant {
             .iter()
             .map(|norm_field| {
                 let field_name = norm_field.ffi_field_name();
-                let maybe_name_and_colon = norm_field.maybe_name_and_colon_string();
-
                 let ty = BridgedType::new_with_type(&norm_field.ty, types).unwrap();
                 let field = ty.convert_ffi_value_to_swift_value(
                     &format!(
@@ -139,7 +137,7 @@ impl EnumVariant {
                     TypePosition::SharedStructField,
                     types,
                 );
-                format!("{}{}", maybe_name_and_colon, field)
+                norm_field.struct_field_setter_string(field)
             })
             .collect();
         let converted_fields = converted_fields.join(", ");
@@ -185,17 +183,11 @@ impl EnumVariant {
             .map(|norm_field| {
                 let ffi_field_name = norm_field.ffi_field_name();
                 let ty = BridgedType::new_with_type(&norm_field.ty, types).unwrap();
-
-                let enum_field = ty.convert_swift_expression_to_ffi_type(
+                let variant_field = ty.convert_swift_expression_to_ffi_type(
                     &format!("{}", ffi_field_name),
                     TypePosition::SharedStructField,
                 );
-                let field_name = norm_field.ffi_field_name();
-                format!(
-                    "{field_name}: {enum_field}",
-                    field_name = field_name,
-                    enum_field = enum_field
-                )
+                norm_field.struct_ffi_field_setter_string(variant_field)
             })
             .collect();
         let converted_fields = converted_fields.join(", ");

--- a/crates/swift-bridge-ir/src/bridged_type/shared_enum/enum_variant.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_enum/enum_variant.rs
@@ -2,7 +2,7 @@ use crate::bridged_type::{BridgedType, StructFields, TypePosition};
 use crate::parse::TypeDeclarations;
 use proc_macro2::Ident;
 use proc_macro2::TokenStream;
-use quote::{quote, format_ident};
+use quote::{format_ident, quote};
 use std::fmt::{Debug, Formatter};
 use syn::spanned::Spanned;
 use syn::Path;
@@ -29,7 +29,7 @@ impl EnumVariant {
             .iter()
             .map(|norm_field| norm_field.ffi_field_name())
             .map(|norm_field| format_ident!("{}", norm_field))
-            .map(|norm_field| quote!{#norm_field})
+            .map(|norm_field| quote! {#norm_field})
             .collect();
         let converted_fields: Vec<TokenStream> = self
             .fields
@@ -38,7 +38,7 @@ impl EnumVariant {
             .map(|norm_field| {
                 let maybe_name_and_colon = norm_field.maybe_name_and_colon();
                 let access_field = format_ident!("{}", norm_field.ffi_field_name());
-                let access_field = quote!{#access_field};
+                let access_field = quote! {#access_field};
                 let ty = BridgedType::new_with_type(&norm_field.ty, types).unwrap();
                 let converted_field = ty.convert_rust_expression_to_ffi_type(
                     &access_field,
@@ -79,7 +79,7 @@ impl EnumVariant {
             .normalized_fields()
             .iter()
             .map(|norm_field| format_ident!("{}", norm_field.ffi_field_name()))
-            .map(|norm_field|quote!{#norm_field})
+            .map(|norm_field| quote! {#norm_field})
             .collect();
         let converted_fields: Vec<TokenStream> = self
             .fields
@@ -88,7 +88,7 @@ impl EnumVariant {
             .map(|norm_field| {
                 let maybe_name_and_colon = norm_field.maybe_name_and_colon();
                 let access_field = format_ident!("{}", norm_field.ffi_field_name());
-                let access_field = quote!{#access_field};
+                let access_field = quote! {#access_field};
                 let ty = BridgedType::new_with_type(&norm_field.ty, types).unwrap();
                 let converted_field = ty.convert_ffi_expression_to_rust_type(
                     &access_field,
@@ -185,7 +185,7 @@ impl EnumVariant {
             .map(|norm_field| {
                 let ffi_field_name = norm_field.ffi_field_name();
                 let ty = BridgedType::new_with_type(&norm_field.ty, types).unwrap();
-                
+
                 let enum_field = ty.convert_swift_expression_to_ffi_type(
                     &format!("{}", ffi_field_name),
                     TypePosition::SharedStructField,

--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct/struct_field/normalized_field.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct/struct_field/normalized_field.rs
@@ -38,6 +38,20 @@ impl NormalizedStructField {
         }
     }
 
+    /// Used when we want to avoid putting spaces at all between the field name and the colon.
+    /// // Example:
+    /// description: String // no spaces between "description" and the colon.
+    pub fn maybe_name_and_colon_string(&self) -> String {
+        match &self.accessor {
+            NormalizedStructFieldAccessor::Named(name) => {
+                format!("{}: ", name.to_string())
+            }
+            NormalizedStructFieldAccessor::Unnamed(_idx) => {
+                format!("")
+            }
+        }
+    }
+
     /// Access a struct's field
     ///
     /// // Example named field access
@@ -58,8 +72,8 @@ impl NormalizedStructField {
 
     pub fn to_enum_field(&self, expression: &TokenStream) -> TokenStream {
         match &self.accessor {
-            NormalizedStructFieldAccessor::Named(_) => {
-                todo!()
+            NormalizedStructFieldAccessor::Named(named) => {
+                quote!{ #named }
             }
             NormalizedStructFieldAccessor::Unnamed(idx) => {
                 let idx = TokenStream::from_str(&idx.to_string()).unwrap();

--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct/struct_field/normalized_field.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct/struct_field/normalized_field.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Ident, TokenStream};
-use quote::{format_ident, quote};
+use quote::quote;
 use std::str::FromStr;
 use syn::Type;
 
@@ -66,19 +66,6 @@ impl NormalizedStructField {
             NormalizedStructFieldAccessor::Unnamed(idx) => {
                 let idx = TokenStream::from_str(&idx.to_string()).unwrap();
                 quote! { #expression.#idx }
-            }
-        }
-    }
-
-    pub fn to_enum_field(&self, expression: &TokenStream) -> TokenStream {
-        match &self.accessor {
-            NormalizedStructFieldAccessor::Named(named) => {
-                quote!{ #named }
-            }
-            NormalizedStructFieldAccessor::Unnamed(idx) => {
-                let idx = TokenStream::from_str(&idx.to_string()).unwrap();
-                let expression = format_ident!("{}_{}", expression.to_string(), idx.to_string());
-                quote! { #expression }
             }
         }
     }

--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct/struct_field/normalized_field.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct/struct_field/normalized_field.rs
@@ -38,16 +38,32 @@ impl NormalizedStructField {
         }
     }
 
-    /// Used when we want to avoid putting spaces at all between the field name and the colon.
-    /// // Example:
-    /// description: String // no spaces between "description" and the colon.
-    pub fn maybe_name_and_colon_string(&self) -> String {
+    /// Create a string for setting the value of a struct's field.
+    ///
+    /// Example if named field -> "field_name: someValue".
+    /// Example if unnamed field -> "someValue".
+    pub fn struct_field_setter_string(&self, value: String) -> String {
         match &self.accessor {
             NormalizedStructFieldAccessor::Named(name) => {
-                format!("{}: ", name.to_string())
+                format!("{}: {}", name.to_string(), value)
             }
-            NormalizedStructFieldAccessor::Unnamed(_idx) => {
-                format!("")
+            NormalizedStructFieldAccessor::Unnamed(_) => {
+                format!("{}", value)
+            }
+        }
+    }
+
+    /// Create a string for setting the value of a struct's ffi field.
+    ///
+    /// Example if named field -> "field_name: someValue".
+    /// Example if unnamed field -> "_0: someValue".
+    pub fn struct_ffi_field_setter_string(&self, value: String) -> String {
+        match &self.accessor {
+            NormalizedStructFieldAccessor::Named(name) => {
+                format!("{}: {}", name.to_string(), value)
+            }
+            NormalizedStructFieldAccessor::Unnamed(idx) => {
+                format!("_{}: {}", idx, value)
             }
         }
     }

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
@@ -587,7 +587,7 @@ typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__
 }
 
 /// Verify that we generate an enum type that has a variant with one named field and one with two named fields.
-mod generates_enum_to_and_from_ffi_conversions_named_data_and_two_named_data {
+mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data {
     use super::*;
 
     fn bridge_module_tokens() -> TokenStream {
@@ -710,7 +710,7 @@ typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__
     }
 
     #[test]
-    fn generates_enum_to_and_from_ffi_conversions_unnamed_data_and_two_unnamed_data() {
+    fn generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data() {
         CodegenTest {
             bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
@@ -596,7 +596,7 @@ mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data
             mod ffi {
                 enum SomeEnum {
                     A{
-                        data1: i32, 
+                        data1: i32,
                         data2: u32
                     },
                     B{
@@ -612,7 +612,7 @@ mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data
             #[derive ()]
             pub enum SomeEnum {
                 A {
-                    data1: i32, 
+                    data1: i32,
                     data2: u32
                 },
                 B {
@@ -624,7 +624,7 @@ mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data
             #[doc(hidden)]
             pub enum __swift_bridge__SomeEnum {
                 A {
-                    data1: i32, 
+                    data1: i32,
                     data2: u32
                 },
                 B {

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
@@ -387,7 +387,7 @@ mod generates_enum_to_and_from_ffi_conversions_one_unnamed_data_and_no_fields {
                 #[inline(always)]
                 pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
                     match self {
-                        SomeEnum::Variant1(value_0) => __swift_bridge__SomeEnum::Variant1(value_0),
+                        SomeEnum::Variant1(_0) => __swift_bridge__SomeEnum::Variant1(_0),
                         SomeEnum::Variant2 => __swift_bridge__SomeEnum::Variant2
                     }
                 }
@@ -398,7 +398,7 @@ mod generates_enum_to_and_from_ffi_conversions_one_unnamed_data_and_no_fields {
                 #[inline(always)]
                 pub fn into_rust_repr(self) -> SomeEnum {
                     match self {
-                        __swift_bridge__SomeEnum::Variant1(value_0) => SomeEnum::Variant1(value_0),
+                        __swift_bridge__SomeEnum::Variant1(_0) => SomeEnum::Variant1(_0),
                         __swift_bridge__SomeEnum::Variant2 => SomeEnum::Variant2
                     }
                 }
@@ -416,8 +416,8 @@ public enum SomeEnum {
 extension SomeEnum {
     func intoFfiRepr() -> __swift_bridge__$SomeEnum {
         switch self {
-            case SomeEnum.Variant1(let value_0):
-                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant1, payload: __swift_bridge__$SomeEnumFields(Variant1: __swift_bridge__$SomeEnum$FieldOfVariant1(_0: value_0)))
+            case SomeEnum.Variant1(let _0):
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$Variant1, payload: __swift_bridge__$SomeEnumFields(Variant1: __swift_bridge__$SomeEnum$FieldOfVariant1(_0: _0)))
             case SomeEnum.Variant2:
                 return {var val = __swift_bridge__$SomeEnum(); val.tag = __swift_bridge__$SomeEnum$Variant2; return val }()
         }
@@ -506,8 +506,8 @@ mod generates_enum_to_and_from_ffi_conversions_unnamed_data_and_two_unnamed_data
                 #[inline(always)]
                 pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
                     match self {
-                        SomeEnum::A(value_0, value_1) => __swift_bridge__SomeEnum::A(value_0, value_1),
-                        SomeEnum::B(value_0) => __swift_bridge__SomeEnum::B(swift_bridge::string::RustString(value_0).box_into_raw())
+                        SomeEnum::A(_0, _1) => __swift_bridge__SomeEnum::A(_0, _1),
+                        SomeEnum::B(_0) => __swift_bridge__SomeEnum::B(swift_bridge::string::RustString(_0).box_into_raw())
                     }
                 }
             }
@@ -517,8 +517,8 @@ mod generates_enum_to_and_from_ffi_conversions_unnamed_data_and_two_unnamed_data
                 #[inline(always)]
                 pub fn into_rust_repr(self) -> SomeEnum {
                     match self {
-                        __swift_bridge__SomeEnum::A(value_0, value_1) => SomeEnum::A(value_0, value_1),
-                        __swift_bridge__SomeEnum::B(value_0) => SomeEnum::B(unsafe { Box::from_raw(value_0).0 })
+                        __swift_bridge__SomeEnum::A(_0, _1) => SomeEnum::A(_0, _1),
+                        __swift_bridge__SomeEnum::B(_0) => SomeEnum::B(unsafe { Box::from_raw(_0).0 })
                     }
                 }
             }
@@ -535,10 +535,10 @@ public enum SomeEnum {
 extension SomeEnum {
     func intoFfiRepr() -> __swift_bridge__$SomeEnum {
         switch self {
-            case SomeEnum.A(let value_0, let value_1):
-                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$A, payload: __swift_bridge__$SomeEnumFields(A: __swift_bridge__$SomeEnum$FieldOfA(_0: value_0, _1: value_1)))
-            case SomeEnum.B(let value_0):
-                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$B, payload: __swift_bridge__$SomeEnumFields(B: __swift_bridge__$SomeEnum$FieldOfB(_0: { let rustString = value_0.intoRustString(); rustString.isOwned = false; return rustString.ptr }())))
+            case SomeEnum.A(let _0, let _1):
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$A, payload: __swift_bridge__$SomeEnumFields(A: __swift_bridge__$SomeEnum$FieldOfA(_0: _0, _1: _1)))
+            case SomeEnum.B(let _0):
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$B, payload: __swift_bridge__$SomeEnumFields(B: __swift_bridge__$SomeEnum$FieldOfB(_0: { let rustString = _0.intoRustString(); rustString.isOwned = false; return rustString.ptr }())))
         }
     }
 }

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -172,19 +172,19 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                                     StructFields::Named(named_fields) => {
                                         let mut params = vec![];
                                         for named_field in named_fields.iter() {
-                                            let variant_field = BridgedType::new_with_type(
+                                            let ty = BridgedType::new_with_type(
                                                 &named_field.ty,
                                                 &self.types,
                                             )
                                             .unwrap();
-                                            if let Some(include) = variant_field.to_c_include() {
+                                            if let Some(include) = ty.to_c_include() {
                                                 bookkeeping.includes.insert(include);
                                             }
-                                            let variant_field = variant_field.to_c();
+                                            let ty = ty.to_c();
                                             let field_name = named_field.name.to_string(); 
                                             params.push(format!(
                                                 "{} {};",
-                                                variant_field, field_name
+                                                ty, field_name
                                             ));
                                         }
                                         let params = params.join(" ");
@@ -195,18 +195,18 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                                     StructFields::Unnamed(unnamed_fields) => {
                                         let mut params = vec![];
                                         for unnamed_field in unnamed_fields.iter() {
-                                            let variant_field = BridgedType::new_with_type(
+                                            let ty = BridgedType::new_with_type(
                                                 &unnamed_field.ty,
                                                 &self.types,
                                             )
                                             .unwrap();
-                                            if let Some(include) = variant_field.to_c_include() {
+                                            if let Some(include) = ty.to_c_include() {
                                                 bookkeeping.includes.insert(include);
                                             }
-                                            let variant_field = variant_field.to_c();
+                                            let ty = ty.to_c();
                                             params.push(format!(
                                                 "{} _{};",
-                                                variant_field, unnamed_field.idx
+                                                ty, unnamed_field.idx
                                             ));
                                         }
                                         let params = params.join(" ");

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -181,11 +181,8 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                                                 bookkeeping.includes.insert(include);
                                             }
                                             let ty = ty.to_c();
-                                            let field_name = named_field.name.to_string(); 
-                                            params.push(format!(
-                                                "{} {};",
-                                                ty, field_name
-                                            ));
+                                            let field_name = named_field.name.to_string();
+                                            params.push(format!("{} {};", ty, field_name));
                                         }
                                         let params = params.join(" ");
                                         let variant_field = format!("typedef struct {ffi_name}$FieldOf{variant_name} {{{params}}} {ffi_name}$FieldOf{variant_name};", ffi_name = ffi_name, variant_name = variant.name, params = params);
@@ -204,10 +201,7 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                                                 bookkeeping.includes.insert(include);
                                             }
                                             let ty = ty.to_c();
-                                            params.push(format!(
-                                                "{} _{};",
-                                                ty, unnamed_field.idx
-                                            ));
+                                            params.push(format!("{} _{};", ty, unnamed_field.idx));
                                         }
                                         let params = params.join(" ");
                                         let variant_field = format!("typedef struct {ffi_name}$FieldOf{variant_name} {{{params}}} {ffi_name}$FieldOf{variant_name};", ffi_name = ffi_name, variant_name = variant.name, params = params);

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -169,8 +169,28 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                         } else {
                             for variant in ty_enum.variants.iter() {
                                 match &variant.fields {
-                                    StructFields::Named(_) => {
-                                        todo!();
+                                    StructFields::Named(named_fields) => {
+                                        let mut params = vec![];
+                                        for named_field in named_fields.iter() {
+                                            let variant_field = BridgedType::new_with_type(
+                                                &named_field.ty,
+                                                &self.types,
+                                            )
+                                            .unwrap();
+                                            if let Some(include) = variant_field.to_c_include() {
+                                                bookkeeping.includes.insert(include);
+                                            }
+                                            let variant_field = variant_field.to_c();
+                                            let field_name = named_field.name.to_string(); 
+                                            params.push(format!(
+                                                "{} {};",
+                                                variant_field, field_name
+                                            ));
+                                        }
+                                        let params = params.join(" ");
+                                        let variant_field = format!("typedef struct {ffi_name}$FieldOf{variant_name} {{{params}}} {ffi_name}$FieldOf{variant_name};", ffi_name = ffi_name, variant_name = variant.name, params = params);
+                                        variant_fields += &variant_field;
+                                        variant_fields += "\n";
                                     }
                                     StructFields::Unnamed(unnamed_fields) => {
                                         let mut params = vec![];

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
@@ -37,7 +37,7 @@ impl SwiftBridgeModule {
                     for named_field in named_fields {
                         let field_name = &named_field.name;
                         let ty = named_field.ty.to_token_stream();
-                        let field = quote!{#field_name : #ty};
+                        let field = quote! {#field_name : #ty};
                         names.push(field);
                     }
                     quote! {
@@ -69,8 +69,10 @@ impl SwiftBridgeModule {
                     let mut names = vec![];
                     for named_field in named_fields {
                         let field_name = &named_field.name;
-                        let ty = BridgedType::new_with_type(&named_field.ty, &self.types).unwrap().to_ffi_compatible_rust_type(&self.swift_bridge_path, &self.types);
-                        let field = quote!{#field_name : #ty};
+                        let ty = BridgedType::new_with_type(&named_field.ty, &self.types)
+                            .unwrap()
+                            .to_ffi_compatible_rust_type(&self.swift_bridge_path, &self.types);
+                        let field = quote! {#field_name : #ty};
                         names.push(field);
                     }
                     quote! {

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
@@ -32,8 +32,17 @@ impl SwiftBridgeModule {
         for variant in shared_enum.variants.iter() {
             let variant_name = &variant.name;
             let enum_variant = match &variant.fields {
-                StructFields::Named(_) => {
-                    todo!();
+                StructFields::Named(named_fields) => {
+                    let mut names = vec![];
+                    for named_field in named_fields {
+                        let field_name = &named_field.name;
+                        let ty = named_field.ty.to_token_stream();
+                        let field = quote!{#field_name : #ty};
+                        names.push(field);
+                    }
+                    quote! {
+                        #variant_name {#(#names),*}
+                    }
                 }
                 StructFields::Unnamed(unamed_fields) => {
                     let mut names = vec![];
@@ -56,8 +65,17 @@ impl SwiftBridgeModule {
         for variant in shared_enum.variants.iter() {
             let variant_name = &variant.name;
             let enum_ffi_variant = match &variant.fields {
-                StructFields::Named(_) => {
-                    todo!();
+                StructFields::Named(named_fields) => {
+                    let mut names = vec![];
+                    for named_field in named_fields {
+                        let field_name = &named_field.name;
+                        let ty = BridgedType::new_with_type(&named_field.ty, &self.types).unwrap().to_ffi_compatible_rust_type(&self.swift_bridge_path, &self.types);
+                        let field = quote!{#field_name : #ty};
+                        names.push(field);
+                    }
+                    quote! {
+                        #variant_name {#(#names),*}
+                    }
                 }
                 StructFields::Unnamed(unamed_fields) => {
                     let mut names = vec![];

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
@@ -18,8 +18,19 @@ impl SwiftBridgeModule {
         let all_variants_empty = shared_enum.all_variants_empty();
         for variant in shared_enum.variants.iter() {
             let v = match &variant.fields {
-                StructFields::Named(_) => {
-                    todo!();
+                StructFields::Named(named_fields) => {
+                    let mut params = vec![];
+                    for named_field in named_fields {
+                        let ty = BridgedType::new_with_type(&named_field.ty, &self.types).unwrap().to_swift_type(TypePosition::SharedStructField, &self.types);
+                        params.push(format!("{}: {}", named_field.name, ty))
+                    }
+                    let params = params.join(", ");
+                    format!(
+                        r#"
+    case {name}({params})"#,
+                        name = variant.name,
+                        params = params,
+                    )
                 }
                 StructFields::Unnamed(unnamed_fields) => {
                     let mut params = vec![];

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
@@ -21,7 +21,9 @@ impl SwiftBridgeModule {
                 StructFields::Named(named_fields) => {
                     let mut params = vec![];
                     for named_field in named_fields {
-                        let ty = BridgedType::new_with_type(&named_field.ty, &self.types).unwrap().to_swift_type(TypePosition::SharedStructField, &self.types);
+                        let ty = BridgedType::new_with_type(&named_field.ty, &self.types)
+                            .unwrap()
+                            .to_swift_type(TypePosition::SharedStructField, &self.types);
                         params.push(format!("{}: {}", named_field.name, ty))
                     }
                     let params = params.join(", ");

--- a/crates/swift-integration-tests/src/shared_types/shared_enum.rs
+++ b/crates/swift-integration-tests/src/shared_types/shared_enum.rs
@@ -18,6 +18,21 @@ mod ffi {
     extern "Rust" {
         fn reflect_enum_with_unnamed_data(arg: EnumWithUnnamedData) -> EnumWithUnnamedData;
     }
+
+    enum EnumWithNamedData {
+        Variant1{
+            hello: String, 
+            data_u8: u8,
+        },
+        Variant2{
+            data_i32: i32,
+        },
+        Variant3,
+    }
+
+    extern "Rust" {
+        fn reflect_enum_with_named_data(arg: EnumWithNamedData) -> EnumWithNamedData;
+    }
 }
 
 fn reflect_enum_with_no_data(arg: ffi::EnumWithNoData) -> ffi::EnumWithNoData {
@@ -25,5 +40,9 @@ fn reflect_enum_with_no_data(arg: ffi::EnumWithNoData) -> ffi::EnumWithNoData {
 }
 
 fn reflect_enum_with_unnamed_data(arg: ffi::EnumWithUnnamedData) -> ffi::EnumWithUnnamedData {
+    arg
+}
+
+fn reflect_enum_with_named_data(arg: ffi::EnumWithNamedData) -> ffi::EnumWithNamedData {
     arg
 }

--- a/crates/swift-integration-tests/src/shared_types/shared_enum.rs
+++ b/crates/swift-integration-tests/src/shared_types/shared_enum.rs
@@ -20,13 +20,8 @@ mod ffi {
     }
 
     enum EnumWithNamedData {
-        Variant1{
-            hello: String, 
-            data_u8: u8,
-        },
-        Variant2{
-            data_i32: i32,
-        },
+        Variant1 { hello: String, data_u8: u8 },
+        Variant2 { data_i32: i32 },
         Variant3,
     }
 


### PR DESCRIPTION
This PR addresses #160 and adds support for enums with named data. 

Here's an example of using this.

```rust
#[swift_bridge::bridge]
mod ffi {
    enum EnumWithNamedData {
        Variant1 { hello: String, data_u8: u8 },
        Variant2 { data_i32: i32 },
        Variant3,
    }

    extern "Rust" {
        fn reflect_enum_with_named_data(arg: EnumWithNamedData) -> EnumWithNamedData;
    }
}
```

```Swift
func testEnumWithNamedData() {
    let enumWithNamedData1 = EnumWithNamedData.Variant1(hello: create_string("hello"), data_u8: 123)
    switch reflect_enum_with_named_data(enumWithNamedData1) {
    case .Variant1(let hello, let dataU8):
        XCTAssertEqual(hello.toString(), "hello")
        XCTAssertEqual(dataU8, 123)
    default:
        XCTFail()
    }
}
```