### PR TITLE
Adding missing C headers and Swift code for Vec<f32/f64> support

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/VecTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/VecTests.swift
@@ -113,6 +113,9 @@ class VecTests: XCTestCase {
         XCTAssertEqual(RustVec<Int>().len(), 0);
         
         XCTAssertEqual(RustVec<Bool>().len(), 0);
+
+        XCTAssertEqual(RustVec<Float>().len(), 0);
+        XCTAssertEqual(RustVec<Double>().len(), 0);
     }
 }
 

--- a/crates/swift-bridge-build/src/generate_core.rs
+++ b/crates/swift-bridge-build/src/generate_core.rs
@@ -88,7 +88,7 @@ typedef struct __private__OptionI64 { int64_t val; bool is_some; } __private__Op
 typedef struct __private__OptionUsize { uintptr_t val; bool is_some; } __private__OptionUsize;
 typedef struct __private__OptionIsize { intptr_t val; bool is_some; } __private__OptionIsize;
 typedef struct __private__OptionF32 { float val; bool is_some; } __private__OptionF32;
-typedef struct __private__OptionF64 { double val; bool is_some; } __private__OptionDouble;
+typedef struct __private__OptionF64 { double val; bool is_some; } __private__OptionF64;
 typedef struct __private__OptionBool { bool val; bool is_some; } __private__OptionBool;
 "#
     .to_string();
@@ -127,11 +127,6 @@ fn vec_of_primitive_headers(rust_ty: &str, c_ty: &str) -> String {
 
     // __private__OptionU8 ... etc
     let option_ty = format!("{}{}", "__private__Option", capatilized_first_letter);
-    let option_ty_tag = if option_ty == "__private__OptionF64" {
-        format!("struct ")
-    } else {
-        format!("")
-    };
 
     format!(
         r#"
@@ -139,15 +134,14 @@ void* __swift_bridge__$Vec_{rust_ty}$new();
 void __swift_bridge__$Vec_{rust_ty}$_free(void* const vec);
 uintptr_t __swift_bridge__$Vec_{rust_ty}$len(void* const vec);
 void __swift_bridge__$Vec_{rust_ty}$push(void* const vec, {c_ty} val);
-{option_ty_tag}{option_ty} __swift_bridge__$Vec_{rust_ty}$pop(void* const vec);
-{option_ty_tag}{option_ty} __swift_bridge__$Vec_{rust_ty}$get(void* const vec, uintptr_t index);
-{option_ty_tag}{option_ty} __swift_bridge__$Vec_{rust_ty}$get_mut(void* const vec, uintptr_t index);
+{option_ty} __swift_bridge__$Vec_{rust_ty}$pop(void* const vec);
+{option_ty} __swift_bridge__$Vec_{rust_ty}$get(void* const vec, uintptr_t index);
+{option_ty} __swift_bridge__$Vec_{rust_ty}$get_mut(void* const vec, uintptr_t index);
 {c_ty} const * __swift_bridge__$Vec_{rust_ty}$as_ptr(void* const vec);
 "#,
         rust_ty = rust_ty,
         c_ty = c_ty,
-        option_ty = option_ty,
-        option_ty_tag = option_ty_tag
+        option_ty = option_ty
     )
 }
 

--- a/crates/swift-bridge-build/src/generate_core.rs
+++ b/crates/swift-bridge-build/src/generate_core.rs
@@ -57,6 +57,9 @@ fn core_swift() -> String {
         ("Int", "isize"),
         //
         ("Bool", "bool"),
+        //
+        ("Float", "f32"),
+        ("Double", "f64"),
     ] {
         core_swift += &conform_to_vectorizable(swift_ty, rust_ty);
     }
@@ -104,6 +107,9 @@ typedef struct __private__OptionBool { bool val; bool is_some; } __private__Opti
         ("isize", "intptr_t"),
         //
         ("bool", "bool"),
+        //
+        ("f32", "float"),
+        ("f64", "double"),
     ] {
         header += &vec_of_primitive_headers(rust_ty, c_ty);
     }
@@ -121,6 +127,11 @@ fn vec_of_primitive_headers(rust_ty: &str, c_ty: &str) -> String {
 
     // __private__OptionU8 ... etc
     let option_ty = format!("{}{}", "__private__Option", capatilized_first_letter);
+    let option_ty_tag = if option_ty == "__private__OptionF64" {
+        format!("struct ")
+    } else {
+        format!("")
+    };
 
     format!(
         r#"
@@ -128,14 +139,15 @@ void* __swift_bridge__$Vec_{rust_ty}$new();
 void __swift_bridge__$Vec_{rust_ty}$_free(void* const vec);
 uintptr_t __swift_bridge__$Vec_{rust_ty}$len(void* const vec);
 void __swift_bridge__$Vec_{rust_ty}$push(void* const vec, {c_ty} val);
-{option_ty} __swift_bridge__$Vec_{rust_ty}$pop(void* const vec);
-{option_ty} __swift_bridge__$Vec_{rust_ty}$get(void* const vec, uintptr_t index);
-{option_ty} __swift_bridge__$Vec_{rust_ty}$get_mut(void* const vec, uintptr_t index);
+{option_ty_tag}{option_ty} __swift_bridge__$Vec_{rust_ty}$pop(void* const vec);
+{option_ty_tag}{option_ty} __swift_bridge__$Vec_{rust_ty}$get(void* const vec, uintptr_t index);
+{option_ty_tag}{option_ty} __swift_bridge__$Vec_{rust_ty}$get_mut(void* const vec, uintptr_t index);
 {c_ty} const * __swift_bridge__$Vec_{rust_ty}$as_ptr(void* const vec);
 "#,
         rust_ty = rust_ty,
         c_ty = c_ty,
-        option_ty = option_ty
+        option_ty = option_ty,
+        option_ty_tag = option_ty_tag
     )
 }
 


### PR DESCRIPTION
This PR adds support for `Vec<f32>`/`Vec<f64>` (it seems it was mostly some C headers and Swift code missing).

Rust code would look like:
```rust
#[swift_bridge::bridge]
mod ffi {
    #[swift_bridge(swift_repr = "struct")]
    struct SomeStruct {
        field: Vec<f32>,
    }

    extern "Rust" {
        fn do_something(val: SomeStruct) -> Vec<f32>;
    }
}

fn do_something(val: SomeStruct) -> Vec<f32> {
    /* do something */
}
```
On Swift side, `Double` and `Float` are now `Vectorizable`.