### PR TITLE
Elide types with one FFI representation

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		225908FC28DA0E320080C737 /* ResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 225908FB28DA0E320080C737 /* ResultTests.swift */; };
 		225908FE28DA0F9F0080C737 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 225908FD28DA0F9F0080C737 /* Result.swift */; };
 		226F944B27BF79B400243D86 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226F944A27BF79B400243D86 /* String.swift */; };
+		2289E82C29A879A7009D89D7 /* SingleRepresentationTypeElisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2289E82B29A879A7009D89D7 /* SingleRepresentationTypeElisionTests.swift */; };
 		228FE5D52740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228FE5D42740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift */; };
 		228FE5D72740DB6A00805D9E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228FE5D62740DB6A00805D9E /* ContentView.swift */; };
 		228FE5D92740DB6D00805D9E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 228FE5D82740DB6D00805D9E /* Assets.xcassets */; };
@@ -85,6 +86,7 @@
 		225908FB28DA0E320080C737 /* ResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
 		225908FD28DA0F9F0080C737 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		226F944A27BF79B400243D86 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		2289E82B29A879A7009D89D7 /* SingleRepresentationTypeElisionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleRepresentationTypeElisionTests.swift; sourceTree = "<group>"; };
 		228FE5D12740DB6A00805D9E /* SwiftRustIntegrationTestRunner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftRustIntegrationTestRunner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		228FE5D42740DB6A00805D9E /* SwiftRustIntegrationTestRunnerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftRustIntegrationTestRunnerApp.swift; sourceTree = "<group>"; };
 		228FE5D62740DB6A00805D9E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -218,6 +220,7 @@
 				22FD1C552753CB3F00F64281 /* SwiftFnUsesOpaqueRustTypeTests.swift */,
 				22043292274A8FDF00BAE645 /* VecTests.swift */,
 				22553323281DB5FC008A3121 /* GenericTests.rs.swift */,
+				2289E82B29A879A7009D89D7 /* SingleRepresentationTypeElisionTests.swift */,
 				22EE4E0A28B538A700FEC83C /* SwiftFnUsesOpaqueSwiftTypeTests.swift */,
 				22C0625428CE6C9A007A6F67 /* CallbackTests.swift */,
 				C926E4DF294F18C50027E7E2 /* FunctionAttributeTests.swift */,
@@ -409,6 +412,7 @@
 				C926E4E0294F18C50027E7E2 /* FunctionAttributeTests.swift in Sources */,
 				220432AF274E7BF800BAE645 /* SharedStructTests.swift in Sources */,
 				178F1CD3298E97FB00335AA0 /* ArgumentAttributesTest.swift in Sources */,
+				2289E82C29A879A7009D89D7 /* SingleRepresentationTypeElisionTests.swift in Sources */,
 				220432EC27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift in Sources */,
 				222A81EB28EB5DF800D4A412 /* PrimitiveTests.swift in Sources */,
 				22553324281DB5FC008A3121 /* GenericTests.rs.swift in Sources */,

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
@@ -46,14 +46,14 @@ class AsyncTests: XCTestCase {
         
         // Should return an AsyncResultOpaqueRustType1 type.
         do {
-            let result = try await rust_async_func_reflect_result_opaque_rust(.Ok(AsyncResultOpaqueRustType1(10)))
+            let _ = try await rust_async_func_reflect_result_opaque_rust(.Ok(AsyncResultOpaqueRustType1(10)))
         } catch {
             XCTFail()
         }
         
         // Should throw an AsyncResultOpaqueRustType2 type that conforms to Error protocol.
         do {
-            let result = try await rust_async_func_reflect_result_opaque_rust(.Err(AsyncResultOpaqueRustType2(100)))
+            let _ = try await rust_async_func_reflect_result_opaque_rust(.Err(AsyncResultOpaqueRustType2(100)))
             XCTFail()
         } catch let error as AsyncResultOpaqueRustType2 {
             XCTAssertEqual(error.val(), 100)

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SingleRepresentationTypeElisionTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SingleRepresentationTypeElisionTests.swift
@@ -1,0 +1,29 @@
+//
+//  SingleRepresentationTypeElisionTests.swift
+//  SwiftRustIntegrationTestRunnerTests
+//
+//  Created by Frankie Nwafili on 2/23/23.
+//
+
+import Foundation
+
+import XCTest
+@testable import SwiftRustIntegrationTestRunner
+
+/// Test that we can call functions that have elided single representation types.
+/// See:
+///   - crates/swift-bridge-ir/src/codegen/codegen_tests/single_representation_type_elision_codegen_tests.rs
+///   - crates/swift-integration-tests/src/single_representation_type_elision.rs
+final class SingleRepresentationTypeElisionTest: XCTestCase {
+    /// Verify that we can call functions that take the null type.
+    func testSwiftCallsRustNullType() throws {
+        let _: () = rust_one_null_arg(())
+        let _: () = rust_two_null_args((), ())
+    }
+    
+    /// Verify that we can call functions that take a unit struct.
+    func testSwiftCallsRustUnitStruct() throws {
+        let _: SingleReprTestUnitStruct = rust_one_unit_struct(SingleReprTestUnitStruct())
+        let _: SingleReprTestUnitStruct = rust_two_unit_structs(SingleReprTestUnitStruct(), SingleReprTestUnitStruct())
+    }
+}

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
@@ -1,4 +1,4 @@
-use crate::bridged_type::{BridgeableType, TypePosition, UnusedOptionNoneValue};
+use crate::bridged_type::{BridgeableType, OnlyEncoding, TypePosition, UnusedOptionNoneValue};
 use crate::TypeDeclarations;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
@@ -10,6 +10,10 @@ pub(crate) struct BridgedString;
 impl BridgeableType for BridgedString {
     fn is_built_in_type(&self) -> bool {
         true
+    }
+
+    fn only_encoding(&self) -> Option<OnlyEncoding> {
+        None
     }
 
     fn is_result(&self) -> bool {

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
@@ -1,4 +1,4 @@
-use crate::bridged_type::{BridgeableType, TypePosition, UnusedOptionNoneValue};
+use crate::bridged_type::{BridgeableType, OnlyEncoding, TypePosition, UnusedOptionNoneValue};
 use crate::parse::{HostLang, OpaqueRustTypeGenerics};
 use crate::{TypeDeclarations, SWIFT_BRIDGE_PREFIX};
 use proc_macro2::{Ident, Span, TokenStream};
@@ -20,6 +20,10 @@ pub(crate) struct OpaqueForeignType {
 impl BridgeableType for OpaqueForeignType {
     fn is_built_in_type(&self) -> bool {
         false
+    }
+
+    fn only_encoding(&self) -> Option<OnlyEncoding> {
+        None
     }
 
     fn is_result(&self) -> bool {

--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
@@ -1,4 +1,4 @@
-use crate::bridged_type::{BridgedType, TypePosition};
+use crate::bridged_type::{BridgedType, OnlyEncoding, TypePosition};
 use crate::parse::TypeDeclarations;
 use crate::SWIFT_BRIDGE_PREFIX;
 use proc_macro2::{Ident, Span, TokenStream};
@@ -62,6 +62,24 @@ impl SharedStruct {
             SWIFT_BRIDGE_PREFIX,
             self.swift_name_string()
         )
+    }
+
+    /// Some if the struct has a single variant.
+    /// TODO: If all of the struct's fields have an `OnlyEncoding`, then the struct has exactly
+    ///  one encoding as well.
+    pub fn only_encoding(&self) -> Option<OnlyEncoding> {
+        let has_fields = !self.fields.is_empty();
+        if has_fields || self.already_declared {
+            return None;
+        }
+
+        let struct_name = &self.name;
+        let empty_fields = self.fields.empty_field_wrapper();
+
+        Some(OnlyEncoding {
+            swift: format!("{}()", self.swift_name_string()),
+            rust: quote! {#struct_name #empty_fields},
+        })
     }
 }
 

--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct/struct_field.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct/struct_field.rs
@@ -63,6 +63,25 @@ impl StructFields {
         }
     }
 
+    /// Given the struct name "SomeStruct".
+    ///
+    /// Unit -> ""
+    /// Named -> "{ }"
+    /// Unnamed -> "()"
+    pub fn empty_field_wrapper(&self) -> TokenStream {
+        match self {
+            StructFields::Named(_) => {
+                quote! { {} }
+            }
+            StructFields::Unnamed(_) => {
+                quote! { () }
+            }
+            StructFields::Unit => {
+                quote! {}
+            }
+        }
+    }
+
     pub fn from_syn_fields(fields: Fields) -> Self {
         match fields {
             Fields::Named(f) => {

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests.rs
@@ -43,6 +43,7 @@ mod opaque_swift_type_codegen_tests;
 mod option_codegen_tests;
 mod result_codegen_tests;
 mod return_into_attribute_codegen_tests;
+mod single_representation_type_elision_codegen_tests;
 mod string_codegen_tests;
 mod transparent_enum_codegen_tests;
 mod transparent_struct_codegen_tests;

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/async_function_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/async_function_codegen_tests.rs
@@ -362,7 +362,9 @@ mod extern_rust_async_function_returns_struct {
         quote! {
             #[swift_bridge::bridge]
             mod ffi {
-                struct SomeStruct;
+                struct SomeStruct {
+                    field: u8
+                }
 
                 extern "Rust" {
                     async fn some_function() -> SomeStruct;

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/function_attribute_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/function_attribute_codegen_tests.rs
@@ -10,7 +10,9 @@ mod function_args_into_attribute {
         quote! {
             mod ffi {
                 #[swift_bridge(swift_name = "SomeStruct")]
-                struct FfiSomeStruct;
+                struct FfiSomeStruct {
+                    field: u16
+                }
 
                 #[swift_bridge(swift_name = "AnotherStruct")]
                 struct FfiAnotherStruct(u8);
@@ -73,7 +75,9 @@ mod return_into_attribute_for_shared_struct {
             #[swift_bridge::bridge]
             mod ffi {
                 #[swift_bridge(swift_name = "StructRename1")]
-                struct StructName1;
+                struct StructName1 {
+                    field: u8
+                }
 
                 extern "Rust" {
                     #[swift_bridge(return_into)]

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/single_representation_type_elision_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/single_representation_type_elision_codegen_tests.rs
@@ -1,0 +1,168 @@
+//! Tests that verify that when generating functions we elide types that have exactly one
+//! representation.
+//!
+//! See crates/swift-integration-tests/src/single_representation_type_elision.rs
+
+use super::{CodegenTest, ExpectedCHeader, ExpectedRustTokens, ExpectedSwiftCode};
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Verify that we elide null type arguments when generating the FFI glue for functions.
+mod elides_null_type {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            #[swift_bridge::bridge]
+            mod ffi {
+                extern "Rust" {
+                    fn rust_function(arg1: (), arg2: ()) -> ();
+                }
+
+                extern "Swift" {
+                    fn swift_function(arg1: (), arg2: ()) -> ();
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::ContainsMany(vec![
+            quote! {
+                pub extern "C" fn __swift_bridge__rust_function() {
+                    super::rust_function((), ())
+                }
+            },
+            //
+            quote! {
+                fn swift_function(_arg1: (), _arg2: ()) -> () {
+                    unsafe { __swift_bridge__swift_function() }
+                }
+            },
+            quote! {
+                fn __swift_bridge__swift_function();
+            },
+        ])
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsManyAfterTrim(vec![
+            r#"
+public func rust_function(_ arg1: (), _ arg2: ()) -> () {
+    __swift_bridge__$rust_function()
+}
+"#,
+            r#"
+@_cdecl("__swift_bridge__$swift_function")
+func __swift_bridge__swift_function () {
+    swift_function(arg1: (), arg2: ())
+}
+"#,
+        ])
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ContainsAfterTrim(
+            r#"
+void __swift_bridge__$rust_function(void);
+"#,
+        )
+    }
+
+    #[test]
+    fn elides_null_type() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}
+
+/// Verify that we elide unit struct arguments when generating the FFI glue for functions.
+mod elides_unit_struct {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            #[swift_bridge::bridge]
+            mod ffi {
+                struct UnitStruct1;
+                struct UnitStruct2 {}
+                struct UnitStruct3();
+
+                extern "Rust" {
+                    fn rust_function(
+                        arg1: UnitStruct1,
+                        arg2: UnitStruct2,
+                        arg3: UnitStruct3,
+                    ) -> UnitStruct1;
+                }
+
+                extern "Swift" {
+                     fn swift_function(
+                        arg1: UnitStruct1,
+                        arg2: UnitStruct2,
+                        arg3: UnitStruct3,
+                    ) -> UnitStruct1;
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::ContainsMany(vec![
+            quote! {
+                fn __swift_bridge__rust_function() {
+                    {super::rust_function(UnitStruct1, UnitStruct2 {}, UnitStruct3());}
+                }
+            },
+            //
+            quote! {
+                fn swift_function(_arg1: UnitStruct1, _arg2: UnitStruct2, _arg3: UnitStruct3) -> UnitStruct1 {
+                    {unsafe { __swift_bridge__swift_function() }; UnitStruct1}
+                }
+            },
+            quote! {
+                fn __swift_bridge__swift_function();
+            },
+        ])
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsManyAfterTrim(vec![
+            r#"
+public func rust_function(_ arg1: UnitStruct1, _ arg2: UnitStruct2, _ arg3: UnitStruct3) -> UnitStruct1 {
+    { let _ = __swift_bridge__$rust_function(); return UnitStruct1() }()
+}
+"#,
+            r#"
+@_cdecl("__swift_bridge__$swift_function")
+func __swift_bridge__swift_function () {
+    { let _ = swift_function(arg1: UnitStruct1(), arg2: UnitStruct2(), arg3: UnitStruct3()); }()
+}
+"#,
+        ])
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ContainsAfterTrim(
+            r#"
+void __swift_bridge__$rust_function(void);
+"#,
+        )
+    }
+
+    #[test]
+    fn elides_unit_struct() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}

--- a/crates/swift-bridge-ir/src/parsed_extern_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn.rs
@@ -1,5 +1,5 @@
 use crate::bridged_type::boxed_fn::BridgeableBoxedFnOnce;
-use crate::bridged_type::{pat_type_pat_is_self, BridgedType, StdLibType};
+use crate::bridged_type::{pat_type_pat_is_self, BridgeableType, BridgedType, StdLibType};
 use crate::parse::{HostLang, SharedTypeDeclaration, TypeDeclaration, TypeDeclarations};
 use crate::SWIFT_BRIDGE_PREFIX;
 use proc_macro2::{Ident, Span, TokenStream};
@@ -163,12 +163,12 @@ impl ParsedExternFn {
         let sig = &self.func.sig;
 
         if let Some(ret) = BridgedType::new_with_return_type(&sig.output, types) {
-            let ty = ret.to_ffi_compatible_rust_type(swift_bridge_path, types);
-            if ty.to_string() == "()" {
-                quote! {}
-            } else {
-                quote! { -> #ty }
+            if ret.has_exactly_one_encoding() {
+                return quote! {};
             }
+
+            let ty = ret.to_ffi_compatible_rust_type(swift_bridge_path, types);
+            quote! { -> #ty }
         } else {
             todo!("Push to ParseErrors")
         }
@@ -251,7 +251,7 @@ impl ParsedExternFn {
     ) -> TokenStream {
         let mut args = vec![];
         let inputs = &self.func.sig.inputs;
-        for fn_arg in inputs {
+        for fn_arg in inputs.into_iter() {
             match fn_arg {
                 FnArg::Receiver(_receiver) => {
                     if self.host_lang.is_swift() {
@@ -273,12 +273,16 @@ impl ParsedExternFn {
 
                     if let Some(built_in) = BridgedType::new_with_type(&pat_ty.ty, types) {
                         if self.host_lang.is_rust() {
-                            arg = built_in.convert_ffi_expression_to_rust_type(
-                                &arg,
-                                pat_ty.ty.span(),
-                                swift_bridge_path,
-                                types,
-                            );
+                            arg = if let Some(repr) = built_in.only_encoding() {
+                                repr.rust
+                            } else {
+                                built_in.convert_ffi_expression_to_rust_type(
+                                    &arg,
+                                    pat_ty.ty.span(),
+                                    swift_bridge_path,
+                                    types,
+                                )
+                            };
 
                             if self.args_into_contains_arg(fn_arg) {
                                 arg = quote_spanned! {pat_ty.span()=>
@@ -286,6 +290,10 @@ impl ParsedExternFn {
                                 };
                             }
                         } else {
+                            if built_in.has_exactly_one_encoding() {
+                                continue;
+                            }
+
                             arg = built_in.convert_rust_expression_to_ffi_type(
                                 &arg,
                                 swift_bridge_path,
@@ -326,6 +334,11 @@ impl ParsedExternFn {
                         self.push_self_param(&mut params);
                     } else {
                         let built_in = BridgedType::new_with_type(&pat_ty.ty, types).unwrap();
+
+                        if built_in.has_exactly_one_encoding() {
+                            continue;
+                        }
+
                         let ty = built_in.to_c();
 
                         let arg_name = pat.to_token_stream().to_string();
@@ -347,6 +360,10 @@ impl ParsedExternFn {
             ReturnType::Default => "void".to_string(),
             ReturnType::Type(_, ty) => {
                 if let Some(ty) = BridgedType::new_with_type(&ty, types) {
+                    if ty.has_exactly_one_encoding() {
+                        return "void".to_string();
+                    }
+
                     ty.to_c()
                 } else {
                     let ty_string = match ty.deref() {

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_param_names_and_types.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_param_names_and_types.rs
@@ -1,4 +1,4 @@
-use crate::bridged_type::{pat_type_pat_is_self, BridgedType};
+use crate::bridged_type::{pat_type_pat_is_self, BridgeableType, BridgedType};
 use crate::parse::{HostLang, TypeDeclaration, TypeDeclarations};
 use crate::parsed_extern_fn::ParsedExternFn;
 use proc_macro2::{Ident, TokenStream};
@@ -41,9 +41,15 @@ impl ParsedExternFn {
 
                     if !pat_ty_is_self {
                         if let Some(built_in) = BridgedType::new_with_type(&pat_ty.ty, types) {
+                            if built_in.has_exactly_one_encoding() {
+                                continue;
+                            }
+
                             let pat = &pat_ty.pat;
                             let ty = built_in.to_ffi_compatible_rust_type(swift_bridge_path, types);
+
                             params.push(quote! { #pat: #ty});
+
                             continue;
                         } else {
                             todo!("Push to ParsedErrors")

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_rust_impl_call_swift.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_rust_impl_call_swift.rs
@@ -1,8 +1,8 @@
-use crate::bridged_type::{pat_type_pat_is_self, BridgedType};
+use crate::bridged_type::{pat_type_pat_is_self, BridgeableType, BridgedType};
 use crate::parse::{SharedTypeDeclaration, TypeDeclaration, TypeDeclarations};
 use crate::parsed_extern_fn::ParsedExternFn;
 use proc_macro2::{Ident, Span, TokenStream};
-use quote::{quote, quote_spanned};
+use quote::{quote, quote_spanned, ToTokens};
 use std::ops::Deref;
 use syn::spanned::Spanned;
 use syn::{FnArg, PatType, Path, ReturnType, Type, TypeReference};
@@ -205,6 +205,20 @@ impl ParsedExternFn {
 
                             if let Some(built_in) = BridgedType::new_with_fn_arg(fn_arg, types) {
                                 let ty = built_in.maybe_convert_pointer_to_super_pointer();
+
+                                let maybe_unused = if built_in.has_exactly_one_encoding() {
+                                    "_"
+                                } else {
+                                    ""
+                                };
+                                let pat = Ident::new(
+                                    &format!(
+                                        "{}{}",
+                                        maybe_unused,
+                                        pat.to_token_stream().to_string()
+                                    ),
+                                    pat.span(),
+                                );
 
                                 quote! { #pat: #ty}
                             } else {

--- a/crates/swift-integration-tests/src/async_function.rs
+++ b/crates/swift-integration-tests/src/async_function.rs
@@ -1,6 +1,9 @@
 #[swift_bridge::bridge]
 mod ffi {
-    struct AsyncRustFnReturnStruct;
+    #[swift_bridge(swift_repr = "struct")]
+    struct AsyncRustFnReturnStruct {
+        field: u8,
+    }
 
     extern "Rust" {
         async fn rust_async_return_null();
@@ -48,7 +51,7 @@ async fn rust_async_reflect_string(string: String) -> String {
 }
 
 async fn rust_async_return_struct() -> ffi::AsyncRustFnReturnStruct {
-    ffi::AsyncRustFnReturnStruct
+    ffi::AsyncRustFnReturnStruct { field: 123 }
 }
 
 pub struct TestRustAsyncSelf;

--- a/crates/swift-integration-tests/src/lib.rs
+++ b/crates/swift-integration-tests/src/lib.rs
@@ -11,6 +11,7 @@ mod primitive;
 mod result;
 mod rust_function_uses_opaque_swift_type;
 mod shared_types;
+mod single_representation_type_elision;
 mod slice;
 mod string;
 mod swift_function_uses_opaque_rust_type;

--- a/crates/swift-integration-tests/src/single_representation_type_elision.rs
+++ b/crates/swift-integration-tests/src/single_representation_type_elision.rs
@@ -1,0 +1,38 @@
+/// Tests that we can pass types that has exactly one FFI representation to/from Swift.
+///
+/// We test this explicitly since our codegen elides types that have exactly one representation.
+///
+/// See crates/swift-bridge-ir/src/codegen/codegen_tests/single_representation_type_elision_codegen_tests.rs
+#[swift_bridge::bridge]
+mod ffi {
+    struct SingleReprTestUnitStruct;
+
+    extern "Rust" {
+        fn rust_one_null_arg(arg: ()) -> ();
+        fn rust_two_null_args(arg1: (), arg2: ()) -> ();
+
+        fn rust_one_unit_struct(arg: SingleReprTestUnitStruct) -> SingleReprTestUnitStruct;
+        fn rust_two_unit_structs(
+            arg1: SingleReprTestUnitStruct,
+            arg2: SingleReprTestUnitStruct,
+        ) -> SingleReprTestUnitStruct;
+    }
+}
+use ffi::SingleReprTestUnitStruct;
+
+fn rust_one_null_arg(_arg: ()) -> () {
+    ()
+}
+fn rust_two_null_args(_arg1: (), _arg2: ()) -> () {
+    ()
+}
+
+fn rust_one_unit_struct(_arg: SingleReprTestUnitStruct) -> SingleReprTestUnitStruct {
+    SingleReprTestUnitStruct
+}
+fn rust_two_unit_structs(
+    _arg1: SingleReprTestUnitStruct,
+    _arg2: SingleReprTestUnitStruct,
+) -> SingleReprTestUnitStruct {
+    SingleReprTestUnitStruct
+}


### PR DESCRIPTION
This commit modifies our codegen to elide arguments and return types
that have exactly one FFI representation, such as `()` `struct Foo;` and
`enum MyEnum { OneVariant }`.

For example, the following bridge module:

```rust
#[swift_bridge::bridge]
mod ffi {
    struct UnitStruct1;
    struct UnitStruct2{};
    struct UnitStruct3();

    extern "Rust" {
        fn some_function(
            arg1: UnitStruct1,
            arg2: UnitStruct2,
            arg3: UnitStruct3,
        ) -> UnitStruct1;
    }
}
```

Will now generate the following foreign function interface:

```rust
#[link_name = "__swift_bridge__$some_function"]
pub extern "C" fn __swift_bridge__some_function() {
    {super::some_function(UnitStruct1, UnitStruct2, UnitStruct3); ()}
}
```

Notice that the extern function does not take any arguments.

This is invisible to the user, since they'll call a function that looks
like:

```swift
// Swift (generated code)

func some_function(arg1: UnitStruct1, arg2: UnitStruct2, arg3: UnitStruct3) -> UnitStruct1 {
    { let _ = __swift_bridge__$some_function(); UnitStruct1() }()
}
```

---

Zero-sized types are not C FFI safe, so bridging them
requires some degree of shenanigans.

Before this commit we would bridge unit structs using an unused `u8`.
This meant that we would waste one byte of memory per bridged
transparent struct instance.

Now, to be fair, this was fairly tiny overhead, and an unimaginably
small number of users should ever have a use case where they're bridging
enough empty structs for a single byte of overhead per struct to be
noticed.

But, where's the fun in wasted memory?

As of this commit unit structs and other types that have a single
possible FFI representation have a 0 byte FFI representation since
we don't bridge them at all and they instead just "appear" on the
other side of the boundary.

---

While implementing this change we added a
`.has_exactly_one_representation(&self) -> bool` method to the
`BridgeableType` trait.

This will be useful in the future for other use cases where knowing that
a type has exactly one FFI representation is important.

For example, we plan to implement support for `Result<(), E>` in the future.
When `E` is a type that is bridged via a pointer, `Result<(), E>` can be
bridged using a single pointer, since the `T = ()` case can be encoded as
a null pointer.

This generalizes for any `T` where `T` is a type that has exactly one
FFI representation.

Notably, this includes single variant enums such as
`MyEnum { OneVariant }`.

Although, perhaps not that notably, since I'm still not sure whether
anyone will have an FFI use case that involves bridging single-repr
types.

Who knows. Developers will surprise you.
