### PR TITLE
Support returning Result<(), OpaqueRust> from Rust functions

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
@@ -40,4 +40,16 @@ class ResultTests: XCTestCase {
             .Err(ResultTestOpaqueSwiftType(val: 666))
         )
     }
+
+    /// Verify that we can receive a Result<(), OpaqueRust> from Rust
+    func testSwiftCallRustResultNullOpaqueRust() throws {
+        try! rust_func_return_result_null_opaque_rust(true)
+
+        do {
+            try rust_func_return_result_null_opaque_rust(false)
+            XCTFail("The function should have returned an error.")
+        } catch let error as ResultTestOpaqueRustType {
+            XCTAssertEqual(error.val(), 222)
+        }
+    }
 }

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
@@ -52,4 +52,16 @@ class ResultTests: XCTestCase {
             XCTAssertEqual(error.val(), 222)
         }
     }
+
+    /// Verify that we can receive a Result<UnitStruct, OpaqueRust> from Rust
+    func testSwiftCallRustResultUnitStructOpaqueRust() throws {
+        try! rust_func_return_result_unit_struct_opaque_rust(true)
+
+        do {
+            try rust_func_return_result_unit_struct_opaque_rust(false)
+            XCTFail("The function should have returned an error.")
+        } catch let error as ResultTestOpaqueRustType {
+            XCTAssertEqual(error.val(), 222)
+        }
+    }
 }

--- a/crates/swift-bridge-build/src/generate_core.rs
+++ b/crates/swift-bridge-build/src/generate_core.rs
@@ -1,7 +1,9 @@
 use crate::generate_core::boxed_fn_support::{
     C_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN, SWIFT_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN,
 };
-use crate::generate_core::result_support::{C_RESULT_SUPPORT, SWIFT_RUST_RESULT};
+use crate::generate_core::result_support::{
+    C_RESULT_SUPPORT, C_RESULT_VOID_SUPPORT, SWIFT_RUST_RESULT,
+};
 use std::path::Path;
 
 const RUST_STRING_SWIFT: &'static str = include_str!("./generate_core/rust_string.swift");
@@ -33,6 +35,8 @@ pub(super) fn write_core_swift_and_c(out_dir: &Path) {
     c_header += &C_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN;
     c_header += "\n";
     c_header += &C_RESULT_SUPPORT;
+    c_header += "\n";
+    c_header += &C_RESULT_VOID_SUPPORT;
 
     std::fs::write(core_c_header_out, c_header).unwrap();
 }

--- a/crates/swift-bridge-build/src/generate_core/result_support.rs
+++ b/crates/swift-bridge-build/src/generate_core/result_support.rs
@@ -38,3 +38,7 @@ extension RustResult {
 pub const C_RESULT_SUPPORT: &'static str = r#"
 struct __private__ResultPtrAndPtr { bool is_ok; void* ok_or_err; };
 "#;
+
+pub const C_RESULT_VOID_SUPPORT: &'static str = r#"
+struct __private__ResultVoidAndPtr { bool is_ok; void* err; };
+"#;

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -58,7 +58,7 @@ pub(crate) trait BridgeableType: Debug {
         !self.is_built_in_type()
     }
 
-    /// Whether or not this type can be encoded to exactly one representation,;
+    /// Whether or not this type can be encoded to exactly one representation,
     /// and therefore can be encoded with zero bytes.
     /// For example `()` and `struct Foo;` can have exactly one representation,
     /// but `u8` cannot since there are 255 possible `u8`s.

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -58,10 +58,11 @@ pub(crate) trait BridgeableType: Debug {
         !self.is_built_in_type()
     }
 
-    /// Whether or not this type can be encoded to exactly one representation.
+    /// Whether or not this type can be encoded to exactly one representation,;
+    /// and therefore can be encoded with zero bytes.
     /// For example `()` and `struct Foo;` can have exactly one representation,
     /// but `u8` cannot since there are 255 possible `u8`s.
-    fn has_exactly_one_encoding(&self) -> bool {
+    fn can_be_encoded_with_zero_bytes(&self) -> bool {
         self.only_encoding().is_some()
     }
 

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
@@ -66,7 +66,7 @@ impl BuiltInResult {
                     Ok(ok) => {
                         #swift_bridge_path::result::ResultVoidAndPtr {
                             is_ok: true,
-                            err: 0 as *mut std::ffi::c_void
+                            err: std::ptr::null_mut::<std::ffi::c_void>()
                         }
                     }
                     Err(err) => {

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
@@ -154,7 +154,7 @@ impl BuiltInResult {
         type_pos: TypePosition,
         types: &TypeDeclarations,
     ) -> String {
-        let (ok, err) = if let Some(zero_byte_encoding) = self.ok_ty.only_encoding() {
+        let (mut ok, err) = if let Some(zero_byte_encoding) = self.ok_ty.only_encoding() {
             let ok = zero_byte_encoding.swift;
             let convert_err = self
                 .err_ty
@@ -171,6 +171,22 @@ impl BuiltInResult {
 
             (convert_ok, convert_err)
         };
+
+        // There is a Swift compiler bug in Xcode 13 where using an explicit `()` here somehow leads
+        // the Swift compiler to a compile time error:
+        // "Unable to infer complex closure return type; add explicit type to disambiguate"
+        //
+        // It's asking us to add a `{ () -> () in .. }` explicit type to the beginning of our closure.
+        //
+        // To solve this bug we can either add that explicit closure type, or remove the explicit
+        // `return ()` in favor of a `return`.. Not sure why making the return type less explicit
+        //  solves the compile time error.. But it does..
+        //
+        // As mentioned, this doesn't seem to happen in Xcode 14.
+        // So, we can remove this if statement whenever we stop supporting Xcode 13.
+        if self.ok_ty.is_null() {
+            ok = "".to_string();
+        }
 
         format!(
             "try {{ let val = {expression}; if val.is_ok {{ return {ok} }} else {{ throw {err} }} }}()",

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/result_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/result_codegen_tests.rs
@@ -289,7 +289,7 @@ mod extern_rust_fn_return_result_null_and_opaque_rust {
                     Ok(ok) => {
                         swift_bridge::result::ResultVoidAndPtr {
                             is_ok: true,
-                            err: 0 as *mut std::ffi::c_void
+                            err: std::ptr::null_mut::<std::ffi::c_void>()
                         }
                     }
                     Err(err) => {

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/result_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/result_codegen_tests.rs
@@ -263,3 +263,73 @@ void __swift_bridge__$some_function(struct __private__ResultPtrAndPtr arg);
         .test();
     }
 }
+
+/// Test code generation for Rust function that accepts a Result<T, E> where T is (), and E is an
+/// opaque Rust type.
+mod extern_rust_fn_return_result_null_and_opaque_rust {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            mod ffi {
+                extern "Rust" {
+                    type SomeType;
+
+                    fn some_function () -> Result<(), SomeType>;
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::Contains(quote! {
+            #[export_name = "__swift_bridge__$some_function"]
+            pub extern "C" fn __swift_bridge__some_function() -> swift_bridge::result::ResultVoidAndPtr {
+                match super::some_function() {
+                    Ok(ok) => {
+                        swift_bridge::result::ResultVoidAndPtr {
+                            is_ok: true,
+                            err: 0 as *mut std::ffi::c_void
+                        }
+                    }
+                    Err(err) => {
+                        swift_bridge::result::ResultVoidAndPtr {
+                            is_ok: false,
+                            err: Box::into_raw(Box::new({
+                                let val: super::SomeType = err;
+                                val
+                            })) as *mut super::SomeType as *mut std::ffi::c_void
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(
+            r#"
+public func some_function() throws -> () {
+    try { let val = __swift_bridge__$some_function(); if val.is_ok { return } else { throw SomeType(ptr: val.err!) } }()
+}
+"#,
+        )
+    }
+
+    const EXPECTED_C_HEADER: ExpectedCHeader = ExpectedCHeader::ContainsAfterTrim(
+        r#"
+struct __private__ResultVoidAndPtr __swift_bridge__$some_function(void);
+    "#,
+    );
+
+    #[test]
+    fn extern_rust_fn_return_result_opaque_rust() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: EXPECTED_C_HEADER,
+        }
+        .test();
+    }
+}

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/result_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/result_codegen_tests.rs
@@ -264,7 +264,7 @@ void __swift_bridge__$some_function(struct __private__ResultPtrAndPtr arg);
     }
 }
 
-/// Test code generation for Rust function that accepts a Result<T, E> where T is (), and E is an
+/// Test code generation for Rust function that accepts a Result<(), E> where E is an
 /// opaque Rust type.
 mod extern_rust_fn_return_result_null_and_opaque_rust {
     use super::*;
@@ -310,7 +310,7 @@ mod extern_rust_fn_return_result_null_and_opaque_rust {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 public func some_function() throws -> () {
-    try { let val = __swift_bridge__$some_function(); if val.is_ok { return } else { throw SomeType(ptr: val.err!) } }()
+    try { let val = __swift_bridge__$some_function(); if val.is_ok { return () } else { throw SomeType(ptr: val.err!) } }()
 }
 "#,
         )
@@ -324,6 +324,77 @@ struct __private__ResultVoidAndPtr __swift_bridge__$some_function(void);
 
     #[test]
     fn extern_rust_fn_return_result_opaque_rust() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: EXPECTED_C_HEADER,
+        }
+        .test();
+    }
+}
+
+// Test code generation for Rust function that accepts a Result<T, E> where T is a UnitStruct and E is an
+/// opaque Rust type.
+mod extern_rust_fn_return_result_unit_and_opaque_rust {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            mod ffi {
+                struct UnitType;
+                extern "Rust" {
+                    type SomeType;
+
+                    fn some_function () -> Result<UnitType, SomeType>;
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::Contains(quote! {
+            #[export_name = "__swift_bridge__$some_function"]
+            pub extern "C" fn __swift_bridge__some_function() -> swift_bridge::result::ResultVoidAndPtr {
+                match super::some_function() {
+                    Ok(ok) => {
+                        swift_bridge::result::ResultVoidAndPtr {
+                            is_ok: true,
+                            err: std::ptr::null_mut::<std::ffi::c_void>()
+                        }
+                    }
+                    Err(err) => {
+                        swift_bridge::result::ResultVoidAndPtr {
+                            is_ok: false,
+                            err: Box::into_raw(Box::new({
+                                let val: super::SomeType = err;
+                                val
+                            })) as *mut super::SomeType as *mut std::ffi::c_void
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(
+            r#"
+public func some_function() throws -> UnitType {
+    try { let val = __swift_bridge__$some_function(); if val.is_ok { return UnitType() } else { throw SomeType(ptr: val.err!) } }()
+}
+"#,
+        )
+    }
+
+    const EXPECTED_C_HEADER: ExpectedCHeader = ExpectedCHeader::ContainsAfterTrim(
+        r#"
+struct __private__ResultVoidAndPtr __swift_bridge__$some_function(void);
+    "#,
+    );
+
+    #[test]
+    fn extern_rust_fn_return_result_unit_and_opaque_rust() {
         CodegenTest {
             bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/result_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/result_codegen_tests.rs
@@ -310,7 +310,7 @@ mod extern_rust_fn_return_result_null_and_opaque_rust {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 public func some_function() throws -> () {
-    try { let val = __swift_bridge__$some_function(); if val.is_ok { return () } else { throw SomeType(ptr: val.err!) } }()
+    try { let val = __swift_bridge__$some_function(); if val.is_ok { return  } else { throw SomeType(ptr: val.err!) } }()
 }
 "#,
         )

--- a/crates/swift-bridge-ir/src/parsed_extern_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn.rs
@@ -163,7 +163,7 @@ impl ParsedExternFn {
         let sig = &self.func.sig;
 
         if let Some(ret) = BridgedType::new_with_return_type(&sig.output, types) {
-            if ret.has_exactly_one_encoding() {
+            if ret.can_be_encoded_with_zero_bytes() {
                 return quote! {};
             }
 
@@ -290,7 +290,7 @@ impl ParsedExternFn {
                                 };
                             }
                         } else {
-                            if built_in.has_exactly_one_encoding() {
+                            if built_in.can_be_encoded_with_zero_bytes() {
                                 continue;
                             }
 
@@ -335,7 +335,7 @@ impl ParsedExternFn {
                     } else {
                         let built_in = BridgedType::new_with_type(&pat_ty.ty, types).unwrap();
 
-                        if built_in.has_exactly_one_encoding() {
+                        if built_in.can_be_encoded_with_zero_bytes() {
                             continue;
                         }
 
@@ -360,7 +360,7 @@ impl ParsedExternFn {
             ReturnType::Default => "void".to_string(),
             ReturnType::Type(_, ty) => {
                 if let Some(ty) = BridgedType::new_with_type(&ty, types) {
-                    if ty.has_exactly_one_encoding() {
+                    if ty.can_be_encoded_with_zero_bytes() {
                         return "void".to_string();
                     }
 

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_param_names_and_types.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_param_names_and_types.rs
@@ -41,7 +41,7 @@ impl ParsedExternFn {
 
                     if !pat_ty_is_self {
                         if let Some(built_in) = BridgedType::new_with_type(&pat_ty.ty, types) {
-                            if built_in.has_exactly_one_encoding() {
+                            if built_in.can_be_encoded_with_zero_bytes() {
                                 continue;
                             }
 

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_rust_impl_call_swift.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_rust_impl_call_swift.rs
@@ -206,7 +206,7 @@ impl ParsedExternFn {
                             if let Some(built_in) = BridgedType::new_with_fn_arg(fn_arg, types) {
                                 let ty = built_in.maybe_convert_pointer_to_super_pointer();
 
-                                let maybe_unused = if built_in.has_exactly_one_encoding() {
+                                let maybe_unused = if built_in.can_be_encoded_with_zero_bytes() {
                                     "_"
                                 } else {
                                     ""

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_swift_func.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_swift_func.rs
@@ -35,7 +35,7 @@ impl ParsedExternFn {
 
                     let ty = if let Some(built_in) = BridgedType::new_with_type(&pat_ty.ty, types) {
                         if self.host_lang.is_swift() {
-                            if built_in.has_exactly_one_encoding() {
+                            if built_in.can_be_encoded_with_zero_bytes() {
                                 continue;
                             }
                         }
@@ -103,7 +103,7 @@ impl ParsedExternFn {
                     let arg =
                         if let Some(bridged_ty) = BridgedType::new_with_type(&pat_ty.ty, types) {
                             if self.host_lang.is_rust() {
-                                if bridged_ty.has_exactly_one_encoding() {
+                                if bridged_ty.can_be_encoded_with_zero_bytes() {
                                     continue;
                                 }
 
@@ -144,7 +144,7 @@ impl ParsedExternFn {
             ReturnType::Type(_, ty) => {
                 if let Some(built_in) = BridgedType::new_with_type(&ty, types) {
                     if self.host_lang.is_swift() {
-                        if built_in.has_exactly_one_encoding() {
+                        if built_in.can_be_encoded_with_zero_bytes() {
                             return "".to_string();
                         }
                     }

--- a/crates/swift-integration-tests/src/result.rs
+++ b/crates/swift-integration-tests/src/result.rs
@@ -12,6 +12,9 @@ mod ffi {
             arg: Result<ResultTestOpaqueSwiftType, ResultTestOpaqueSwiftType>,
         );
 
+        fn rust_func_return_result_null_opaque_rust(
+            succeed: bool,
+        ) -> Result<(), ResultTestOpaqueRustType>;
     }
 
     extern "Rust" {
@@ -65,6 +68,14 @@ fn rust_func_takes_result_opaque_swift(
         Err(err) => {
             assert_eq!(err.val(), 666)
         }
+    }
+}
+
+fn rust_func_return_result_null_opaque_rust(succeed: bool) -> Result<(), ResultTestOpaqueRustType> {
+    if succeed {
+        Ok(())
+    } else {
+        Err(ResultTestOpaqueRustType { val: 222 })
     }
 }
 

--- a/crates/swift-integration-tests/src/result.rs
+++ b/crates/swift-integration-tests/src/result.rs
@@ -2,6 +2,8 @@
 
 #[swift_bridge::bridge]
 mod ffi {
+    struct UnitStruct;
+
     extern "Rust" {
         fn rust_func_reflect_result_opaque_rust(
             arg: Result<ResultTestOpaqueRustType, ResultTestOpaqueRustType>,
@@ -15,6 +17,10 @@ mod ffi {
         fn rust_func_return_result_null_opaque_rust(
             succeed: bool,
         ) -> Result<(), ResultTestOpaqueRustType>;
+
+        fn rust_func_return_result_unit_struct_opaque_rust(
+            succeed: bool,
+        ) -> Result<UnitStruct, ResultTestOpaqueRustType>;
     }
 
     extern "Rust" {
@@ -74,6 +80,16 @@ fn rust_func_takes_result_opaque_swift(
 fn rust_func_return_result_null_opaque_rust(succeed: bool) -> Result<(), ResultTestOpaqueRustType> {
     if succeed {
         Ok(())
+    } else {
+        Err(ResultTestOpaqueRustType { val: 222 })
+    }
+}
+
+fn rust_func_return_result_unit_struct_opaque_rust(
+    succeed: bool,
+) -> Result<ffi::UnitStruct, ResultTestOpaqueRustType> {
+    if succeed {
+        Ok(ffi::UnitStruct {})
     } else {
         Err(ResultTestOpaqueRustType { val: 222 })
     }

--- a/crates/swift-integration-tests/src/result.rs
+++ b/crates/swift-integration-tests/src/result.rs
@@ -89,7 +89,7 @@ fn rust_func_return_result_unit_struct_opaque_rust(
     succeed: bool,
 ) -> Result<ffi::UnitStruct, ResultTestOpaqueRustType> {
     if succeed {
-        Ok(ffi::UnitStruct {})
+        Ok(ffi::UnitStruct)
     } else {
         Err(ResultTestOpaqueRustType { val: 222 })
     }

--- a/examples/rust-binary-calls-swift-package/build.rs
+++ b/examples/rust-binary-calls-swift-package/build.rs
@@ -24,8 +24,20 @@ fn main() {
     // ld: warning: Could not find or use auto-linked library 'swiftCompatibility50'
     // ld: warning: Could not find or use auto-linked library 'swiftCompatibilityDynamicReplacements'
     // ld: warning: Could not find or use auto-linked library 'swiftCompatibilityConcurrency'
-    println!("cargo:rustc-link-search={}",
-        "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/"
+    let xcode_path = if let Ok(output) = std::process::Command::new("xcode-select")
+        .arg("--print-path")
+        .output()
+    {
+        String::from_utf8(output.stdout.as_slice().into())
+            .unwrap()
+            .trim()
+            .to_string()
+    } else {
+        "/Applications/Xcode.app/Contents/Developer".to_string()
+    };
+    println!(
+        "cargo:rustc-link-search={}/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/",
+        &xcode_path
     );
     println!("cargo:rustc-link-search={}", "/usr/lib/swift");
 }

--- a/src/std_bridge/result.rs
+++ b/src/std_bridge/result.rs
@@ -45,8 +45,8 @@ pub struct ResultPtrAndPtr {
     pub ok_or_err: *mut std::ffi::c_void,
 }
 
-// Bridges `Result<(), E>` where `E` is able to be encoded
-// as a pointer.
+// Bridges `Result<T, E>` where `T` is able to be encoded with zero bytes - e.g. `()` or `struct UnitStruct;`,
+// and where `E` is able to be encoded as a pointer.
 #[repr(C)]
 #[doc(hidden)]
 pub struct ResultVoidAndPtr {

--- a/src/std_bridge/result.rs
+++ b/src/std_bridge/result.rs
@@ -44,3 +44,12 @@ pub struct ResultPtrAndPtr {
     pub is_ok: bool,
     pub ok_or_err: *mut std::ffi::c_void,
 }
+
+// Bridges `Result<(), E>` where `E` is able to be encoded
+// as a pointer.
+#[repr(C)]
+#[doc(hidden)]
+pub struct ResultVoidAndPtr {
+    pub is_ok: bool,
+    pub err: *mut std::ffi::c_void,
+}


### PR DESCRIPTION
Adds partial support for #177 - supports returning `Result<(), OpaqueRust>` but not passing as an arg.

The change to `examples/rust-binary-calls-swift-package/build.rs` was to support xcode not existing in the default location (I use the `xcodes` tool).

This PR also supports empty types, based on @chinedufn's recommendation.

This enables the following:
```rust
#[swift_bridge::bridge]
mod ffi {
    struct UnitType;
    extern "Rust" {
        type OpaqueType;
        fn null_result() -> Result<(), OpaqueType>;
        fn unit_result() -> Result<UnitType, OpaqueType>;
    }
}

fn null_result() -> Result<(), OpaqueType> {
    Ok(())
}

fn unit_result() -> Result<UnitType, OpaqueType> {
    Ok(UnitType {})
}
```