### PR TITLE
Support returning `Result<(), TransparentEnum>` from Rust async functions.

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
@@ -87,8 +87,6 @@ class AsyncTests: XCTestCase {
             XCTFail()
         } catch let error as AsyncResultErrEnum {
             switch error {
-            case .NoFields:
-                XCTFail()
             case .UnnamedFields(_, _):
                 XCTFail()
             case .NamedFields(let valueUInt32):
@@ -114,8 +112,6 @@ class AsyncTests: XCTestCase {
             let _: AsyncResultOpaqueRustType1 = try await rust_async_func_return_result_opaque_rust_and_transparent_enum(false)
         } catch let error as AsyncResultErrEnum {
             switch error {
-            case .NoFields:
-                XCTFail()
             case .UnnamedFields(_, _):
                 XCTFail()
             case .NamedFields(let value):
@@ -153,6 +149,32 @@ class AsyncTests: XCTestCase {
             XCTFail()
         }
         
+    }
+    
+    /// Verify that we can return a Result<(), TransparentEnum> from async Rust function
+    func testSwiftCallsRustAsyncFnReturnResultNullTransparentEnum() async throws {
+        //Should return an Unit type
+        do {
+            let _: () = try await rust_async_func_return_result_null_and_transparent_enum(true)
+        } catch {
+            XCTFail()
+        }
+        
+        //Should throw an AsyncResultErrEnum
+        do {
+            let _ = try await rust_async_func_return_result_null_and_transparent_enum(false)
+            XCTFail()
+        } catch let error as AsyncResultErrEnum {
+            switch error {
+            case .UnnamedFields(let valueString, let valueInt32):
+                XCTAssertEqual(valueString.toString(), "foo")
+                XCTAssertEqual(valueInt32, 123)
+            case .NamedFields(_):
+                XCTFail()
+            }
+        } catch {
+            XCTFail()
+        }
     }
     
     func testSwiftCallsRustAsyncFnRetStruct() async throws {

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
@@ -184,9 +184,6 @@ impl BuiltInResult {
                 )
             }
             TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
-                if self.ok_ty.can_be_encoded_with_zero_bytes() {
-                    todo!()
-                }
                 if self.err_ty.can_be_encoded_with_zero_bytes() {
                     todo!()
                 }
@@ -417,11 +414,15 @@ typedef struct {c_enum_name}{{{c_tag_name} tag; union {c_fields_name} payload;}}
         types: &TypeDeclarations,
     ) -> String {
         if self.is_custom_result_type() {
-            let ok = self.ok_ty.convert_ffi_expression_to_swift_type(
-                &format!("{expression}.payload.ok"),
-                type_pos,
-                types,
-            );
+            let ok = if self.ok_ty.can_be_encoded_with_zero_bytes() {
+                "()".to_string()
+            } else {
+                self.ok_ty.convert_ffi_expression_to_swift_type(
+                    &format!("{expression}.payload.ok"),
+                    type_pos,
+                    types,
+                )
+            };
             let err = self.err_ty.convert_ffi_expression_to_swift_type(
                 &format!("{expression}.payload.err"),
                 type_pos,

--- a/crates/swift-integration-tests/src/async_function.rs
+++ b/crates/swift-integration-tests/src/async_function.rs
@@ -46,7 +46,6 @@ mod ffi {
     }
 
     enum AsyncResultErrEnum {
-        NoFields,
         UnnamedFields(String, i32),
         NamedFields { value: u32 },
     }
@@ -61,6 +60,9 @@ mod ffi {
         async fn rust_async_func_return_result_transparent_enum_and_opaque_rust(
             succeed: bool,
         ) -> Result<AsyncResultOkEnum, AsyncResultOpaqueRustType1>;
+        async fn rust_async_func_return_result_null_and_transparent_enum(
+            succeed: bool,
+        ) -> Result<(), AsyncResultErrEnum>;
     }
 }
 
@@ -159,5 +161,18 @@ async fn rust_async_func_return_result_transparent_enum_and_opaque_rust(
         Ok(ffi::AsyncResultOkEnum::NoFields)
     } else {
         Err(AsyncResultOpaqueRustType1(1000))
+    }
+}
+
+async fn rust_async_func_return_result_null_and_transparent_enum(
+    succeed: bool,
+) -> Result<(), ffi::AsyncResultErrEnum> {
+    if succeed {
+        Ok(())
+    } else {
+        Err(ffi::AsyncResultErrEnum::UnnamedFields(
+            "foo".to_string(),
+            123,
+        ))
     }
 }


### PR DESCRIPTION
This PR adds support for returning Result<(), TransparentEnum> from Rust async functions.

Here's an example of using this:

```Rust
//Rust
#[swift_bridge::bridge]
mod ffi {
    enum SomeEnum {
       //...
    }
    extern "Rust" {
        async fn some_function() -> Result<(), SomeEnum>;
    }
}
```

```Swift
//Swift
do {
    let value = try await some_function()
    //...
} catch let error as SomeEnum {
    //...
} catch {
    //...
}
```