### PR TITLE
Support for returning `Result<OpaqueRustType, TransparentEnumType>` from `async` Rust functions

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Result.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Result.swift
@@ -26,14 +26,17 @@ public class ResultTestOpaqueSwiftType {
 extension ResultTestOpaqueRustType: @unchecked Sendable {}
 extension ResultTestOpaqueRustType: Error {}
 
+extension AsyncResultOpaqueRustType1: @unchecked Sendable {}
+extension AsyncResultOpaqueRustType1: Error {}
+
 extension AsyncResultOpaqueRustType2: @unchecked Sendable {}
 extension AsyncResultOpaqueRustType2: Error {}
 
-extension ResultTransparentEnum: Error {}
 extension ResultTransparentEnum: @unchecked Sendable {}
+extension ResultTransparentEnum: Error {}
 
-extension SameEnum: Error {}
 extension SameEnum: @unchecked Sendable {}
+extension SameEnum: Error {}
 
-extension AsyncResultErrEnum: Error {}
 extension AsyncResultErrEnum: @unchecked Sendable {}
+extension AsyncResultErrEnum: Error {}

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Result.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Result.swift
@@ -34,3 +34,6 @@ extension ResultTransparentEnum: @unchecked Sendable {}
 
 extension SameEnum: Error {}
 extension SameEnum: @unchecked Sendable {}
+
+extension AsyncResultErrEnum: Error {}
+extension AsyncResultErrEnum: @unchecked Sendable {}

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
@@ -62,6 +62,42 @@ class AsyncTests: XCTestCase {
         }
     }
     
+    //Verify that we can return a Result<TransparentEnum, TransparentEnum> from async Rust function
+    func testSwiftCallsRustAsyncFnReturnResultTransparentEnum() async throws {
+        
+        //Should return an AsyncResultOkEnum
+        do {
+            let value: AsyncResultOkEnum = try await rust_async_func_return_result_transparent_enum_and_transparent_enum(true)
+            switch value {
+            case .NoFields:
+                XCTFail()
+            case .UnnamedFields(let valueInt32, let valueString):
+                XCTAssertEqual(valueInt32, 123)
+                XCTAssertEqual(valueString.toString(), "hello")
+            case .NamedFields(_):
+                XCTFail()
+            }
+        } catch {
+            XCTFail()
+        }
+        
+        //Should throw an AsyncResultErrEnum
+        do {
+            let _ = try await rust_async_func_return_result_transparent_enum_and_transparent_enum(false)
+        } catch let error as AsyncResultErrEnum {
+            switch error {
+            case .NoFields:
+                XCTFail()
+            case .UnnamedFields(_, _):
+                XCTFail()
+            case .NamedFields(let valueUInt32):
+                XCTAssertEqual(valueUInt32, 100)
+            }
+        } catch {
+            XCTFail()
+        }
+    }
+    
     func testSwiftCallsRustAsyncFnRetStruct() async throws {
         let _: AsyncRustFnReturnStruct = await rust_async_return_struct()
     }

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
@@ -62,7 +62,7 @@ class AsyncTests: XCTestCase {
         }
     }
     
-    //Verify that we can return a Result<TransparentEnum, TransparentEnum> from async Rust function
+    /// Verify that we can return a Result<TransparentEnum, TransparentEnum> from async Rust function
     func testSwiftCallsRustAsyncFnReturnResultTransparentEnum() async throws {
         
         //Should return an AsyncResultOkEnum
@@ -84,6 +84,7 @@ class AsyncTests: XCTestCase {
         //Should throw an AsyncResultErrEnum
         do {
             let _ = try await rust_async_func_return_result_transparent_enum_and_transparent_enum(false)
+            XCTFail()
         } catch let error as AsyncResultErrEnum {
             switch error {
             case .NoFields:
@@ -96,6 +97,62 @@ class AsyncTests: XCTestCase {
         } catch {
             XCTFail()
         }
+    }
+    
+    /// Verify that we can return a Result<OpaqueRust, TransparentEnum> from async Rust function
+    func testSwiftCallsRustAsyncFnReturnResultOpaqueRustTransparentEnum() async throws {
+        //Should return an AsyncResultOpaqueRustType1
+        do {
+            let value: AsyncResultOpaqueRustType1 = try await rust_async_func_return_result_opaque_rust_and_transparent_enum(true)
+            XCTAssertEqual(value.val(), 10)
+        } catch {
+            XCTFail()
+        }
+        
+        //Should throw an AsyncResultErrEnum
+        do {
+            let _: AsyncResultOpaqueRustType1 = try await rust_async_func_return_result_opaque_rust_and_transparent_enum(false)
+        } catch let error as AsyncResultErrEnum {
+            switch error {
+            case .NoFields:
+                XCTFail()
+            case .UnnamedFields(_, _):
+                XCTFail()
+            case .NamedFields(let value):
+                XCTAssertEqual(value, 1000)
+            }
+        } catch {
+            XCTFail()
+        }
+    }
+    
+    /// Verify that we can return a Result<TransparentEnum, OpaqueRust> from async Rust function
+    func testSwiftCallsRustAsyncFnReturnResultTransparentEnumOpaqueRust() async throws {
+        //Should return an AsyncResultOkEnum
+        do {
+            let value: AsyncResultOkEnum = try await rust_async_func_return_result_transparent_enum_and_opaque_rust(true)
+            switch value {
+            case .NoFields:
+                break
+            case .UnnamedFields(_, _):
+                XCTFail()
+            case .NamedFields(let value):
+                XCTFail()
+            }
+        } catch {
+            XCTFail()
+        }
+        
+        //Should throw an AsyncResultOpaqueRustType1
+        do {
+            let _ = try await rust_async_func_return_result_transparent_enum_and_opaque_rust(false)
+            XCTFail()
+        } catch let error as AsyncResultOpaqueRustType1 {
+            XCTAssertEqual(error.val(), 1000)
+        } catch {
+            XCTFail()
+        }
+        
     }
     
     func testSwiftCallsRustAsyncFnRetStruct() async throws {

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
@@ -410,23 +410,37 @@ typedef struct {c_enum_name}{{{c_tag_name} tag; union {c_fields_name} payload;}}
         return true;
     }
 
-    pub fn generate_async_run_wrapper_cb(&self, expression: &str, type_pos: TypePosition, types: &TypeDeclarations) -> String {
+    pub fn generate_async_run_wrapper_cb(
+        &self,
+        expression: &str,
+        type_pos: TypePosition,
+        types: &TypeDeclarations,
+    ) -> String {
         if self.is_custom_result_type() {
-            let ok = self.ok_ty.convert_ffi_expression_to_swift_type(&format!("{expression}.payload.ok"), type_pos, types);
-            let err = self.err_ty.convert_ffi_expression_to_swift_type(&format!("{expression}.payload.err"), type_pos, types);
+            let ok = self.ok_ty.convert_ffi_expression_to_swift_type(
+                &format!("{expression}.payload.ok"),
+                type_pos,
+                types,
+            );
+            let err = self.err_ty.convert_ffi_expression_to_swift_type(
+                &format!("{expression}.payload.err"),
+                type_pos,
+                types,
+            );
             return format!(
-                r#"switch {expression}.tag {{ case {c_ok_tag_name}: wrapper.cb(.success({ok})) case {c_err_tag_name}: wrapper.cb(.failure({err})) default: fatalError() }}"#
-            , expression = expression, ok = ok, err = err, c_ok_tag_name = self.c_ok_tag_name(), c_err_tag_name = self.c_err_tag_name());
+                r#"switch {expression}.tag {{ case {c_ok_tag_name}: wrapper.cb(.success({ok})) case {c_err_tag_name}: wrapper.cb(.failure({err})) default: fatalError() }}"#,
+                expression = expression,
+                ok = ok,
+                err = err,
+                c_ok_tag_name = self.c_ok_tag_name(),
+                c_err_tag_name = self.c_err_tag_name()
+            );
         }
-        let ok = self
-        .ok_ty
-        .to_swift_type(type_pos, types);
-        let err = self
-        .err_ty
-        .to_swift_type(type_pos, types);
+        let ok = self.ok_ty.to_swift_type(type_pos, types);
+        let err = self.err_ty.to_swift_type(type_pos, types);
 
         format!(
-                r#"if rustFnRetVal.is_ok {{
+            r#"if rustFnRetVal.is_ok {{
         wrapper.cb(.success({ok}(ptr: rustFnRetVal.ok_or_err!)))
     }} else {{
         wrapper.cb(.failure({err}(ptr: rustFnRetVal.ok_or_err!)))

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
@@ -412,9 +412,11 @@ typedef struct {c_enum_name}{{{c_tag_name} tag; union {c_fields_name} payload;}}
 
     pub fn generate_async_run_wrapper_cb(&self, expression: &str, type_pos: TypePosition, types: &TypeDeclarations) -> String {
         if self.is_custom_result_type() {
+            let ok = self.ok_ty.convert_ffi_expression_to_swift_type(&format!("{expression}.payload.ok"), type_pos, types);
+            let err = self.err_ty.convert_ffi_expression_to_swift_type(&format!("{expression}.payload.err"), type_pos, types);
             return format!(
-                r#"switch {expression}.tag {{ case {c_ok_tag_name}: wrapper.cb(.success({expression}.payload.ok.intoSwiftRepr())) case {c_err_tag_name}: wrapper.cb(.failure({expression}.payload.err.intoSwiftRepr())) default: fatalError() }}"#
-            , expression = expression, c_ok_tag_name = self.c_ok_tag_name(), c_err_tag_name = self.c_err_tag_name());
+                r#"switch {expression}.tag {{ case {c_ok_tag_name}: wrapper.cb(.success({ok})) case {c_err_tag_name}: wrapper.cb(.failure({err})) default: fatalError() }}"#
+            , expression = expression, ok = ok, err = err, c_ok_tag_name = self.c_ok_tag_name(), c_err_tag_name = self.c_err_tag_name());
         }
         let ok = self
         .ok_ty

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
@@ -410,11 +410,11 @@ typedef struct {c_enum_name}{{{c_tag_name} tag; union {c_fields_name} payload;}}
         return true;
     }
 
-    pub fn generate_async_run_wrapper_cb(&self, type_pos: TypePosition, types: &TypeDeclarations) -> String {
+    pub fn generate_async_run_wrapper_cb(&self, expression: &str, type_pos: TypePosition, types: &TypeDeclarations) -> String {
         if self.is_custom_result_type() {
             return format!(
-                r#"switch rustFnRetVal.tag {{ case __swift_bridge__$ResultOkEnumAndErrEnum$ResultOk: wrapper.cb(.success(rustFnRetVal.payload.ok.intoSwiftRepr())) case __swift_bridge__$ResultOkEnumAndErrEnum$ResultErr: wrapper.cb(.failure(rustFnRetVal.payload.err.intoSwiftRepr())) default: fatalError() }}"#
-            );
+                r#"switch {expression}.tag {{ case {c_ok_tag_name}: wrapper.cb(.success({expression}.payload.ok.intoSwiftRepr())) case {c_err_tag_name}: wrapper.cb(.failure({expression}.payload.err.intoSwiftRepr())) default: fatalError() }}"#
+            , expression = expression, c_ok_tag_name = self.c_ok_tag_name(), c_err_tag_name = self.c_err_tag_name());
         }
         let ok = self
         .ok_ty

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/async_function_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/async_function_codegen_tests.rs
@@ -660,8 +660,8 @@ mod extern_rust_async_function_returns_result_transparent_enum {
             #[swift_bridge::bridge]
             mod ffi {
                 enum OkEnum {
-                    OkVariant1, 
-                    OkVariant2, 
+                    OkVariant1,
+                    OkVariant2,
                 }
                 enum ErrEnum {
                     ErrVariant1,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/async_function_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/async_function_codegen_tests.rs
@@ -704,10 +704,10 @@ mod extern_rust_async_function_returns_result_transparent_enum {
     fn expected_swift_code() -> ExpectedSwiftCode {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
-public func some_function() async throws -> OkType {
+public func some_function() async throws -> OkEnum {
     func onComplete(cbWrapperPtr: UnsafeMutableRawPointer?, rustFnRetVal: __swift_bridge__$ResultOkEnumAndErrEnum) {
         let wrapper = Unmanaged<CbWrapper$some_function>.fromOpaque(cbWrapperPtr!).takeRetainedValue()
-        switch val.tag { case __swift_bridge__$ResultOkEnumAndErrEnum$ResultOk: wrapper.cb(.success(val.payload.ok.intoSwiftRepr())) case __swift_bridge__$ResultOkEnumAndErrEnum$ResultErr: wrapper.cb(.failure(val.payload.err.intoSwiftRepr())) }
+        switch rustFnRetVal.tag { case __swift_bridge__$ResultOkEnumAndErrEnum$ResultOk: wrapper.cb(.success(rustFnRetVal.payload.ok.intoSwiftRepr())) case __swift_bridge__$ResultOkEnumAndErrEnum$ResultErr: wrapper.cb(.failure(rustFnRetVal.payload.err.intoSwiftRepr())) default: fatalError() }
     }
 
     return try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<OkEnum, Error>) in

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/async_function_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/async_function_codegen_tests.rs
@@ -751,3 +751,104 @@ void __swift_bridge__$some_function(void* callback_wrapper, void __swift_bridge_
         .test();
     }
 }
+
+/// Verify that we generate the correct code for extern "Rust" async functions that returns a Result<OpaqueRustType, TransparentEnum>.
+mod extern_rust_async_function_returns_result_opaque_rust_transparent_enum {
+    use super::*;
+
+    fn bridge_module() -> TokenStream {
+        quote! {
+            #[swift_bridge::bridge]
+            mod ffi {
+                enum ErrEnum {
+                    ErrVariant1,
+                    ErrVariant2,
+                }
+                extern "Rust" {
+                    type SomeType;
+                    async fn some_function() -> Result<SomeType, ErrEnum>;
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::Contains(quote! {
+             pub extern "C" fn __swift_bridge__some_function(
+                callback_wrapper: *mut std::ffi::c_void,
+                callback: extern "C" fn(*mut std::ffi::c_void, ResultSomeTypeAndErrEnum) -> (),
+            ) {
+                let callback_wrapper = swift_bridge::async_support::SwiftCallbackWrapper(callback_wrapper);
+                let fut = super::some_function();
+                let task = async move {
+                let val = match fut.await {
+                    Ok(ok) => ResultSomeTypeAndErrEnum::Ok(Box::into_raw(Box::new({
+                        let val: super::SomeType = ok;
+                        val
+                    })) as *mut super::SomeType),
+                    Err(err) => ResultSomeTypeAndErrEnum::Err(err.into_ffi_repr()),
+                };
+                    let callback_wrapper = callback_wrapper;
+                    let callback_wrapper = callback_wrapper.0;
+
+                    (callback)(callback_wrapper, val)
+                };
+                swift_bridge::async_support::ASYNC_RUNTIME.spawn_task(Box::pin(task))
+            }
+        })
+    }
+
+    // TODO: Replace `Error` with the concrete error type `ErrorType`.
+    // As of Feb 2023 using the concrete error type leads to a compile time error.
+    // This seems like a bug in the Swift compiler.
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(
+            r#"
+public func some_function() async throws -> SomeType {
+    func onComplete(cbWrapperPtr: UnsafeMutableRawPointer?, rustFnRetVal: __swift_bridge__$ResultSomeTypeAndErrEnum) {
+        let wrapper = Unmanaged<CbWrapper$some_function>.fromOpaque(cbWrapperPtr!).takeRetainedValue()
+        switch rustFnRetVal.tag { case __swift_bridge__$ResultSomeTypeAndErrEnum$ResultOk: wrapper.cb(.success(SomeType(ptr: rustFnRetVal.payload.ok))) case __swift_bridge__$ResultSomeTypeAndErrEnum$ResultErr: wrapper.cb(.failure(rustFnRetVal.payload.err.intoSwiftRepr())) default: fatalError() }
+    }
+
+    return try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<SomeType, Error>) in
+        let callback = { rustFnRetVal in
+            continuation.resume(with: rustFnRetVal)
+        }
+
+        let wrapper = CbWrapper$some_function(cb: callback)
+        let wrapperPtr = Unmanaged.passRetained(wrapper).toOpaque()
+
+        __swift_bridge__$some_function(wrapperPtr, onComplete)
+    })
+}
+class CbWrapper$some_function {
+    var cb: (Result<SomeType, Error>) -> ()
+
+    public init(cb: @escaping (Result<SomeType, Error>) -> ()) {
+        self.cb = cb
+    }
+}
+"#,
+        )
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ContainsAfterTrim(
+            r#"
+void __swift_bridge__$some_function(void* callback_wrapper, void __swift_bridge__$some_function$async(void* callback_wrapper, struct __swift_bridge__$ResultSomeTypeAndErrEnum ret));
+    "#,
+        )
+    }
+
+    #[test]
+    fn extern_rust_async_function_returns_result_opaque_rust_transparent_enum() {
+        CodegenTest {
+            bridge_module: bridge_module().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/generate_function_swift_calls_rust.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/generate_function_swift_calls_rust.rs
@@ -213,20 +213,9 @@ pub(super) fn gen_func_swift_calls_rust(
         let callback_wrapper_ty = format!("CbWrapper{}${}", maybe_type_name_segment, fn_name);
         let (run_wrapper_cb, error, maybe_try, with_checked_continuation_function_name) =
             if let Some(result) = func_ret_ty.as_result() {
-                let ok = result
-                    .ok_ty
-                    .to_swift_type(TypePosition::FnReturn(HostLang::Rust), types);
-                let err = result
-                    .err_ty
-                    .to_swift_type(TypePosition::FnReturn(HostLang::Rust), types);
+                let run_wrapper_cb = result.generate_async_run_wrapper_cb(types);
                 (
-                    format!(
-                        r#"if rustFnRetVal.is_ok {{
-        wrapper.cb(.success({ok}(ptr: rustFnRetVal.ok_or_err!)))
-    }} else {{
-        wrapper.cb(.failure({err}(ptr: rustFnRetVal.ok_or_err!)))
-    }}"#
-                    ),
+                    run_wrapper_cb,
                     "Error".to_string(),
                     " try ".to_string(),
                     "withCheckedThrowingContinuation".to_string(),

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/generate_function_swift_calls_rust.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/generate_function_swift_calls_rust.rs
@@ -213,7 +213,11 @@ pub(super) fn gen_func_swift_calls_rust(
         let callback_wrapper_ty = format!("CbWrapper{}${}", maybe_type_name_segment, fn_name);
         let (run_wrapper_cb, error, maybe_try, with_checked_continuation_function_name) =
             if let Some(result) = func_ret_ty.as_result() {
-                let run_wrapper_cb = result.generate_async_run_wrapper_cb("rustFnRetVal", TypePosition::FnReturn(HostLang::Rust), types);
+                let run_wrapper_cb = result.generate_async_run_wrapper_cb(
+                    "rustFnRetVal",
+                    TypePosition::FnReturn(HostLang::Rust),
+                    types,
+                );
                 (
                     run_wrapper_cb,
                     "Error".to_string(),

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/generate_function_swift_calls_rust.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/generate_function_swift_calls_rust.rs
@@ -213,7 +213,7 @@ pub(super) fn gen_func_swift_calls_rust(
         let callback_wrapper_ty = format!("CbWrapper{}${}", maybe_type_name_segment, fn_name);
         let (run_wrapper_cb, error, maybe_try, with_checked_continuation_function_name) =
             if let Some(result) = func_ret_ty.as_result() {
-                let run_wrapper_cb = result.generate_async_run_wrapper_cb(types);
+                let run_wrapper_cb = result.generate_async_run_wrapper_cb(TypePosition::FnReturn(HostLang::Rust), types);
                 (
                     run_wrapper_cb,
                     "Error".to_string(),

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/generate_function_swift_calls_rust.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/generate_function_swift_calls_rust.rs
@@ -213,7 +213,7 @@ pub(super) fn gen_func_swift_calls_rust(
         let callback_wrapper_ty = format!("CbWrapper{}${}", maybe_type_name_segment, fn_name);
         let (run_wrapper_cb, error, maybe_try, with_checked_continuation_function_name) =
             if let Some(result) = func_ret_ty.as_result() {
-                let run_wrapper_cb = result.generate_async_run_wrapper_cb(TypePosition::FnReturn(HostLang::Rust), types);
+                let run_wrapper_cb = result.generate_async_run_wrapper_cb("rustFnRetVal", TypePosition::FnReturn(HostLang::Rust), types);
                 (
                     run_wrapper_cb,
                     "Error".to_string(),

--- a/crates/swift-integration-tests/src/async_function.rs
+++ b/crates/swift-integration-tests/src/async_function.rs
@@ -57,6 +57,8 @@ mod ffi {
 
     extern "Rust" {
         async fn rust_async_func_return_result_transparent_enum_and_transparent_enum(succeed: bool) -> Result<AsyncResultOkEnum, AsyncResultErrEnum>;
+        async fn rust_async_func_return_result_opaque_rust_and_transparent_enum(succeed: bool) -> Result<AsyncResultOpaqueRustType1, AsyncResultErrEnum>;
+        async fn rust_async_func_return_result_transparent_enum_and_opaque_rust(succeed: bool) -> Result<AsyncResultOkEnum, AsyncResultOpaqueRustType1>;
     }
 }
 
@@ -131,5 +133,21 @@ async fn rust_async_func_return_result_transparent_enum_and_transparent_enum(suc
         Ok(ffi::AsyncResultOkEnum::UnnamedFields(123, "hello".to_string()))
     } else {
         Err(ffi::AsyncResultErrEnum::NamedFields { value: 100 })
+    }
+}
+
+async fn rust_async_func_return_result_opaque_rust_and_transparent_enum(succeed: bool) -> Result<AsyncResultOpaqueRustType1, ffi::AsyncResultErrEnum> {
+    if succeed {
+        Ok(AsyncResultOpaqueRustType1(10))
+    } else {
+        Err(ffi::AsyncResultErrEnum::NamedFields { value: 1000 })
+    }
+}
+
+async fn rust_async_func_return_result_transparent_enum_and_opaque_rust(succeed: bool) -> Result<ffi::AsyncResultOkEnum, AsyncResultOpaqueRustType1> {
+    if succeed {
+        Ok(ffi::AsyncResultOkEnum::NoFields)
+    } else {
+        Err(AsyncResultOpaqueRustType1(1000))
     }
 }

--- a/crates/swift-integration-tests/src/async_function.rs
+++ b/crates/swift-integration-tests/src/async_function.rs
@@ -42,23 +42,25 @@ mod ffi {
     enum AsyncResultOkEnum {
         NoFields,
         UnnamedFields(i32, String),
-        NamedFields{
-            value: u8
-        },
+        NamedFields { value: u8 },
     }
 
     enum AsyncResultErrEnum {
         NoFields,
         UnnamedFields(String, i32),
-        NamedFields{
-            value: u32
-        },
+        NamedFields { value: u32 },
     }
 
     extern "Rust" {
-        async fn rust_async_func_return_result_transparent_enum_and_transparent_enum(succeed: bool) -> Result<AsyncResultOkEnum, AsyncResultErrEnum>;
-        async fn rust_async_func_return_result_opaque_rust_and_transparent_enum(succeed: bool) -> Result<AsyncResultOpaqueRustType1, AsyncResultErrEnum>;
-        async fn rust_async_func_return_result_transparent_enum_and_opaque_rust(succeed: bool) -> Result<AsyncResultOkEnum, AsyncResultOpaqueRustType1>;
+        async fn rust_async_func_return_result_transparent_enum_and_transparent_enum(
+            succeed: bool,
+        ) -> Result<AsyncResultOkEnum, AsyncResultErrEnum>;
+        async fn rust_async_func_return_result_opaque_rust_and_transparent_enum(
+            succeed: bool,
+        ) -> Result<AsyncResultOpaqueRustType1, AsyncResultErrEnum>;
+        async fn rust_async_func_return_result_transparent_enum_and_opaque_rust(
+            succeed: bool,
+        ) -> Result<AsyncResultOkEnum, AsyncResultOpaqueRustType1>;
     }
 }
 
@@ -127,16 +129,22 @@ async fn rust_async_func_reflect_result_opaque_rust(
     }
 }
 
-
-async fn rust_async_func_return_result_transparent_enum_and_transparent_enum(succeed: bool) -> Result<ffi::AsyncResultOkEnum, ffi::AsyncResultErrEnum> {
+async fn rust_async_func_return_result_transparent_enum_and_transparent_enum(
+    succeed: bool,
+) -> Result<ffi::AsyncResultOkEnum, ffi::AsyncResultErrEnum> {
     if succeed {
-        Ok(ffi::AsyncResultOkEnum::UnnamedFields(123, "hello".to_string()))
+        Ok(ffi::AsyncResultOkEnum::UnnamedFields(
+            123,
+            "hello".to_string(),
+        ))
     } else {
         Err(ffi::AsyncResultErrEnum::NamedFields { value: 100 })
     }
 }
 
-async fn rust_async_func_return_result_opaque_rust_and_transparent_enum(succeed: bool) -> Result<AsyncResultOpaqueRustType1, ffi::AsyncResultErrEnum> {
+async fn rust_async_func_return_result_opaque_rust_and_transparent_enum(
+    succeed: bool,
+) -> Result<AsyncResultOpaqueRustType1, ffi::AsyncResultErrEnum> {
     if succeed {
         Ok(AsyncResultOpaqueRustType1(10))
     } else {
@@ -144,7 +152,9 @@ async fn rust_async_func_return_result_opaque_rust_and_transparent_enum(succeed:
     }
 }
 
-async fn rust_async_func_return_result_transparent_enum_and_opaque_rust(succeed: bool) -> Result<ffi::AsyncResultOkEnum, AsyncResultOpaqueRustType1> {
+async fn rust_async_func_return_result_transparent_enum_and_opaque_rust(
+    succeed: bool,
+) -> Result<ffi::AsyncResultOkEnum, AsyncResultOpaqueRustType1> {
     if succeed {
         Ok(ffi::AsyncResultOkEnum::NoFields)
     } else {

--- a/crates/swift-integration-tests/src/async_function.rs
+++ b/crates/swift-integration-tests/src/async_function.rs
@@ -38,6 +38,26 @@ mod ffi {
         fn new(val: u32) -> AsyncResultOpaqueRustType2;
         fn val(&self) -> u32;
     }
+
+    enum AsyncResultOkEnum {
+        NoFields,
+        UnnamedFields(i32, String),
+        NamedFields{
+            value: u8
+        },
+    }
+
+    enum AsyncResultErrEnum {
+        NoFields,
+        UnnamedFields(String, i32),
+        NamedFields{
+            value: u32
+        },
+    }
+
+    extern "Rust" {
+        async fn rust_async_func_return_result_transparent_enum_and_transparent_enum(succeed: bool) -> Result<AsyncResultOkEnum, AsyncResultErrEnum>;
+    }
 }
 
 async fn rust_async_return_null() {}
@@ -102,5 +122,14 @@ async fn rust_async_func_reflect_result_opaque_rust(
             assert_eq!(err.0, 100);
             Err(err)
         }
+    }
+}
+
+
+async fn rust_async_func_return_result_transparent_enum_and_transparent_enum(succeed: bool) -> Result<ffi::AsyncResultOkEnum, ffi::AsyncResultErrEnum> {
+    if succeed {
+        Ok(ffi::AsyncResultOkEnum::UnnamedFields(123, "hello".to_string()))
+    } else {
+        Err(ffi::AsyncResultErrEnum::NamedFields { value: 100 })
     }
 }


### PR DESCRIPTION
This PR adds support for returning `Result<OpaqueRustType, TransparentEnumType>` from `async` Rust functions.

related to #159.

Here's an example of using this.

```rust
#[swift_bridge::bridge]
mod ffi {
    enum NetworkError {
	NoData,
	Authentication,
    }
    extern "Rust" {
        type Data;
    }
    extern "Rust" {
        async fn fetch_from_server() -> Result<Data, NetworkError>;
    }
}
```

```Swift
do {
    let data = try await fetch_from_server()
    //...
} catch let error as NetworkError {
    //...
} catch {
    //...
}
```