### PR TITLE
Support opaque types as enum variant fields 

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
@@ -33,11 +33,11 @@ class SharedEnumTests: XCTestCase {
     }
 
     func testEnumWithUnnamedData() {
-        let enumWithUnnamedData1 = EnumWithUnnamedData.Variant1(create_string("hello"), Foo.new())
+        let enumWithUnnamedData1 = EnumWithUnnamedData.Variant1(create_string("hello"), Foo())
         switch reflect_enum_with_unnamed_data(enumWithUnnamedData1) {
         case .Variant1(let rustString, let foo):
             XCTAssertEqual(rustString.toString(), "hello")
-            XCTAssertEqual(foo, Foo.new())
+            XCTAssertEqual(foo, Foo())
         default:
             XCTFail()
         }
@@ -78,10 +78,10 @@ class SharedEnumTests: XCTestCase {
             XCTFail()
         }
 
-        let enumWithNamedData3 = EnumWithNamedData.Variant3(foo: Foo.new())
+        let enumWithNamedData3 = EnumWithNamedData.Variant3(foo: Foo())
         switch reflect_enum_with_named_data(enumWithNamedData3) {
         case .Variant3(let foo):
-            XCTAssertEqual(foo, Foo.new())
+            XCTAssertEqual(foo, Foo())
             break
         default:
             XCTFail()

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
@@ -85,6 +85,23 @@ class SharedEnumTests: XCTestCase {
         default:
             XCTFail()
         }
-
+    }
+    
+    func testEnumWithOpaqueRust() {
+        let named = EnumWithOpaqueRust.Named(data: OpaqueRustForEnumTest())
+        switch reflect_enum_with_opaque_type(named) {
+        case .Named(let value):
+            XCTAssertEqual(value, OpaqueRustForEnumTest())
+        case .Unnamed(_):
+            XCTFail()
+        }
+        
+        let unnamed = EnumWithOpaqueRust.Unnamed(OpaqueRustForEnumTest())
+        switch reflect_enum_with_opaque_type(unnamed) {
+        case .Named(_):
+            XCTFail()
+        case .Unnamed(let value):
+            XCTAssertEqual(value, OpaqueRustForEnumTest())
+        }
     }
 }

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
@@ -33,11 +33,11 @@ class SharedEnumTests: XCTestCase {
     }
 
     func testEnumWithUnnamedData() {
-        let enumWithUnnamedData1 = EnumWithUnnamedData.Variant1(create_string("hello"), 0)
+        let enumWithUnnamedData1 = EnumWithUnnamedData.Variant1(create_string("hello"), Foo.new())
         switch reflect_enum_with_unnamed_data(enumWithUnnamedData1) {
-        case .Variant1(let rustString, let valueUInt32):
+        case .Variant1(let rustString, let foo):
             XCTAssertEqual(rustString.toString(), "hello")
-            XCTAssertEqual(valueUInt32, 0)
+            XCTAssertEqual(foo, Foo.new())
         default:
             XCTFail()
         }
@@ -78,9 +78,10 @@ class SharedEnumTests: XCTestCase {
             XCTFail()
         }
 
-        let enumWithNamedData3 = EnumWithNamedData.Variant3
+        let enumWithNamedData3 = EnumWithNamedData.Variant3(foo: Foo.new())
         switch reflect_enum_with_named_data(enumWithNamedData3) {
-        case .Variant3:
+        case .Variant3(let foo):
+            XCTAssertEqual(foo, Foo.new())
             break
         default:
             XCTFail()

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
@@ -33,27 +33,26 @@ class SharedEnumTests: XCTestCase {
     }
 
     func testEnumWithUnnamedData() {
-        let enumWithUnnamedData1 = EnumWithUnnamedData.Variant1(create_string("hello"), OpaqueRustForEnumTest())
+        let enumWithUnnamedData1 = EnumWithUnnamedData.TwoFields(create_string("hello"), OpaqueRustForEnumTest())
         switch reflect_enum_with_unnamed_data(enumWithUnnamedData1) {
-        case .Variant1(let rustString, let opaqueRustForEnumTest):
+        case .TwoFields(let rustString, let opaqueRustForEnumTest):
             XCTAssertEqual(rustString.toString(), "hello")
             XCTAssertEqual(opaqueRustForEnumTest, OpaqueRustForEnumTest())
         default:
             XCTFail()
         }
         
-        let enumWithUnnamedData2 = EnumWithUnnamedData.Variant2(1000, 10)
+        let enumWithUnnamedData2 = EnumWithUnnamedData.OneField(1000)
         switch reflect_enum_with_unnamed_data(enumWithUnnamedData2) {
-        case .Variant2(let valueInt32, let valueUInt8):
+        case .OneField(let valueInt32):
             XCTAssertEqual(valueInt32, 1000)
-            XCTAssertEqual(valueUInt8, 10)
         default:
             XCTFail()
         }
 
-        let enumWithUnnamedData3 = EnumWithUnnamedData.Variant3
+        let enumWithUnnamedData3 = EnumWithUnnamedData.NoFields
         switch reflect_enum_with_unnamed_data(enumWithUnnamedData3) {
-        case .Variant3:
+        case .NoFields:
             break
         default:
             XCTFail()
@@ -61,26 +60,26 @@ class SharedEnumTests: XCTestCase {
     }
     
     func testEnumWithNamedData() {
-        let enumWithNamedData1 = EnumWithNamedData.Variant1(hello: create_string("hello"), data_u8: 123)
+        let enumWithNamedData1 = EnumWithNamedData.TwoFields(hello: create_string("hello"), data_u8: 123)
         switch reflect_enum_with_named_data(enumWithNamedData1) {
-        case .Variant1(let hello, let dataU8):
+        case .TwoFields(let hello, let dataU8):
             XCTAssertEqual(hello.toString(), "hello")
             XCTAssertEqual(dataU8, 123)
         default:
             XCTFail()
         }
         
-        let enumWithNamedData2 = EnumWithNamedData.Variant2(data_i32: -123)
+        let enumWithNamedData2 = EnumWithNamedData.OneField(data_i32: -123)
         switch reflect_enum_with_named_data(enumWithNamedData2) {
-        case .Variant2(let dataI32):
+        case .OneField(let dataI32):
             XCTAssertEqual(dataI32, -123)
         default:
             XCTFail()
         }
 
-        let enumWithNamedData3 = EnumWithNamedData.Variant3
+        let enumWithNamedData3 = EnumWithNamedData.NoFields
         switch reflect_enum_with_named_data(enumWithNamedData3) {
-        case .Variant3:
+        case .NoFields:
             break
         default:
             XCTFail()

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
@@ -33,11 +33,11 @@ class SharedEnumTests: XCTestCase {
     }
 
     func testEnumWithUnnamedData() {
-        let enumWithUnnamedData1 = EnumWithUnnamedData.Variant1(create_string("hello"), Foo())
+        let enumWithUnnamedData1 = EnumWithUnnamedData.Variant1(create_string("hello"), OpaqueRustForEnumTest())
         switch reflect_enum_with_unnamed_data(enumWithUnnamedData1) {
-        case .Variant1(let rustString, let foo):
+        case .Variant1(let rustString, let opaqueRustForEnumTest):
             XCTAssertEqual(rustString.toString(), "hello")
-            XCTAssertEqual(foo, Foo())
+            XCTAssertEqual(opaqueRustForEnumTest, OpaqueRustForEnumTest())
         default:
             XCTFail()
         }
@@ -78,10 +78,10 @@ class SharedEnumTests: XCTestCase {
             XCTFail()
         }
 
-        let enumWithNamedData3 = EnumWithNamedData.Variant3(foo: Foo())
+        let enumWithNamedData3 = EnumWithNamedData.Variant3(foo: OpaqueRustForEnumTest())
         switch reflect_enum_with_named_data(enumWithNamedData3) {
-        case .Variant3(let foo):
-            XCTAssertEqual(foo, Foo())
+        case .Variant3(let opaqueRustForEnumTest):
+            XCTAssertEqual(opaqueRustForEnumTest, OpaqueRustForEnumTest())
             break
         default:
             XCTFail()

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
@@ -78,10 +78,9 @@ class SharedEnumTests: XCTestCase {
             XCTFail()
         }
 
-        let enumWithNamedData3 = EnumWithNamedData.Variant3(foo: OpaqueRustForEnumTest())
+        let enumWithNamedData3 = EnumWithNamedData.Variant3
         switch reflect_enum_with_named_data(enumWithNamedData3) {
-        case .Variant3(let opaqueRustForEnumTest):
-            XCTAssertEqual(opaqueRustForEnumTest, OpaqueRustForEnumTest())
+        case .Variant3:
             break
         default:
             XCTFail()

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
@@ -108,7 +108,9 @@ class SharedEnumTests: XCTestCase {
         let named = EnumWithGenericOpaqueRust.Named(data: new_generic_opaque_rust_for_enum_test())
         switch reflect_enum_with_generic_opaque_type(named) {
         case .Named(_):
-            //TODO: call several methods on GenericOpaqueRustForEnumTest<Int32>
+            // TODO: call a method on GenericOpaqueRustForEnumTest<Int32>
+            // after we add support for methods on generic opaque Rust Types.
+            // See https://github.com/chinedufn/swift-bridge/issues/44#issuecomment-1114198605
             break
         case .Unnamed(_):
             XCTFail()
@@ -119,7 +121,9 @@ class SharedEnumTests: XCTestCase {
         case .Named(_):
             XCTFail()
         case .Unnamed(_):
-            //TODO: call several methods on GenericOpaqueRustForEnumTest<Int32>
+            // TODO: call a method on GenericOpaqueRustForEnumTest<Int32>
+            // after we add support for methods on generic opaque Rust Types.
+            // See https://github.com/chinedufn/swift-bridge/issues/44#issuecomment-1114198605
             break
         }
     }

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedEnumTests.swift
@@ -103,4 +103,25 @@ class SharedEnumTests: XCTestCase {
             XCTAssertEqual(value, OpaqueRustForEnumTest())
         }
     }
+
+    func testEnumWithGenericOpaqueRust() {
+        let named = EnumWithGenericOpaqueRust.Named(data: new_generic_opaque_rust_for_enum_test())
+        switch reflect_enum_with_generic_opaque_type(named) {
+        case .Named(_):
+            //TODO: call several methods on GenericOpaqueRustForEnumTest<Int32>
+            break
+        case .Unnamed(_):
+            XCTFail()
+        }
+        
+        let unnamed = EnumWithGenericOpaqueRust.Unnamed(new_generic_opaque_rust_for_enum_test())
+        switch reflect_enum_with_generic_opaque_type(unnamed) {
+        case .Named(_):
+            XCTFail()
+        case .Unnamed(_):
+            //TODO: call several methods on GenericOpaqueRustForEnumTest<Int32>
+            break
+        }
+    }
+
 }

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -816,20 +816,6 @@ impl BridgedType {
                 StdLibType::Bool => quote! { bool },
                 StdLibType::Pointer(ptr) => {
                     ptr.to_ffi_compatible_rust_type(swift_bridge_path, types)
-                    /***
-                    let kind = ptr.kind.to_token_stream();
-
-                    let ty = match &ptr.pointee {
-                        Pointee::BuiltIn(ty) => {
-                            ty.to_ffi_compatible_rust_type(swift_bridge_path, types)
-                        }
-                        Pointee::Void(ty) => {
-                            quote! { super::#ty }
-                        }
-                    };
-
-                    quote! { #kind #ty}
-                    ***/
                 }
                 StdLibType::RefSlice(slice) => {
                     let ty = slice

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -754,18 +754,7 @@ impl BridgedType {
                     StdLibType::F64 => quote! { f64 },
                     StdLibType::Bool => quote! { bool },
                     StdLibType::Pointer(ptr) => {
-                        let ptr_kind = &ptr.kind;
-
-                        match &ptr.pointee {
-                            Pointee::BuiltIn(ty) => {
-                                let ty = ty.to_rust_type_path(types);
-                                quote! { #ptr_kind #ty}
-                            }
-                            Pointee::Void(_ty) => {
-                                // quote! { * #ptr_kind #ty };
-                                panic!("Add a test case that hits this branch, then make it pass")
-                            }
-                        }
+                        ptr.to_rust_type_path(types)
                     }
                     StdLibType::RefSlice(ref_slice) => {
                         let ty = ref_slice.ty.to_rust_type_path(types);
@@ -826,6 +815,8 @@ impl BridgedType {
                 StdLibType::Isize => quote! { isize },
                 StdLibType::Bool => quote! { bool },
                 StdLibType::Pointer(ptr) => {
+                    ptr.to_ffi_compatible_rust_type(swift_bridge_path, types)
+                    /***
                     let kind = ptr.kind.to_token_stream();
 
                     let ty = match &ptr.pointee {
@@ -838,6 +829,7 @@ impl BridgedType {
                     };
 
                     quote! { #kind #ty}
+                    ***/
                 }
                 StdLibType::RefSlice(slice) => {
                     let ty = slice
@@ -1179,20 +1171,7 @@ impl BridgedType {
         match self {
             BridgedType::StdLib(stdlib_type) => {
                 match stdlib_type {
-                    StdLibType::Pointer(pointer) => match &pointer.pointee {
-                        Pointee::BuiltIn(_built_in) => {
-                            //
-                            todo!();
-                            self.to_rust_type_path(types)
-                        }
-                        Pointee::Void(_) => {
-                            todo!();
-                            let pointer_kind = &pointer.kind;
-                            let pointee = &pointer.pointee;
-
-                            quote! { #pointer_kind super:: #pointee }
-                        }
-                    },
+                    StdLibType::Pointer(pointer) => pointer.to_rust_type_path(types),
                     _ => self.to_rust_type_path(types),
                 }
             }

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -735,44 +735,40 @@ impl BridgedType {
     pub(crate) fn to_rust_type_path(&self, types: &TypeDeclarations) -> TokenStream {
         match self {
             BridgedType::Bridgeable(b) => b.to_rust_type_path(types),
-            BridgedType::StdLib(stdlib_type) => {
-                match stdlib_type {
-                    StdLibType::Null => {
-                        quote! {()}
-                    }
-                    StdLibType::U8 => quote! { u8 },
-                    StdLibType::I8 => quote! { i8 },
-                    StdLibType::U16 => quote! { u16},
-                    StdLibType::I16 => quote! { i16},
-                    StdLibType::U32 => quote! { u32 },
-                    StdLibType::I32 => quote! { i32 },
-                    StdLibType::U64 => quote! { u64 },
-                    StdLibType::I64 => quote! { i64 },
-                    StdLibType::Usize => quote! { usize },
-                    StdLibType::Isize => quote! { isize },
-                    StdLibType::F32 => quote! { f32 },
-                    StdLibType::F64 => quote! { f64 },
-                    StdLibType::Bool => quote! { bool },
-                    StdLibType::Pointer(ptr) => {
-                        ptr.to_rust_type_path(types)
-                    }
-                    StdLibType::RefSlice(ref_slice) => {
-                        let ty = ref_slice.ty.to_rust_type_path(types);
-                        quote! { &[#ty]}
-                    }
-                    StdLibType::Str => quote! { &str },
-                    StdLibType::Vec(v) => {
-                        let ty = v.ty.to_rust_type_path(types);
-                        quote! { Vec<#ty> }
-                    }
-                    StdLibType::Option(opt) => {
-                        let ty = opt.ty.to_rust_type_path(types);
-                        quote! { Option<#ty> }
-                    }
-                    StdLibType::Result(result) => result.to_rust_type_path(types),
-                    StdLibType::BoxedFnOnce(fn_once) => fn_once.to_rust_type_path(types),
+            BridgedType::StdLib(stdlib_type) => match stdlib_type {
+                StdLibType::Null => {
+                    quote! {()}
                 }
-            }
+                StdLibType::U8 => quote! { u8 },
+                StdLibType::I8 => quote! { i8 },
+                StdLibType::U16 => quote! { u16},
+                StdLibType::I16 => quote! { i16},
+                StdLibType::U32 => quote! { u32 },
+                StdLibType::I32 => quote! { i32 },
+                StdLibType::U64 => quote! { u64 },
+                StdLibType::I64 => quote! { i64 },
+                StdLibType::Usize => quote! { usize },
+                StdLibType::Isize => quote! { isize },
+                StdLibType::F32 => quote! { f32 },
+                StdLibType::F64 => quote! { f64 },
+                StdLibType::Bool => quote! { bool },
+                StdLibType::Pointer(ptr) => ptr.to_rust_type_path(types),
+                StdLibType::RefSlice(ref_slice) => {
+                    let ty = ref_slice.ty.to_rust_type_path(types);
+                    quote! { &[#ty]}
+                }
+                StdLibType::Str => quote! { &str },
+                StdLibType::Vec(v) => {
+                    let ty = v.ty.to_rust_type_path(types);
+                    quote! { Vec<#ty> }
+                }
+                StdLibType::Option(opt) => {
+                    let ty = opt.ty.to_rust_type_path(types);
+                    quote! { Option<#ty> }
+                }
+                StdLibType::Result(result) => result.to_rust_type_path(types),
+                StdLibType::BoxedFnOnce(fn_once) => fn_once.to_rust_type_path(types),
+            },
             BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Struct(shared_struct))) => {
                 let ty_name = &shared_struct.name;
                 quote! {
@@ -970,7 +966,6 @@ impl BridgedType {
                 StdLibType::Isize => "Int".to_string(),
                 StdLibType::Bool => "Bool".to_string(),
                 StdLibType::Pointer(ptr) => {
-
                     let maybe_mutable = match ptr.kind {
                         PointerKind::Const => "",
                         PointerKind::Mut => "Mutable",
@@ -1101,7 +1096,6 @@ impl BridgedType {
                 StdLibType::Isize => "intptr_t".to_string(),
                 StdLibType::Bool => "bool".to_string(),
                 StdLibType::Pointer(ptr) => {
-
                     let maybe_const = match ptr.kind {
                         PointerKind::Const => " const ",
                         PointerKind::Mut => "",
@@ -1152,15 +1146,12 @@ impl BridgedType {
     ///     unsafe { __swift_bridge__void_pointers(arg1) }
     /// }
     ///
-    pub fn maybe_convert_pointer_to_super_pointer(&self,
-        types: &TypeDeclarations) -> TokenStream {
+    pub fn maybe_convert_pointer_to_super_pointer(&self, types: &TypeDeclarations) -> TokenStream {
         match self {
-            BridgedType::StdLib(stdlib_type) => {
-                match stdlib_type {
-                    StdLibType::Pointer(pointer) => pointer.to_rust_type_path(types),
-                    _ => self.to_rust_type_path(types),
-                }
-            }
+            BridgedType::StdLib(stdlib_type) => match stdlib_type {
+                StdLibType::Pointer(pointer) => pointer.to_rust_type_path(types),
+                _ => self.to_rust_type_path(types),
+            },
             _ => self.to_rust_type_path(types),
         }
     }

--- a/crates/swift-bridge-ir/src/bridged_type/boxed_fn.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/boxed_fn.rs
@@ -35,7 +35,11 @@ impl BridgeableBoxedFnOnce {
 
     /// Box<dyn FnOnce(A, B) -> C>
     pub fn to_rust_type_path(&self, types: &TypeDeclarations) -> TokenStream {
-        let args: Vec<TokenStream> = self.params.iter().map(|a| a.to_rust_type_path(types)).collect();
+        let args: Vec<TokenStream> = self
+            .params
+            .iter()
+            .map(|a| a.to_rust_type_path(types))
+            .collect();
         let ret = &self.ret.to_rust_type_path(types);
         quote! {
             Box<dyn FnOnce(#(#args),*) -> #ret>
@@ -47,7 +51,11 @@ impl BridgeableBoxedFnOnce {
         expression: &TokenStream,
         types: &TypeDeclarations,
     ) -> TokenStream {
-        let args: Vec<TokenStream> = self.params.iter().map(|a| a.to_rust_type_path(types)).collect();
+        let args: Vec<TokenStream> = self
+            .params
+            .iter()
+            .map(|a| a.to_rust_type_path(types))
+            .collect();
         let ret = &self.ret.to_rust_type_path(types);
 
         quote! {
@@ -56,7 +64,11 @@ impl BridgeableBoxedFnOnce {
     }
 
     pub fn to_ffi_compatible_rust_type(&self, types: &TypeDeclarations) -> TokenStream {
-        let params: Vec<TokenStream> = self.params.iter().map(|a| a.to_rust_type_path(types)).collect();
+        let params: Vec<TokenStream> = self
+            .params
+            .iter()
+            .map(|a| a.to_rust_type_path(types))
+            .collect();
         let ret = &self.ret.to_rust_type_path(types);
         quote! {
             *mut Box<dyn FnOnce(#(#params),*) -> #ret>

--- a/crates/swift-bridge-ir/src/bridged_type/boxed_fn.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/boxed_fn.rs
@@ -34,9 +34,9 @@ impl BridgeableBoxedFnOnce {
     }
 
     /// Box<dyn FnOnce(A, B) -> C>
-    pub fn to_rust_type_path(&self) -> TokenStream {
-        let args: Vec<TokenStream> = self.params.iter().map(|a| a.to_rust_type_path()).collect();
-        let ret = &self.ret.to_rust_type_path();
+    pub fn to_rust_type_path(&self, types: &TypeDeclarations) -> TokenStream {
+        let args: Vec<TokenStream> = self.params.iter().map(|a| a.to_rust_type_path(types)).collect();
+        let ret = &self.ret.to_rust_type_path(types);
         quote! {
             Box<dyn FnOnce(#(#args),*) -> #ret>
         }
@@ -45,18 +45,19 @@ impl BridgeableBoxedFnOnce {
     pub fn convert_rust_value_to_ffi_compatible_value(
         &self,
         expression: &TokenStream,
+        types: &TypeDeclarations,
     ) -> TokenStream {
-        let args: Vec<TokenStream> = self.params.iter().map(|a| a.to_rust_type_path()).collect();
-        let ret = &self.ret.to_rust_type_path();
+        let args: Vec<TokenStream> = self.params.iter().map(|a| a.to_rust_type_path(types)).collect();
+        let ret = &self.ret.to_rust_type_path(types);
 
         quote! {
             Box::into_raw(Box::new(#expression)) as *mut Box<dyn FnOnce(#(#args),*) -> #ret>
         }
     }
 
-    pub fn to_ffi_compatible_rust_type(&self) -> TokenStream {
-        let params: Vec<TokenStream> = self.params.iter().map(|a| a.to_rust_type_path()).collect();
-        let ret = &self.ret.to_rust_type_path();
+    pub fn to_ffi_compatible_rust_type(&self, types: &TypeDeclarations) -> TokenStream {
+        let params: Vec<TokenStream> = self.params.iter().map(|a| a.to_rust_type_path(types)).collect();
+        let ret = &self.ret.to_rust_type_path(types);
         quote! {
             *mut Box<dyn FnOnce(#(#params),*) -> #ret>
         }

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
@@ -40,7 +40,57 @@ impl BridgeableType for BuiltInPointer {
     }
 
     fn to_rust_type_path(&self, types: &TypeDeclarations) -> TokenStream {
-        todo!()
+        /***
+        let ptr_kind = &ptr.kind;
+
+        match &ptr.pointee {
+            Pointee::BuiltIn(ty) => {
+                let ty = ty.to_rust_type_path(types);
+                quote! { #ptr_kind #ty}
+            }
+            Pointee::Void(_ty) => {
+                // quote! { * #ptr_kind #ty };
+                panic!("Add a test case that hits this branch, then make it pass")
+            }
+        }
+
+    pub fn maybe_convert_pointer_to_super_pointer(&self,
+        types: &TypeDeclarations) -> TokenStream {
+        match self {
+            BridgedType::StdLib(stdlib_type) => {
+                match stdlib_type {
+                    StdLibType::Pointer(pointer) => match &pointer.pointee {
+                        Pointee::BuiltIn(_built_in) => {
+                            self.to_rust_type_path(types)
+                        }
+                        Pointee::Void(_) => {
+                            todo!();
+                            let pointer_kind = &pointer.kind;
+                            let pointee = &pointer.pointee;
+
+                            quote! { #pointer_kind super:: #pointee }
+                        }
+                    },
+                    _ => self.to_rust_type_path(types),
+                }
+            }
+            _ => self.to_rust_type_path(types),
+        }
+        }
+        ***/
+        match &self.pointee {
+            Pointee::BuiltIn(ty) => {
+                let pointer_kind = &self.kind;
+                let ty = ty.to_rust_type_path(types);
+                quote! { #pointer_kind #ty}
+            }
+            Pointee::Void(_ty) => {
+                let pointer_kind = &self.kind;
+                let pointee = &self.pointee;
+
+                quote! { #pointer_kind super:: #pointee }
+            }
+        }
     }
 
     fn to_swift_type(&self, _type_pos: TypePosition, _types: &TypeDeclarations) -> String {

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
@@ -229,6 +229,10 @@ impl BridgeableType for BuiltInPointer {
     fn has_swift_bridge_copy_annotation(&self) -> bool {
         todo!()
     }
+
+    fn only_encoding(&self) -> Option<super::OnlyEncoding> {
+        todo!()
+    }
 }
 
 impl PointerKind {

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
@@ -2,7 +2,7 @@ use crate::bridged_type::{BridgedType, BridgeableType, TypePosition, BuiltInResu
 use crate::parse::TypeDeclarations;
 use crate::Path;
 use proc_macro2::{TokenStream, Span};
-use quote::{quote, ToTokens, format_ident};
+use quote::{quote, ToTokens};
 use std::fmt::{Debug, Formatter};
 use syn::{Type};
 

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
@@ -1,10 +1,12 @@
-use crate::bridged_type::{BridgedType, BridgeableType, TypePosition, BuiltInResult, UnusedOptionNoneValue};
+use crate::bridged_type::{
+    BridgeableType, BridgedType, BuiltInResult, TypePosition, UnusedOptionNoneValue,
+};
 use crate::parse::TypeDeclarations;
 use crate::Path;
-use proc_macro2::{TokenStream, Span};
+use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use std::fmt::{Debug, Formatter};
-use syn::{Type};
+use syn::Type;
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct BuiltInPointer {
@@ -75,9 +77,7 @@ impl BridgeableType for BuiltInPointer {
         let kind = self.kind.to_ffi_compatible_rust_type();
 
         let ty = match &self.pointee {
-            Pointee::BuiltIn(ty) => {
-                ty.to_ffi_compatible_rust_type(swift_bridge_path, types)
-            }
+            Pointee::BuiltIn(ty) => ty.to_ffi_compatible_rust_type(swift_bridge_path, types),
             Pointee::Void(ty) => {
                 quote! { super::#ty }
             }
@@ -247,12 +247,8 @@ impl PointerKind {
 impl Pointee {
     fn to_rust_type_path(&self, types: &TypeDeclarations) -> TokenStream {
         match self {
-            Pointee::BuiltIn(built_in) => {
-                built_in.to_rust_type_path(types)
-            }
-            Pointee::Void(ty) => {
-                ty.to_token_stream()
-            }
+            Pointee::BuiltIn(built_in) => built_in.to_rust_type_path(types),
+            Pointee::Void(ty) => ty.to_token_stream(),
         }
     }
 }

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
@@ -1,8 +1,10 @@
-use crate::bridged_type::BridgedType;
-use proc_macro2::TokenStream;
+use crate::bridged_type::{BridgedType, BridgeableType, TypePosition, BuiltInResult, UnusedOptionNoneValue};
+use crate::parse::TypeDeclarations;
+use crate::Path;
+use proc_macro2::{TokenStream, Span};
 use quote::{quote, ToTokens};
 use std::fmt::{Debug, Formatter};
-use syn::Type;
+use syn::{Type};
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct BuiltInPointer {
@@ -24,6 +26,188 @@ pub(crate) enum Pointee {
     Void(Type),
 }
 
+impl BridgeableType for BuiltInPointer {
+    fn is_built_in_type(&self) -> bool {
+        todo!()
+    }
+
+    fn is_result(&self) -> bool {
+        todo!()
+    }
+
+    fn as_result(&self) -> Option<&BuiltInResult> {
+        todo!()
+    }
+
+    fn to_rust_type_path(&self, types: &TypeDeclarations) -> TokenStream {
+        todo!()
+    }
+
+    fn to_swift_type(&self, _type_pos: TypePosition, _types: &TypeDeclarations) -> String {
+        todo!()
+    }
+
+    fn to_c_type(&self) -> String {
+        todo!()
+    }
+
+    fn to_c_include(&self) -> Option<&'static str> {
+        todo!()
+    }
+
+    fn to_ffi_compatible_rust_type(
+        &self,
+        _swift_bridge_path: &Path,
+        _types: &TypeDeclarations,
+    ) -> TokenStream {
+        todo!()
+    }
+
+    fn to_ffi_compatible_option_rust_type(
+        &self,
+        _swift_bridge_path: &Path,
+        _types: &TypeDeclarations,
+    ) -> TokenStream {
+        todo!()
+    }
+
+    fn to_ffi_compatible_option_swift_type(
+        &self,
+        _swift_bridge_path: &Path,
+        _types: &TypeDeclarations,
+    ) -> String {
+        todo!()
+    }
+
+    fn to_ffi_compatible_option_c_type(&self) -> String {
+        todo!()
+    }
+
+    fn convert_rust_expression_to_ffi_type(
+        &self,
+        _expression: &TokenStream,
+        _swift_bridge_path: &Path,
+        _types: &TypeDeclarations,
+        _span: Span,
+    ) -> TokenStream {
+        todo!()
+    }
+
+    fn convert_option_rust_expression_to_ffi_type(
+        &self,
+        _expression: &TokenStream,
+        _swift_bridge_path: &Path,
+    ) -> TokenStream {
+        todo!()
+    }
+
+    fn convert_swift_expression_to_ffi_type(
+        &self,
+        _expression: &str,
+        _type_pos: TypePosition,
+    ) -> String {
+        todo!()
+    }
+
+    fn convert_option_swift_expression_to_ffi_type(
+        &self,
+        _expression: &str,
+        _type_pos: TypePosition,
+    ) -> String {
+        todo!()
+    }
+
+    fn convert_ffi_expression_to_rust_type(
+        &self,
+        _expression: &TokenStream,
+        _span: Span,
+        _swift_bridge_path: &Path,
+        _types: &TypeDeclarations,
+    ) -> TokenStream {
+        todo!()
+    }
+
+    fn convert_ffi_option_expression_to_rust_type(&self, _expression: &TokenStream) -> TokenStream {
+        todo!()
+    }
+
+    fn convert_ffi_expression_to_swift_type(
+        &self,
+        _expression: &str,
+        _type_pos: TypePosition,
+        _types: &TypeDeclarations,
+    ) -> String {
+        todo!()
+    }
+
+    fn convert_ffi_option_expression_to_swift_type(&self, _expression: &str) -> String {
+        todo!()
+    }
+
+    fn convert_ffi_result_ok_value_to_rust_value(
+        &self,
+        _ok_ffi_value: &TokenStream,
+        _swift_bridge_path: &Path,
+        _types: &TypeDeclarations,
+    ) -> TokenStream {
+        todo!()
+    }
+
+    fn convert_ffi_result_err_value_to_rust_value(
+        &self,
+        _err_ffi_value: &TokenStream,
+        _swift_bridge_path: &Path,
+        _types: &TypeDeclarations,
+    ) -> TokenStream {
+        todo!()
+    }
+
+    fn unused_option_none_val(&self, _swift_bridge_path: &Path) -> UnusedOptionNoneValue {
+        todo!()
+    }
+
+    fn can_parse_token_stream_str(_tokens: &str) -> bool
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+
+    fn from_type(_ty: &Type, _types: &TypeDeclarations) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+
+    fn parse_token_stream_str(_tokens: &str, _types: &TypeDeclarations) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+
+    fn is_null(&self) -> bool {
+        todo!()
+    }
+
+    fn is_str(&self) -> bool {
+        todo!()
+    }
+
+    fn contains_owned_string_recursive(&self) -> bool {
+        todo!()
+    }
+
+    fn contains_ref_string_recursive(&self) -> bool {
+        todo!()
+    }
+
+    fn has_swift_bridge_copy_annotation(&self) -> bool {
+        todo!()
+    }
+}
+
 impl ToTokens for PointerKind {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
@@ -43,7 +227,7 @@ impl ToTokens for Pointee {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
             Pointee::BuiltIn(built_in) => {
-                built_in.to_rust_type_path().to_tokens(tokens);
+                //built_in.to_rust_type_path().to_tokens(tokens);
             }
             Pointee::Void(ty) => {
                 ty.to_tokens(tokens);

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
@@ -40,44 +40,6 @@ impl BridgeableType for BuiltInPointer {
     }
 
     fn to_rust_type_path(&self, types: &TypeDeclarations) -> TokenStream {
-        /***
-        let ptr_kind = &ptr.kind;
-
-        match &ptr.pointee {
-            Pointee::BuiltIn(ty) => {
-                let ty = ty.to_rust_type_path(types);
-                quote! { #ptr_kind #ty}
-            }
-            Pointee::Void(_ty) => {
-                // quote! { * #ptr_kind #ty };
-                panic!("Add a test case that hits this branch, then make it pass")
-            }
-        }
-
-    pub fn maybe_convert_pointer_to_super_pointer(&self,
-        types: &TypeDeclarations) -> TokenStream {
-        match self {
-            BridgedType::StdLib(stdlib_type) => {
-                match stdlib_type {
-                    StdLibType::Pointer(pointer) => match &pointer.pointee {
-                        Pointee::BuiltIn(_built_in) => {
-                            self.to_rust_type_path(types)
-                        }
-                        Pointee::Void(_) => {
-                            todo!();
-                            let pointer_kind = &pointer.kind;
-                            let pointee = &pointer.pointee;
-
-                            quote! { #pointer_kind super:: #pointee }
-                        }
-                    },
-                    _ => self.to_rust_type_path(types),
-                }
-            }
-            _ => self.to_rust_type_path(types),
-        }
-        }
-        ***/
         match &self.pointee {
             Pointee::BuiltIn(ty) => {
                 let pointer_kind = &self.kind;
@@ -107,10 +69,21 @@ impl BridgeableType for BuiltInPointer {
 
     fn to_ffi_compatible_rust_type(
         &self,
-        _swift_bridge_path: &Path,
-        _types: &TypeDeclarations,
+        swift_bridge_path: &Path,
+        types: &TypeDeclarations,
     ) -> TokenStream {
-        todo!()
+        let kind = self.kind.to_token_stream();
+
+        let ty = match &self.pointee {
+            Pointee::BuiltIn(ty) => {
+                ty.to_ffi_compatible_rust_type(swift_bridge_path, types)
+            }
+            Pointee::Void(ty) => {
+                quote! { super::#ty }
+            }
+        };
+
+        quote! { #kind #ty}
     }
 
     fn to_ffi_compatible_option_rust_type(

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
@@ -100,9 +100,9 @@ impl BuiltInResult {
         }
     }
 
-    pub fn to_rust_type_path(&self) -> TokenStream {
-        let ok = self.ok_ty.to_rust_type_path();
-        let err = self.err_ty.to_rust_type_path();
+    pub fn to_rust_type_path(&self, types: &TypeDeclarations) -> TokenStream {
+        let ok = self.ok_ty.to_rust_type_path(types);
+        let err = self.err_ty.to_rust_type_path(types);
 
         quote! { Result<#ok, #err> }
     }

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
@@ -20,7 +20,7 @@ impl BridgeableType for BridgedString {
         None
     }
 
-    fn to_rust_type_path(&self) -> TokenStream {
+    fn to_rust_type_path(&self, types: &TypeDeclarations) -> TokenStream {
         // FIXME: Change to `::std::string::String`
         quote! { String }
     }

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
@@ -20,7 +20,7 @@ impl BridgeableType for BridgedString {
         None
     }
 
-    fn to_rust_type_path(&self, types: &TypeDeclarations) -> TokenStream {
+    fn to_rust_type_path(&self, _types: &TypeDeclarations) -> TokenStream {
         // FIXME: Change to `::std::string::String`
         quote! { String }
     }

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
@@ -30,11 +30,15 @@ impl BridgeableType for OpaqueForeignType {
         None
     }
 
-    fn to_rust_type_path(&self, _types: &TypeDeclarations) -> TokenStream {
+    fn to_rust_type_path(&self, types: &TypeDeclarations) -> TokenStream {
         let ty_name = &self.ty;
+        let generics = self
+        .generics
+        .angle_bracketed_concrete_generics_tokens(types);
+
         if self.host_lang.is_rust() {
             quote! {
-                super:: #ty_name
+                super:: #ty_name #generics
             }
         } else {
             quote! {

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
@@ -30,7 +30,7 @@ impl BridgeableType for OpaqueForeignType {
         None
     }
 
-    fn to_rust_type_path(&self, types: &TypeDeclarations) -> TokenStream {
+    fn to_rust_type_path(&self, _types: &TypeDeclarations) -> TokenStream {
         let ty_name = &self.ty;
         if self.host_lang.is_rust() {
             quote! {

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
@@ -30,7 +30,7 @@ impl BridgeableType for OpaqueForeignType {
         None
     }
 
-    fn to_rust_type_path(&self) -> TokenStream {
+    fn to_rust_type_path(&self, types: &TypeDeclarations) -> TokenStream {
         let ty_name = &self.ty;
         if self.host_lang.is_rust() {
             quote! {

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
@@ -33,8 +33,8 @@ impl BridgeableType for OpaqueForeignType {
     fn to_rust_type_path(&self, types: &TypeDeclarations) -> TokenStream {
         let ty_name = &self.ty;
         let generics = self
-        .generics
-        .angle_bracketed_concrete_generics_tokens(types);
+            .generics
+            .angle_bracketed_concrete_generics_tokens(types);
 
         if self.host_lang.is_rust() {
             quote! {

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
@@ -84,7 +84,6 @@ impl BridgeableType for OpaqueForeignType {
                         self.generics
                             .angle_bracketed_generic_concrete_swift_types_string(types)
                     )
-                    
                 }
                 TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                     unimplemented!()
@@ -132,7 +131,7 @@ impl BridgeableType for OpaqueForeignType {
         types: &TypeDeclarations,
     ) -> TokenStream {
         let ty_name = &self.ty;
-        
+
         if self.has_swift_bridge_copy_annotation {
             let ty = self.copy_rust_repr_type();
             quote! { #ty }

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
@@ -825,7 +825,7 @@ extension __swift_bridge__$SomeEnum {
             r#"
 #include <stdbool.h>
 "#,
-r#"
+            r#"
 typedef struct __swift_bridge__$SomeEnum$FieldOfUnnamed {void* _0;} __swift_bridge__$SomeEnum$FieldOfUnnamed;
 typedef struct __swift_bridge__$SomeEnum$FieldOfNamed {void* data;} __swift_bridge__$SomeEnum$FieldOfNamed;
 union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfUnnamed Unnamed; __swift_bridge__$SomeEnum$FieldOfNamed Named;};

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
@@ -255,7 +255,6 @@ extension __swift_bridge__$Option$SomeEnum {
             return nil
         }
     }
-
     @inline(__always)
     static func fromSwiftRepr(_ val: Optional<SomeEnum>) -> __swift_bridge__$Option$SomeEnum {
         if let v = val {
@@ -445,7 +444,6 @@ extension __swift_bridge__$SomeEnum {
 #include <stdint.h>
 #include <stdbool.h>
 typedef struct __swift_bridge__$SomeEnum$FieldOfVariant1 {int32_t _0;} __swift_bridge__$SomeEnum$FieldOfVariant1;
-
 union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfVariant1 Variant1;};
 typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$Variant1, __swift_bridge__$SomeEnum$Variant2, } __swift_bridge__$SomeEnumTag;
 typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; union __swift_bridge__$SomeEnumFields payload;} __swift_bridge__$SomeEnum;
@@ -475,11 +473,8 @@ mod generates_enum_to_and_from_ffi_conversions_unnamed_data_and_two_unnamed_data
             #[swift_bridge::bridge]
             mod ffi {
                 enum SomeEnum {
-                    A(i32, SomeType),
+                    A(i32, u32),
                     B(String),
-                }
-                extern "Rust" {
-                    type SomeType;
                 }
             }
         }
@@ -489,14 +484,14 @@ mod generates_enum_to_and_from_ffi_conversions_unnamed_data_and_two_unnamed_data
         ExpectedRustTokens::Contains(quote! {
             #[derive ()]
             pub enum SomeEnum {
-                A(i32, super::SomeType),
+                A(i32, u32),
                 B(String)
             }
 
             #[repr(C)]
             #[doc(hidden)]
             pub enum __swift_bridge__SomeEnum {
-                A(i32, *mut super::SomeType),
+                A(i32, u32),
                 B(*mut swift_bridge::string::RustString)
             }
 
@@ -509,10 +504,7 @@ mod generates_enum_to_and_from_ffi_conversions_unnamed_data_and_two_unnamed_data
                 #[inline(always)]
                 pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
                     match self {
-                        SomeEnum::A(_0, _1) => __swift_bridge__SomeEnum::A(_0, Box::into_raw(Box::new({
-                            let val: super::SomeType = _1;
-                            val
-                        })) as *mut super::SomeType),
+                        SomeEnum::A(_0, _1) => __swift_bridge__SomeEnum::A(_0, _1),
                         SomeEnum::B(_0) => __swift_bridge__SomeEnum::B(swift_bridge::string::RustString(_0).box_into_raw())
                     }
                 }
@@ -523,7 +515,7 @@ mod generates_enum_to_and_from_ffi_conversions_unnamed_data_and_two_unnamed_data
                 #[inline(always)]
                 pub fn into_rust_repr(self) -> SomeEnum {
                     match self {
-                        __swift_bridge__SomeEnum::A(_0, _1) => SomeEnum::A(_0, unsafe { * Box::from_raw(_1) }),
+                        __swift_bridge__SomeEnum::A(_0, _1) => SomeEnum::A(_0, _1),
                         __swift_bridge__SomeEnum::B(_0) => SomeEnum::B(unsafe { Box::from_raw(_0).0 })
                     }
                 }
@@ -535,14 +527,14 @@ mod generates_enum_to_and_from_ffi_conversions_unnamed_data_and_two_unnamed_data
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 public enum SomeEnum {
-    case A(Int32, SomeType)
+    case A(Int32, UInt32)
     case B(RustString)
 }
 extension SomeEnum {
     func intoFfiRepr() -> __swift_bridge__$SomeEnum {
         switch self {
             case SomeEnum.A(let _0, let _1):
-                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$A, payload: __swift_bridge__$SomeEnumFields(A: __swift_bridge__$SomeEnum$FieldOfA(_0: _0, _1: {_1.isOwned = false; return _1.ptr;}())))
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$A, payload: __swift_bridge__$SomeEnumFields(A: __swift_bridge__$SomeEnum$FieldOfA(_0: _0, _1: _1)))
             case SomeEnum.B(let _0):
                 return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$B, payload: __swift_bridge__$SomeEnumFields(B: __swift_bridge__$SomeEnum$FieldOfB(_0: { let rustString = _0.intoRustString(); rustString.isOwned = false; return rustString.ptr }())))
         }
@@ -552,7 +544,7 @@ extension __swift_bridge__$SomeEnum {
     func intoSwiftRepr() -> SomeEnum {
         switch self.tag {
             case __swift_bridge__$SomeEnum$A:
-                return SomeEnum.A(self.payload.A._0, SomeType(ptr: self.payload.A._1))
+                return SomeEnum.A(self.payload.A._0, self.payload.A._1)
             case __swift_bridge__$SomeEnum$B:
                 return SomeEnum.B(RustString(ptr: self.payload.B._0))
             default:
@@ -569,9 +561,8 @@ extension __swift_bridge__$SomeEnum {
             r#"
 #include <stdint.h>
 #include <stdbool.h>
-typedef struct __swift_bridge__$SomeEnum$FieldOfA {int32_t _0; void* _1;} __swift_bridge__$SomeEnum$FieldOfA;
+typedef struct __swift_bridge__$SomeEnum$FieldOfA {int32_t _0; uint32_t _1;} __swift_bridge__$SomeEnum$FieldOfA;
 typedef struct __swift_bridge__$SomeEnum$FieldOfB {void* _0;} __swift_bridge__$SomeEnum$FieldOfB;
-
 union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfA A; __swift_bridge__$SomeEnum$FieldOfB B;};
 typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$A, __swift_bridge__$SomeEnum$B, } __swift_bridge__$SomeEnumTag;
 typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; union __swift_bridge__$SomeEnumFields payload;} __swift_bridge__$SomeEnum;
@@ -592,20 +583,17 @@ typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__
     }
 }
 
-/// Verify that we generate an enum type that has a variant with one with two named fields and one named field.
-mod generates_enum_to_and_from_ffi_conversions_two_named_data_and_one_named_data {
+/// Verify that we generate an enum type that has a variant with one named field and one with two named fields.
+mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data {
     use super::*;
 
     fn bridge_module_tokens() -> TokenStream {
         quote! {
             #[swift_bridge::bridge]
             mod ffi {
-                extern "Rust" {
-                    type SomeType;
-                }
                 enum SomeEnum {
                     A{
-                        data1: SomeType,
+                        data1: i32,
                         data2: u32
                     },
                     B{
@@ -621,7 +609,7 @@ mod generates_enum_to_and_from_ffi_conversions_two_named_data_and_one_named_data
             #[derive ()]
             pub enum SomeEnum {
                 A {
-                    data1: super::SomeType,
+                    data1: i32,
                     data2: u32
                 },
                 B {
@@ -633,7 +621,7 @@ mod generates_enum_to_and_from_ffi_conversions_two_named_data_and_one_named_data
             #[doc(hidden)]
             pub enum __swift_bridge__SomeEnum {
                 A {
-                    data1: *mut super::SomeType,
+                    data1: i32,
                     data2: u32
                 },
                 B {
@@ -650,10 +638,7 @@ mod generates_enum_to_and_from_ffi_conversions_two_named_data_and_one_named_data
                 #[inline(always)]
                 pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
                     match self {
-                        SomeEnum::A{data1, data2} => __swift_bridge__SomeEnum::A{data1: Box::into_raw(Box::new({
-                            let val: super::SomeType = data1;
-                            val
-                        })) as *mut super::SomeType, data2: data2},
+                        SomeEnum::A{data1, data2} => __swift_bridge__SomeEnum::A{data1: data1, data2: data2},
                         SomeEnum::B{description} => __swift_bridge__SomeEnum::B{description: swift_bridge::string::RustString(description).box_into_raw()}
                     }
                 }
@@ -664,7 +649,7 @@ mod generates_enum_to_and_from_ffi_conversions_two_named_data_and_one_named_data
                 #[inline(always)]
                 pub fn into_rust_repr(self) -> SomeEnum {
                     match self {
-                        __swift_bridge__SomeEnum::A{data1, data2} => SomeEnum::A{data1: unsafe { * Box::from_raw(data1) }, data2: data2},
+                        __swift_bridge__SomeEnum::A{data1, data2} => SomeEnum::A{data1: data1, data2: data2},
                         __swift_bridge__SomeEnum::B{description} => SomeEnum::B{description: unsafe { Box::from_raw(description).0 }}
                     }
                 }
@@ -676,14 +661,14 @@ mod generates_enum_to_and_from_ffi_conversions_two_named_data_and_one_named_data
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 public enum SomeEnum {
-    case A(data1: SomeType, data2: UInt32)
+    case A(data1: Int32, data2: UInt32)
     case B(description: RustString)
 }
 extension SomeEnum {
     func intoFfiRepr() -> __swift_bridge__$SomeEnum {
         switch self {
             case SomeEnum.A(let data1, let data2):
-                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$A, payload: __swift_bridge__$SomeEnumFields(A: __swift_bridge__$SomeEnum$FieldOfA(data1: {data1.isOwned = false; return data1.ptr;}(), data2: data2)))
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$A, payload: __swift_bridge__$SomeEnumFields(A: __swift_bridge__$SomeEnum$FieldOfA(data1: data1, data2: data2)))
             case SomeEnum.B(let description):
                 return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$B, payload: __swift_bridge__$SomeEnumFields(B: __swift_bridge__$SomeEnum$FieldOfB(description: { let rustString = description.intoRustString(); rustString.isOwned = false; return rustString.ptr }())))
         }
@@ -693,7 +678,7 @@ extension __swift_bridge__$SomeEnum {
     func intoSwiftRepr() -> SomeEnum {
         switch self.tag {
             case __swift_bridge__$SomeEnum$A:
-                return SomeEnum.A(data1: SomeType(ptr: self.payload.A.data1), data2: self.payload.A.data2)
+                return SomeEnum.A(data1: self.payload.A.data1, data2: self.payload.A.data2)
             case __swift_bridge__$SomeEnum$B:
                 return SomeEnum.B(description: RustString(ptr: self.payload.B.description))
             default:
@@ -706,25 +691,22 @@ extension __swift_bridge__$SomeEnum {
     }
 
     fn expected_c_header() -> ExpectedCHeader {
-        ExpectedCHeader::ContainsManyAfterTrim(vec![
+        ExpectedCHeader::ContainsAfterTrim(
             r#"
 #include <stdint.h>
 #include <stdbool.h>
-"#,
-            r#"
-typedef struct __swift_bridge__$SomeEnum$FieldOfA {void* data1; uint32_t data2;} __swift_bridge__$SomeEnum$FieldOfA;
+typedef struct __swift_bridge__$SomeEnum$FieldOfA {int32_t data1; uint32_t data2;} __swift_bridge__$SomeEnum$FieldOfA;
 typedef struct __swift_bridge__$SomeEnum$FieldOfB {void* description;} __swift_bridge__$SomeEnum$FieldOfB;
-
 union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfA A; __swift_bridge__$SomeEnum$FieldOfB B;};
 typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$A, __swift_bridge__$SomeEnum$B, } __swift_bridge__$SomeEnumTag;
 typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; union __swift_bridge__$SomeEnumFields payload;} __swift_bridge__$SomeEnum;
 typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__$SomeEnum val; } __swift_bridge__$Option$SomeEnum;
 "#,
-        ])
+        )
     }
 
     #[test]
-    fn generates_enum_to_and_from_ffi_conversions_two_named_data_and_one_named_data() {
+    fn generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data() {
         CodegenTest {
             bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
@@ -475,8 +475,11 @@ mod generates_enum_to_and_from_ffi_conversions_unnamed_data_and_two_unnamed_data
             #[swift_bridge::bridge]
             mod ffi {
                 enum SomeEnum {
-                    A(i32, u32),
+                    A(i32, SomeType),
                     B(String),
+                }
+                extern "Rust" {
+                    type SomeType;
                 }
             }
         }
@@ -486,14 +489,14 @@ mod generates_enum_to_and_from_ffi_conversions_unnamed_data_and_two_unnamed_data
         ExpectedRustTokens::Contains(quote! {
             #[derive ()]
             pub enum SomeEnum {
-                A(i32, u32),
+                A(i32, super::SomeType),
                 B(String)
             }
 
             #[repr(C)]
             #[doc(hidden)]
             pub enum __swift_bridge__SomeEnum {
-                A(i32, u32),
+                A(i32, *mut super::SomeType),
                 B(*mut swift_bridge::string::RustString)
             }
 
@@ -506,7 +509,10 @@ mod generates_enum_to_and_from_ffi_conversions_unnamed_data_and_two_unnamed_data
                 #[inline(always)]
                 pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
                     match self {
-                        SomeEnum::A(_0, _1) => __swift_bridge__SomeEnum::A(_0, _1),
+                        SomeEnum::A(_0, _1) => __swift_bridge__SomeEnum::A(_0, Box::into_raw(Box::new({
+                            let val: super::SomeType = _1;
+                            val
+                        })) as *mut super::SomeType),
                         SomeEnum::B(_0) => __swift_bridge__SomeEnum::B(swift_bridge::string::RustString(_0).box_into_raw())
                     }
                 }
@@ -517,7 +523,7 @@ mod generates_enum_to_and_from_ffi_conversions_unnamed_data_and_two_unnamed_data
                 #[inline(always)]
                 pub fn into_rust_repr(self) -> SomeEnum {
                     match self {
-                        __swift_bridge__SomeEnum::A(_0, _1) => SomeEnum::A(_0, _1),
+                        __swift_bridge__SomeEnum::A(_0, _1) => SomeEnum::A(_0, unsafe { * Box::from_raw(_1) }),
                         __swift_bridge__SomeEnum::B(_0) => SomeEnum::B(unsafe { Box::from_raw(_0).0 })
                     }
                 }
@@ -529,14 +535,14 @@ mod generates_enum_to_and_from_ffi_conversions_unnamed_data_and_two_unnamed_data
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 public enum SomeEnum {
-    case A(Int32, UInt32)
+    case A(Int32, SomeType)
     case B(RustString)
 }
 extension SomeEnum {
     func intoFfiRepr() -> __swift_bridge__$SomeEnum {
         switch self {
             case SomeEnum.A(let _0, let _1):
-                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$A, payload: __swift_bridge__$SomeEnumFields(A: __swift_bridge__$SomeEnum$FieldOfA(_0: _0, _1: _1)))
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$A, payload: __swift_bridge__$SomeEnumFields(A: __swift_bridge__$SomeEnum$FieldOfA(_0: _0, _1: {_1.isOwned = false; return _1.ptr;}())))
             case SomeEnum.B(let _0):
                 return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$B, payload: __swift_bridge__$SomeEnumFields(B: __swift_bridge__$SomeEnum$FieldOfB(_0: { let rustString = _0.intoRustString(); rustString.isOwned = false; return rustString.ptr }())))
         }
@@ -546,7 +552,7 @@ extension __swift_bridge__$SomeEnum {
     func intoSwiftRepr() -> SomeEnum {
         switch self.tag {
             case __swift_bridge__$SomeEnum$A:
-                return SomeEnum.A(self.payload.A._0, self.payload.A._1)
+                return SomeEnum.A(self.payload.A._0, SomeType(ptr: self.payload.A._1))
             case __swift_bridge__$SomeEnum$B:
                 return SomeEnum.B(RustString(ptr: self.payload.B._0))
             default:
@@ -563,7 +569,7 @@ extension __swift_bridge__$SomeEnum {
             r#"
 #include <stdint.h>
 #include <stdbool.h>
-typedef struct __swift_bridge__$SomeEnum$FieldOfA {int32_t _0; uint32_t _1;} __swift_bridge__$SomeEnum$FieldOfA;
+typedef struct __swift_bridge__$SomeEnum$FieldOfA {int32_t _0; void* _1;} __swift_bridge__$SomeEnum$FieldOfA;
 typedef struct __swift_bridge__$SomeEnum$FieldOfB {void* _0;} __swift_bridge__$SomeEnum$FieldOfB;
 
 union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfA A; __swift_bridge__$SomeEnum$FieldOfB B;};
@@ -594,9 +600,12 @@ mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data
         quote! {
             #[swift_bridge::bridge]
             mod ffi {
+                extern "Rust" {
+                    type SomeType;
+                }
                 enum SomeEnum {
                     A{
-                        data1: i32,
+                        data1: SomeType,
                         data2: u32
                     },
                     B{
@@ -612,7 +621,7 @@ mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data
             #[derive ()]
             pub enum SomeEnum {
                 A {
-                    data1: i32,
+                    data1: super::SomeType,
                     data2: u32
                 },
                 B {
@@ -624,7 +633,7 @@ mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data
             #[doc(hidden)]
             pub enum __swift_bridge__SomeEnum {
                 A {
-                    data1: i32,
+                    data1: *mut super::SomeType,
                     data2: u32
                 },
                 B {
@@ -641,7 +650,10 @@ mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data
                 #[inline(always)]
                 pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
                     match self {
-                        SomeEnum::A{data1, data2} => __swift_bridge__SomeEnum::A{data1: data1, data2: data2},
+                        SomeEnum::A{data1, data2} => __swift_bridge__SomeEnum::A{data1: Box::into_raw(Box::new({
+                            let val: super::SomeType = data1;
+                            val
+                        })) as *mut super::SomeType, data2: data2},
                         SomeEnum::B{description} => __swift_bridge__SomeEnum::B{description: swift_bridge::string::RustString(description).box_into_raw()}
                     }
                 }
@@ -652,7 +664,7 @@ mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data
                 #[inline(always)]
                 pub fn into_rust_repr(self) -> SomeEnum {
                     match self {
-                        __swift_bridge__SomeEnum::A{data1, data2} => SomeEnum::A{data1: data1, data2: data2},
+                        __swift_bridge__SomeEnum::A{data1, data2} => SomeEnum::A{data1: unsafe { * Box::from_raw(data1) }, data2: data2},
                         __swift_bridge__SomeEnum::B{description} => SomeEnum::B{description: unsafe { Box::from_raw(description).0 }}
                     }
                 }
@@ -664,14 +676,14 @@ mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 public enum SomeEnum {
-    case A(data1: Int32, data2: UInt32)
+    case A(data1: SomeType, data2: UInt32)
     case B(description: RustString)
 }
 extension SomeEnum {
     func intoFfiRepr() -> __swift_bridge__$SomeEnum {
         switch self {
             case SomeEnum.A(let data1, let data2):
-                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$A, payload: __swift_bridge__$SomeEnumFields(A: __swift_bridge__$SomeEnum$FieldOfA(data1: data1, data2: data2)))
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$A, payload: __swift_bridge__$SomeEnumFields(A: __swift_bridge__$SomeEnum$FieldOfA(data1: {data1.isOwned = false; return data1.ptr;}(), data2: data2)))
             case SomeEnum.B(let description):
                 return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$B, payload: __swift_bridge__$SomeEnumFields(B: __swift_bridge__$SomeEnum$FieldOfB(description: { let rustString = description.intoRustString(); rustString.isOwned = false; return rustString.ptr }())))
         }
@@ -681,7 +693,7 @@ extension __swift_bridge__$SomeEnum {
     func intoSwiftRepr() -> SomeEnum {
         switch self.tag {
             case __swift_bridge__$SomeEnum$A:
-                return SomeEnum.A(data1: self.payload.A.data1, data2: self.payload.A.data2)
+                return SomeEnum.A(data1: SomeType(ptr: self.payload.A.data1), data2: self.payload.A.data2)
             case __swift_bridge__$SomeEnum$B:
                 return SomeEnum.B(description: RustString(ptr: self.payload.B.description))
             default:
@@ -694,11 +706,13 @@ extension __swift_bridge__$SomeEnum {
     }
 
     fn expected_c_header() -> ExpectedCHeader {
-        ExpectedCHeader::ContainsAfterTrim(
+        ExpectedCHeader::ContainsManyAfterTrim(vec![
             r#"
 #include <stdint.h>
 #include <stdbool.h>
-typedef struct __swift_bridge__$SomeEnum$FieldOfA {int32_t data1; uint32_t data2;} __swift_bridge__$SomeEnum$FieldOfA;
+"#,
+            r#"
+typedef struct __swift_bridge__$SomeEnum$FieldOfA {void* data1; uint32_t data2;} __swift_bridge__$SomeEnum$FieldOfA;
 typedef struct __swift_bridge__$SomeEnum$FieldOfB {void* description;} __swift_bridge__$SomeEnum$FieldOfB;
 
 union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfA A; __swift_bridge__$SomeEnum$FieldOfB B;};
@@ -706,11 +720,155 @@ typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$A, __swift
 typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; union __swift_bridge__$SomeEnumFields payload;} __swift_bridge__$SomeEnum;
 typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__$SomeEnum val; } __swift_bridge__$Option$SomeEnum;
 "#,
-        )
+        ])
     }
 
     #[test]
     fn generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}
+
+
+/// Verify that we generate an enum type that has a variant with one named field and one with two named fields.
+mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data_generics {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            #[swift_bridge::bridge]
+            mod ffi {
+                extern "Rust" {
+                    type SomeType<i32, u32>;
+                }
+                enum SomeEnum {
+                    A{
+                        data1: SomeType<i32, u32>,
+                        data2: u32
+                    },
+                    B{
+                        description: String
+                    },
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::Contains(quote! {
+            #[derive ()]
+            pub enum SomeEnum {
+                A {
+                    data1: super::SomeType<i32, u32>,
+                    data2: u32
+                },
+                B {
+                    description: String
+                }
+            }
+
+            #[repr(C)]
+            #[doc(hidden)]
+            pub enum __swift_bridge__SomeEnum {
+                A {
+                    data1: *mut super::SomeType<i32, u32>,
+                    data2: u32
+                },
+                B {
+                    description: *mut swift_bridge::string::RustString
+                }
+            }
+
+            impl swift_bridge::SharedEnum for SomeEnum {
+                type FfiRepr = __swift_bridge__SomeEnum;
+            }
+
+            impl SomeEnum {
+                #[doc(hidden)]
+                #[inline(always)]
+                pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
+                    match self {
+                        SomeEnum::A{data1, data2} => __swift_bridge__SomeEnum::A{data1: Box::into_raw(Box::new({
+                            let val: super::SomeType = data1;
+                            val
+                        })) as *mut super::SomeType, data2: data2},
+                        SomeEnum::B{description} => __swift_bridge__SomeEnum::B{description: swift_bridge::string::RustString(description).box_into_raw()}
+                    }
+                }
+            }
+
+            impl __swift_bridge__SomeEnum {
+                #[doc(hidden)]
+                #[inline(always)]
+                pub fn into_rust_repr(self) -> SomeEnum {
+                    match self {
+                        __swift_bridge__SomeEnum::A{data1, data2} => SomeEnum::A{data1: unsafe { * Box::from_raw(data1) }, data2: data2},
+                        __swift_bridge__SomeEnum::B{description} => SomeEnum::B{description: unsafe { Box::from_raw(description).0 }}
+                    }
+                }
+            }
+        })
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(
+            r#"
+public enum SomeEnum {
+    case A(data1: SomeType, data2: UInt32)
+    case B(description: RustString)
+}
+extension SomeEnum {
+    func intoFfiRepr() -> __swift_bridge__$SomeEnum {
+        switch self {
+            case SomeEnum.A(let data1, let data2):
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$A, payload: __swift_bridge__$SomeEnumFields(A: __swift_bridge__$SomeEnum$FieldOfA(data1: {data1.isOwned = false; return data1.ptr;}(), data2: data2)))
+            case SomeEnum.B(let description):
+                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$B, payload: __swift_bridge__$SomeEnumFields(B: __swift_bridge__$SomeEnum$FieldOfB(description: { let rustString = description.intoRustString(); rustString.isOwned = false; return rustString.ptr }())))
+        }
+    }
+}
+extension __swift_bridge__$SomeEnum {
+    func intoSwiftRepr() -> SomeEnum {
+        switch self.tag {
+            case __swift_bridge__$SomeEnum$A:
+                return SomeEnum.A(data1: SomeType(ptr: self.payload.A.data1), data2: self.payload.A.data2)
+            case __swift_bridge__$SomeEnum$B:
+                return SomeEnum.B(description: RustString(ptr: self.payload.B.description))
+            default:
+                fatalError("Unreachable")
+        }
+    }
+}
+"#,
+        )
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ContainsManyAfterTrim(vec![
+            r#"
+#include <stdint.h>
+#include <stdbool.h>
+"#,
+            r#"
+typedef struct __swift_bridge__$SomeEnum$FieldOfA {void* data1; uint32_t data2;} __swift_bridge__$SomeEnum$FieldOfA;
+typedef struct __swift_bridge__$SomeEnum$FieldOfB {void* description;} __swift_bridge__$SomeEnum$FieldOfB;
+
+union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfA A; __swift_bridge__$SomeEnum$FieldOfB B;};
+typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$A, __swift_bridge__$SomeEnum$B, } __swift_bridge__$SomeEnumTag;
+typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; union __swift_bridge__$SomeEnumFields payload;} __swift_bridge__$SomeEnum;
+typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__$SomeEnum val; } __swift_bridge__$Option$SomeEnum;
+"#,
+        ])
+    }
+
+    #[test]
+    fn generics() {
         CodegenTest {
             bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
@@ -745,11 +745,11 @@ mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data
             #[swift_bridge::bridge]
             mod ffi {
                 extern "Rust" {
-                    type SomeType<i32, u32>;
+                    type SomeType;
                 }
                 enum SomeEnum {
                     A{
-                        data1: SomeType<i32, u32>,
+                        data1: SomeType,
                         data2: u32
                     },
                     B{
@@ -765,7 +765,7 @@ mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data
             #[derive ()]
             pub enum SomeEnum {
                 A {
-                    data1: super::SomeType<i32, u32>,
+                    data1: super::SomeType,
                     data2: u32
                 },
                 B {
@@ -777,7 +777,7 @@ mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data
             #[doc(hidden)]
             pub enum __swift_bridge__SomeEnum {
                 A {
-                    data1: *mut super::SomeType<i32, u32>,
+                    data1: *mut super::SomeType,
                     data2: u32
                 },
                 B {
@@ -868,7 +868,7 @@ typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__
     }
 
     #[test]
-    fn generics() {
+    fn generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data() {
         CodegenTest {
             bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_enum_codegen_tests.rs
@@ -592,8 +592,8 @@ typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__
     }
 }
 
-/// Verify that we generate an enum type that has a variant with one named field and one with two named fields.
-mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data {
+/// Verify that we generate an enum type that has a variant with one with two named fields and one named field.
+mod generates_enum_to_and_from_ffi_conversions_two_named_data_and_one_named_data {
     use super::*;
 
     fn bridge_module_tokens() -> TokenStream {
@@ -724,151 +724,7 @@ typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__
     }
 
     #[test]
-    fn generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data() {
-        CodegenTest {
-            bridge_module: bridge_module_tokens().into(),
-            expected_rust_tokens: expected_rust_tokens(),
-            expected_swift_code: expected_swift_code(),
-            expected_c_header: expected_c_header(),
-        }
-        .test();
-    }
-}
-
-
-/// Verify that we generate an enum type that has a variant with one named field and one with two named fields.
-mod generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data_generics {
-    use super::*;
-
-    fn bridge_module_tokens() -> TokenStream {
-        quote! {
-            #[swift_bridge::bridge]
-            mod ffi {
-                extern "Rust" {
-                    type SomeType;
-                }
-                enum SomeEnum {
-                    A{
-                        data1: SomeType,
-                        data2: u32
-                    },
-                    B{
-                        description: String
-                    },
-                }
-            }
-        }
-    }
-
-    fn expected_rust_tokens() -> ExpectedRustTokens {
-        ExpectedRustTokens::Contains(quote! {
-            #[derive ()]
-            pub enum SomeEnum {
-                A {
-                    data1: super::SomeType,
-                    data2: u32
-                },
-                B {
-                    description: String
-                }
-            }
-
-            #[repr(C)]
-            #[doc(hidden)]
-            pub enum __swift_bridge__SomeEnum {
-                A {
-                    data1: *mut super::SomeType,
-                    data2: u32
-                },
-                B {
-                    description: *mut swift_bridge::string::RustString
-                }
-            }
-
-            impl swift_bridge::SharedEnum for SomeEnum {
-                type FfiRepr = __swift_bridge__SomeEnum;
-            }
-
-            impl SomeEnum {
-                #[doc(hidden)]
-                #[inline(always)]
-                pub fn into_ffi_repr(self) -> __swift_bridge__SomeEnum {
-                    match self {
-                        SomeEnum::A{data1, data2} => __swift_bridge__SomeEnum::A{data1: Box::into_raw(Box::new({
-                            let val: super::SomeType = data1;
-                            val
-                        })) as *mut super::SomeType, data2: data2},
-                        SomeEnum::B{description} => __swift_bridge__SomeEnum::B{description: swift_bridge::string::RustString(description).box_into_raw()}
-                    }
-                }
-            }
-
-            impl __swift_bridge__SomeEnum {
-                #[doc(hidden)]
-                #[inline(always)]
-                pub fn into_rust_repr(self) -> SomeEnum {
-                    match self {
-                        __swift_bridge__SomeEnum::A{data1, data2} => SomeEnum::A{data1: unsafe { * Box::from_raw(data1) }, data2: data2},
-                        __swift_bridge__SomeEnum::B{description} => SomeEnum::B{description: unsafe { Box::from_raw(description).0 }}
-                    }
-                }
-            }
-        })
-    }
-
-    fn expected_swift_code() -> ExpectedSwiftCode {
-        ExpectedSwiftCode::ContainsAfterTrim(
-            r#"
-public enum SomeEnum {
-    case A(data1: SomeType, data2: UInt32)
-    case B(description: RustString)
-}
-extension SomeEnum {
-    func intoFfiRepr() -> __swift_bridge__$SomeEnum {
-        switch self {
-            case SomeEnum.A(let data1, let data2):
-                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$A, payload: __swift_bridge__$SomeEnumFields(A: __swift_bridge__$SomeEnum$FieldOfA(data1: {data1.isOwned = false; return data1.ptr;}(), data2: data2)))
-            case SomeEnum.B(let description):
-                return __swift_bridge__$SomeEnum(tag: __swift_bridge__$SomeEnum$B, payload: __swift_bridge__$SomeEnumFields(B: __swift_bridge__$SomeEnum$FieldOfB(description: { let rustString = description.intoRustString(); rustString.isOwned = false; return rustString.ptr }())))
-        }
-    }
-}
-extension __swift_bridge__$SomeEnum {
-    func intoSwiftRepr() -> SomeEnum {
-        switch self.tag {
-            case __swift_bridge__$SomeEnum$A:
-                return SomeEnum.A(data1: SomeType(ptr: self.payload.A.data1), data2: self.payload.A.data2)
-            case __swift_bridge__$SomeEnum$B:
-                return SomeEnum.B(description: RustString(ptr: self.payload.B.description))
-            default:
-                fatalError("Unreachable")
-        }
-    }
-}
-"#,
-        )
-    }
-
-    fn expected_c_header() -> ExpectedCHeader {
-        ExpectedCHeader::ContainsManyAfterTrim(vec![
-            r#"
-#include <stdint.h>
-#include <stdbool.h>
-"#,
-            r#"
-typedef struct __swift_bridge__$SomeEnum$FieldOfA {void* data1; uint32_t data2;} __swift_bridge__$SomeEnum$FieldOfA;
-typedef struct __swift_bridge__$SomeEnum$FieldOfB {void* description;} __swift_bridge__$SomeEnum$FieldOfB;
-
-union __swift_bridge__$SomeEnumFields { __swift_bridge__$SomeEnum$FieldOfA A; __swift_bridge__$SomeEnum$FieldOfB B;};
-typedef enum __swift_bridge__$SomeEnumTag { __swift_bridge__$SomeEnum$A, __swift_bridge__$SomeEnum$B, } __swift_bridge__$SomeEnumTag;
-typedef struct __swift_bridge__$SomeEnum { __swift_bridge__$SomeEnumTag tag; union __swift_bridge__$SomeEnumFields payload;} __swift_bridge__$SomeEnum;
-typedef struct __swift_bridge__$Option$SomeEnum { bool is_some; __swift_bridge__$SomeEnum val; } __swift_bridge__$Option$SomeEnum;
-"#,
-        ])
-    }
-
-    #[test]
-    fn generates_enum_to_and_from_ffi_conversions_one_named_data_and_two_named_data() {
+    fn generates_enum_to_and_from_ffi_conversions_two_named_data_and_one_named_data() {
         CodegenTest {
             bridge_module: bridge_module_tokens().into(),
             expected_rust_tokens: expected_rust_tokens(),

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -212,8 +212,7 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                                 }
                             }
                             let enum_decl = format!(
-                                r#"{variant_fields}
-union {ffi_union_name} {union_fields};
+                                r#"{variant_fields}union {ffi_union_name} {union_fields};
 typedef enum {ffi_tag_name} {{ {variants}}} {ffi_tag_name};
 typedef struct {ffi_name} {{ {ffi_tag_name} tag; union {ffi_union_name} payload;}} {ffi_name};
 typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi_name};{maybe_vec_support}"#,

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
@@ -77,7 +77,9 @@ impl ToTokens for SwiftBridgeModule {
                     }
                 }
                 TypeDeclaration::Shared(SharedTypeDeclaration::Enum(shared_enum)) => {
-                    if let Some(definition) = self.generate_shared_enum_tokens(shared_enum, &self.types) {
+                    if let Some(definition) =
+                        self.generate_shared_enum_tokens(shared_enum, &self.types)
+                    {
                         shared_enum_definitions.push(definition);
                     }
                 }

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
@@ -77,7 +77,7 @@ impl ToTokens for SwiftBridgeModule {
                     }
                 }
                 TypeDeclaration::Shared(SharedTypeDeclaration::Enum(shared_enum)) => {
-                    if let Some(definition) = self.generate_shared_enum_tokens(shared_enum) {
+                    if let Some(definition) = self.generate_shared_enum_tokens(shared_enum, &self.types) {
                         shared_enum_definitions.push(definition);
                     }
                 }

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
@@ -5,7 +5,7 @@ use crate::bridged_type::{BridgedType, SharedEnum, StructFields};
 use crate::codegen::generate_rust_tokens::vec::vec_of_transparent_enum::generate_vec_of_transparent_enum_functions;
 use crate::{SwiftBridgeModule, SWIFT_BRIDGE_PREFIX};
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote, ToTokens};
+use quote::{format_ident, quote};
 use syn::Ident;
 
 impl SwiftBridgeModule {

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
@@ -36,7 +36,9 @@ impl SwiftBridgeModule {
                     let mut names = vec![];
                     for named_field in named_fields {
                         let field_name = &named_field.name;
-                        let ty = BridgedType::new_with_type(&named_field.ty, &self.types).unwrap().to_rust_type_path();
+                        let ty = BridgedType::new_with_type(&named_field.ty, &self.types)
+                            .unwrap()
+                            .to_rust_type_path();
                         let field = quote! {#field_name : #ty};
                         names.push(field);
                     }
@@ -47,7 +49,8 @@ impl SwiftBridgeModule {
                 StructFields::Unnamed(unamed_fields) => {
                     let mut names = vec![];
                     for unnamed_field in unamed_fields {
-                        let ty = BridgedType::new_with_type(&unnamed_field.ty, &self.types).unwrap();
+                        let ty =
+                            BridgedType::new_with_type(&unnamed_field.ty, &self.types).unwrap();
                         names.push(ty.to_rust_type_path());
                     }
                     quote! {

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
@@ -36,7 +36,7 @@ impl SwiftBridgeModule {
                     let mut names = vec![];
                     for named_field in named_fields {
                         let field_name = &named_field.name;
-                        let ty = named_field.ty.to_token_stream();
+                        let ty = BridgedType::new_with_type(&named_field.ty, &self.types).unwrap().to_rust_type_path();
                         let field = quote! {#field_name : #ty};
                         names.push(field);
                     }
@@ -47,7 +47,8 @@ impl SwiftBridgeModule {
                 StructFields::Unnamed(unamed_fields) => {
                     let mut names = vec![];
                     for unnamed_field in unamed_fields {
-                        names.push(unnamed_field.ty.to_token_stream());
+                        let ty = BridgedType::new_with_type(&unnamed_field.ty, &self.types).unwrap();
+                        names.push(ty.to_rust_type_path());
                     }
                     quote! {
                         #variant_name (#(#names),*)

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_enum.rs
@@ -3,6 +3,7 @@
 
 use crate::bridged_type::{BridgedType, SharedEnum, StructFields};
 use crate::codegen::generate_rust_tokens::vec::vec_of_transparent_enum::generate_vec_of_transparent_enum_functions;
+use crate::parse::TypeDeclarations;
 use crate::{SwiftBridgeModule, SWIFT_BRIDGE_PREFIX};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
@@ -13,6 +14,7 @@ impl SwiftBridgeModule {
     pub(super) fn generate_shared_enum_tokens(
         &self,
         shared_enum: &SharedEnum,
+        types: &TypeDeclarations,
     ) -> Option<TokenStream> {
         if shared_enum.already_declared {
             return None;
@@ -38,7 +40,7 @@ impl SwiftBridgeModule {
                         let field_name = &named_field.name;
                         let ty = BridgedType::new_with_type(&named_field.ty, &self.types)
                             .unwrap()
-                            .to_rust_type_path();
+                            .to_rust_type_path(types);
                         let field = quote! {#field_name : #ty};
                         names.push(field);
                     }
@@ -51,7 +53,7 @@ impl SwiftBridgeModule {
                     for unnamed_field in unamed_fields {
                         let ty =
                             BridgedType::new_with_type(&unnamed_field.ty, &self.types).unwrap();
-                        names.push(ty.to_rust_type_path());
+                        names.push(ty.to_rust_type_path(types));
                     }
                     quote! {
                         #variant_name (#(#names),*)

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
@@ -151,7 +151,6 @@ extension {option_ffi_name} {{
             return nil
         }}
     }}
-
     @inline(__always)
     static func fromSwiftRepr(_ val: Optional<{enum_name}>) -> {option_ffi_name} {{
         if let v = val {{

--- a/crates/swift-bridge-ir/src/parse/type_declarations/generics.rs
+++ b/crates/swift-bridge-ir/src/parse/type_declarations/generics.rs
@@ -105,7 +105,7 @@ impl OpaqueRustTypeGenerics {
             .iter()
             .map(|g| {
                 let ty = BridgedType::new_with_str(&g.ident.to_string(), types).unwrap();
-                let path = ty.to_rust_type_path();
+                let path = ty.to_rust_type_path(types);
                 quote! { #path }
             })
             .collect();

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_rust_impl_call_swift.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_rust_impl_call_swift.rs
@@ -45,7 +45,7 @@ impl ParsedExternFn {
             }
             ReturnType::Type(arrow, _ty) => {
                 if let Some(built_in) = BridgedType::new_with_return_type(&sig.output, types) {
-                    let ty = built_in.maybe_convert_pointer_to_super_pointer();
+                    let ty = built_in.maybe_convert_pointer_to_super_pointer(types);
                     let return_ty_span = sig.output.span();
 
                     quote_spanned! {return_ty_span=> #arrow #ty}
@@ -113,7 +113,7 @@ impl ParsedExternFn {
             let boxed_fn_name = format!("{}{}_param{idx}", maybe_associated_ty, fn_name);
             let boxed_fn_name = Ident::new(&boxed_fn_name, fn_name.span());
 
-            let boxed_fn_ffi_repr = boxed_fn.to_ffi_compatible_rust_type();
+            let boxed_fn_ffi_repr = boxed_fn.to_ffi_compatible_rust_type(types);
 
             let free_boxed_fn_name = format!("free_{}{}_param{idx}", maybe_associated_ty, fn_name);
             let free_boxed_fn_name = Ident::new(&free_boxed_fn_name, fn_name.span());
@@ -204,7 +204,7 @@ impl ParsedExternFn {
                             let pat = &pat_ty.pat;
 
                             if let Some(built_in) = BridgedType::new_with_fn_arg(fn_arg, types) {
-                                let ty = built_in.maybe_convert_pointer_to_super_pointer();
+                                let ty = built_in.maybe_convert_pointer_to_super_pointer(types);
 
                                 quote! { #pat: #ty}
                             } else {

--- a/crates/swift-integration-tests/src/shared_types/shared_enum.rs
+++ b/crates/swift-integration-tests/src/shared_types/shared_enum.rs
@@ -9,8 +9,15 @@ mod ffi {
         fn reflect_enum_with_no_data(arg: EnumWithNoData) -> EnumWithNoData;
     }
 
+    extern "Rust" {
+        #[swift_bridge(Equatable)]
+        type Foo;
+        #[swift_bridge(associated_to = Foo)]
+        fn new() -> Foo;
+    }
+
     enum EnumWithUnnamedData {
-        Variant1(String, u32),
+        Variant1(String, Foo),
         Variant2(i32, u8),
         Variant3,
     }
@@ -19,14 +26,10 @@ mod ffi {
         fn reflect_enum_with_unnamed_data(arg: EnumWithUnnamedData) -> EnumWithUnnamedData;
     }
 
-    extern "Rust" {
-        type SomeType<i32, u32>;
-    }
-
     enum EnumWithNamedData {
         Variant1 { hello: String, data_u8: u8 },
-        Variant2 { data_i32: SomeType<i32, u32> },
-        Variant3,
+        Variant2 { data_i32: i32 },
+        Variant3 {foo: Foo},
     }
 
     extern "Rust" {
@@ -46,4 +49,11 @@ fn reflect_enum_with_named_data(arg: ffi::EnumWithNamedData) -> ffi::EnumWithNam
     arg
 }
 
-pub struct SomeType<T, U>(T, U);
+#[derive(PartialEq)]
+pub struct Foo;
+
+impl Foo {
+    fn new() -> Self {
+        Foo
+    }
+}

--- a/crates/swift-integration-tests/src/shared_types/shared_enum.rs
+++ b/crates/swift-integration-tests/src/shared_types/shared_enum.rs
@@ -30,7 +30,7 @@ mod ffi {
     enum EnumWithNamedData {
         Variant1 { hello: String, data_u8: u8 },
         Variant2 { data_i32: i32 },
-        Variant3 { foo: OpaqueRustForEnumTest },
+        Variant3,
     }
 
     extern "Rust" {

--- a/crates/swift-integration-tests/src/shared_types/shared_enum.rs
+++ b/crates/swift-integration-tests/src/shared_types/shared_enum.rs
@@ -19,9 +19,13 @@ mod ffi {
         fn reflect_enum_with_unnamed_data(arg: EnumWithUnnamedData) -> EnumWithUnnamedData;
     }
 
+    extern "Rust" {
+        type SomeType<i32, u32>;
+    }
+
     enum EnumWithNamedData {
         Variant1 { hello: String, data_u8: u8 },
-        Variant2 { data_i32: i32 },
+        Variant2 { data_i32: SomeType<i32, u32> },
         Variant3,
     }
 
@@ -41,3 +45,5 @@ fn reflect_enum_with_unnamed_data(arg: ffi::EnumWithUnnamedData) -> ffi::EnumWit
 fn reflect_enum_with_named_data(arg: ffi::EnumWithNamedData) -> ffi::EnumWithNamedData {
     arg
 }
+
+pub struct SomeType<T, U>(T, U);

--- a/crates/swift-integration-tests/src/shared_types/shared_enum.rs
+++ b/crates/swift-integration-tests/src/shared_types/shared_enum.rs
@@ -45,6 +45,24 @@ mod ffi {
     extern "Rust" {
         fn reflect_enum_with_opaque_type(arg: EnumWithOpaqueRust) -> EnumWithOpaqueRust;
     }
+
+    extern "Rust" {
+        #[swift_bridge(declare_generic)]
+        type GenericOpaqueRustForEnumTest<T>;
+
+        type GenericOpaqueRustForEnumTest<i32>;
+        fn new_generic_opaque_rust_for_enum_test() -> GenericOpaqueRustForEnumTest<i32>;
+    }
+
+    enum EnumWithGenericOpaqueRust {
+        Named { data: GenericOpaqueRustForEnumTest<i32> },
+        Unnamed(GenericOpaqueRustForEnumTest<i32>)
+    }
+
+    extern "Rust" {
+        fn reflect_enum_with_generic_opaque_type(arg: EnumWithGenericOpaqueRust) -> EnumWithGenericOpaqueRust;
+    }
+
 }
 
 fn reflect_enum_with_no_data(arg: ffi::EnumWithNoData) -> ffi::EnumWithNoData {
@@ -70,4 +88,19 @@ impl OpaqueRustForEnumTest {
     fn new() -> Self {
         OpaqueRustForEnumTest
     }
+}
+
+pub struct GenericOpaqueRustForEnumTest<T>{
+    #[allow(unused)]
+    field: T,
+}
+
+fn new_generic_opaque_rust_for_enum_test() -> GenericOpaqueRustForEnumTest<i32>{
+    GenericOpaqueRustForEnumTest{
+        field: 123
+    }
+}
+
+fn reflect_enum_with_generic_opaque_type(arg: ffi::EnumWithGenericOpaqueRust) -> ffi::EnumWithGenericOpaqueRust {
+    arg
 }

--- a/crates/swift-integration-tests/src/shared_types/shared_enum.rs
+++ b/crates/swift-integration-tests/src/shared_types/shared_enum.rs
@@ -29,7 +29,7 @@ mod ffi {
     enum EnumWithNamedData {
         Variant1 { hello: String, data_u8: u8 },
         Variant2 { data_i32: i32 },
-        Variant3 {foo: Foo},
+        Variant3 { foo: Foo },
     }
 
     extern "Rust" {

--- a/crates/swift-integration-tests/src/shared_types/shared_enum.rs
+++ b/crates/swift-integration-tests/src/shared_types/shared_enum.rs
@@ -12,7 +12,7 @@ mod ffi {
     extern "Rust" {
         #[swift_bridge(Equatable)]
         type OpaqueRustForEnumTest;
-        
+
         #[swift_bridge(init)]
         fn new() -> OpaqueRustForEnumTest;
     }
@@ -39,7 +39,7 @@ mod ffi {
 
     enum EnumWithOpaqueRust {
         Named { data: OpaqueRustForEnumTest },
-        Unnamed(OpaqueRustForEnumTest)
+        Unnamed(OpaqueRustForEnumTest),
     }
 
     extern "Rust" {
@@ -55,14 +55,17 @@ mod ffi {
     }
 
     enum EnumWithGenericOpaqueRust {
-        Named { data: GenericOpaqueRustForEnumTest<i32> },
-        Unnamed(GenericOpaqueRustForEnumTest<i32>)
+        Named {
+            data: GenericOpaqueRustForEnumTest<i32>,
+        },
+        Unnamed(GenericOpaqueRustForEnumTest<i32>),
     }
 
     extern "Rust" {
-        fn reflect_enum_with_generic_opaque_type(arg: EnumWithGenericOpaqueRust) -> EnumWithGenericOpaqueRust;
+        fn reflect_enum_with_generic_opaque_type(
+            arg: EnumWithGenericOpaqueRust,
+        ) -> EnumWithGenericOpaqueRust;
     }
-
 }
 
 fn reflect_enum_with_no_data(arg: ffi::EnumWithNoData) -> ffi::EnumWithNoData {
@@ -90,17 +93,17 @@ impl OpaqueRustForEnumTest {
     }
 }
 
-pub struct GenericOpaqueRustForEnumTest<T>{
+pub struct GenericOpaqueRustForEnumTest<T> {
     #[allow(unused)]
     field: T,
 }
 
-fn new_generic_opaque_rust_for_enum_test() -> GenericOpaqueRustForEnumTest<i32>{
-    GenericOpaqueRustForEnumTest{
-        field: 123
-    }
+fn new_generic_opaque_rust_for_enum_test() -> GenericOpaqueRustForEnumTest<i32> {
+    GenericOpaqueRustForEnumTest { field: 123 }
 }
 
-fn reflect_enum_with_generic_opaque_type(arg: ffi::EnumWithGenericOpaqueRust) -> ffi::EnumWithGenericOpaqueRust {
+fn reflect_enum_with_generic_opaque_type(
+    arg: ffi::EnumWithGenericOpaqueRust,
+) -> ffi::EnumWithGenericOpaqueRust {
     arg
 }

--- a/crates/swift-integration-tests/src/shared_types/shared_enum.rs
+++ b/crates/swift-integration-tests/src/shared_types/shared_enum.rs
@@ -12,7 +12,8 @@ mod ffi {
     extern "Rust" {
         #[swift_bridge(Equatable)]
         type Foo;
-        #[swift_bridge(associated_to = Foo)]
+        
+        #[swift_bridge(init)]
         fn new() -> Foo;
     }
 

--- a/crates/swift-integration-tests/src/shared_types/shared_enum.rs
+++ b/crates/swift-integration-tests/src/shared_types/shared_enum.rs
@@ -18,9 +18,9 @@ mod ffi {
     }
 
     enum EnumWithUnnamedData {
-        Variant1(String, OpaqueRustForEnumTest),
-        Variant2(i32, u8),
-        Variant3,
+        TwoFields(String, OpaqueRustForEnumTest),
+        OneField(i32),
+        NoFields,
     }
 
     extern "Rust" {
@@ -28,9 +28,9 @@ mod ffi {
     }
 
     enum EnumWithNamedData {
-        Variant1 { hello: String, data_u8: u8 },
-        Variant2 { data_i32: i32 },
-        Variant3,
+        TwoFields { hello: String, data_u8: u8 },
+        OneField { data_i32: i32 },
+        NoFields,
     }
 
     extern "Rust" {

--- a/crates/swift-integration-tests/src/shared_types/shared_enum.rs
+++ b/crates/swift-integration-tests/src/shared_types/shared_enum.rs
@@ -11,14 +11,14 @@ mod ffi {
 
     extern "Rust" {
         #[swift_bridge(Equatable)]
-        type Foo;
+        type OpaqueRustForEnumTest;
         
         #[swift_bridge(init)]
-        fn new() -> Foo;
+        fn new() -> OpaqueRustForEnumTest;
     }
 
     enum EnumWithUnnamedData {
-        Variant1(String, Foo),
+        Variant1(String, OpaqueRustForEnumTest),
         Variant2(i32, u8),
         Variant3,
     }
@@ -30,7 +30,7 @@ mod ffi {
     enum EnumWithNamedData {
         Variant1 { hello: String, data_u8: u8 },
         Variant2 { data_i32: i32 },
-        Variant3 { foo: Foo },
+        Variant3 { foo: OpaqueRustForEnumTest },
     }
 
     extern "Rust" {
@@ -51,10 +51,10 @@ fn reflect_enum_with_named_data(arg: ffi::EnumWithNamedData) -> ffi::EnumWithNam
 }
 
 #[derive(PartialEq)]
-pub struct Foo;
+pub struct OpaqueRustForEnumTest;
 
-impl Foo {
+impl OpaqueRustForEnumTest {
     fn new() -> Self {
-        Foo
+        OpaqueRustForEnumTest
     }
 }

--- a/crates/swift-integration-tests/src/shared_types/shared_enum.rs
+++ b/crates/swift-integration-tests/src/shared_types/shared_enum.rs
@@ -36,6 +36,15 @@ mod ffi {
     extern "Rust" {
         fn reflect_enum_with_named_data(arg: EnumWithNamedData) -> EnumWithNamedData;
     }
+
+    enum EnumWithOpaqueRust {
+        Named { data: OpaqueRustForEnumTest },
+        Unnamed(OpaqueRustForEnumTest)
+    }
+
+    extern "Rust" {
+        fn reflect_enum_with_opaque_type(arg: EnumWithOpaqueRust) -> EnumWithOpaqueRust;
+    }
 }
 
 fn reflect_enum_with_no_data(arg: ffi::EnumWithNoData) -> ffi::EnumWithNoData {
@@ -47,6 +56,10 @@ fn reflect_enum_with_unnamed_data(arg: ffi::EnumWithUnnamedData) -> ffi::EnumWit
 }
 
 fn reflect_enum_with_named_data(arg: ffi::EnumWithNamedData) -> ffi::EnumWithNamedData {
+    arg
+}
+
+fn reflect_enum_with_opaque_type(arg: ffi::EnumWithOpaqueRust) -> ffi::EnumWithOpaqueRust {
     arg
 }
 


### PR DESCRIPTION
This PR adds support for opaque types as enum variant fields. However, This PR doesn't support generic opaque types. I'll write the reason later.

Here's an example:

```rust
#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        #[swift_bridge(Equatable)]
        type Foo;
        #[swift_bridge(associated_to = Foo)]
        fn new() -> Foo;
    }

    enum EnumWithNamedData {
        Variant1 { hello: String, data_u8: u8 },
        Variant2 { data_i32: i32 },
        Variant3 { foo: Foo },
    }

    extern "Rust" {
        fn reflect_enum_with_named_data(arg: EnumWithNamedData) -> EnumWithNamedData;
    }
}
```

```Swift
let enumWithNamedData3 = EnumWithNamedData.Variant3(foo: Foo.new())
switch reflect_enum_with_named_data(enumWithNamedData3) {
case .Variant3(let foo):
    XCTAssertEqual(foo, Foo.new())
    break
default:
    XCTFail()
}
```