### PR TITLE
Support Option<Primitive> in Swift fns

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Option.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Option.swift
@@ -7,10 +7,43 @@
 
 import Foundation
 
-func create_swift_option_u8_some() -> Optional<UInt8> {
-    55
+func swift_reflect_option_u8(arg: Optional<UInt8>) -> Optional<UInt8> {
+    arg
+}
+func swift_reflect_option_i8(arg: Optional<Int8>) -> Optional<Int8> {
+    arg
+}
+func swift_reflect_option_u16(arg: Optional<UInt16>) -> Optional<UInt16> {
+    arg
+}
+func swift_reflect_option_i16(arg: Optional<Int16>) -> Optional<Int16> {
+    arg
+}
+func swift_reflect_option_u32(arg: Optional<UInt32>) -> Optional<UInt32> {
+    arg
+}
+func swift_reflect_option_i32(arg: Optional<Int32>) -> Optional<Int32> {
+    arg
+}
+func swift_reflect_option_u64(arg: Optional<UInt64>) -> Optional<UInt64> {
+    arg
+}
+func swift_reflect_option_i64(arg: Optional<Int64>) -> Optional<Int64> {
+    arg
+}
+func swift_reflect_option_usize(arg: Optional<UInt>) -> Optional<UInt> {
+    arg
+}
+func swift_reflect_option_isize(arg: Optional<Int>) -> Optional<Int> {
+    arg
+}
+func swift_reflect_option_f32(arg: Optional<Float>) -> Optional<Float> {
+    arg
+}
+func swift_reflect_option_f64(arg: Optional<Double>) -> Optional<Double> {
+    arg
+}
+func swift_reflect_option_bool(arg: Optional<Bool>) -> Optional<Bool> {
+    arg
 }
 
-func create_swift_option_u8_none() -> Optional<UInt8> {
-    nil
-}

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
@@ -9,70 +9,52 @@ import XCTest
 @testable import SwiftRustIntegrationTestRunner
 
 class OptionTests: XCTestCase {
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-    
-    func testSwiftCallRustOptionU8() throws {
+
+    /// Verify that Swift can call Rust functions that accept and return Option<T>
+    /// where T is a primitive.
+    func testSwiftCallRustOptionPrimitive() throws {
         XCTAssertEqual(rust_reflect_option_u8(70), 70)
         XCTAssertEqual(rust_reflect_option_u8(nil), nil)
-    }
-     
-    func testSwiftCallRustOptionI8() throws {
+        
         XCTAssertEqual(rust_reflect_option_i8(70), 70)
         XCTAssertEqual(rust_reflect_option_i8(nil), nil)
-    }
-     
-    func testSwiftCallRustOptionU16() throws {
+        
         XCTAssertEqual(rust_reflect_option_u16(70), 70)
         XCTAssertEqual(rust_reflect_option_u16(nil), nil)
-    }
-     
-    func testSwiftCallRustOptionI16() throws {
+        
         XCTAssertEqual(rust_reflect_option_i16(70), 70)
         XCTAssertEqual(rust_reflect_option_i16(nil), nil)
-    }
-
-    func testSwiftCallRustOptionU32() throws {
+        
         XCTAssertEqual(rust_reflect_option_u32(70), 70)
         XCTAssertEqual(rust_reflect_option_u32(nil), nil)
-    }
-     
-    func testSwiftCallRustOptionI32() throws {
+        
         XCTAssertEqual(rust_reflect_option_i32(70), 70)
         XCTAssertEqual(rust_reflect_option_i32(nil), nil)
-    }
-
-    func testSwiftCallRustOptionU64() throws {
+        
         XCTAssertEqual(rust_reflect_option_u64(70), 70)
         XCTAssertEqual(rust_reflect_option_u64(nil), nil)
-    }
-     
-    func testSwiftCallRustOptionI64() throws {
+        
         XCTAssertEqual(rust_reflect_option_i64(70), 70)
         XCTAssertEqual(rust_reflect_option_i64(nil), nil)
-    }
-
-    func testSwiftCallRustOptionF32() throws {
+        
         XCTAssertEqual(rust_reflect_option_f32(70.0), 70.0)
         XCTAssertEqual(rust_reflect_option_f32(nil), nil)
-    }
-     
-    func testSwiftCallRustOptionF64() throws {
+        
         XCTAssertEqual(rust_reflect_option_f64(70.0), 70.0)
         XCTAssertEqual(rust_reflect_option_f64(nil), nil)
-    }
-
-    func testSwiftCallRustOptionBool() throws {
+        
         XCTAssertEqual(rust_reflect_option_bool(true), true)
         XCTAssertEqual(rust_reflect_option_bool(false), false)
         XCTAssertEqual(rust_reflect_option_bool(nil), nil)
     }
+
+    /// Verify that Rust can call Swift functions that accept and return Option<T>.
+    func testRustCallSwiftOptionPrimitive() throws {
+        test_rust_calls_swift_option_primitive()
+    }
     
+    /// Verify that Swift can call a Rust function that accepts and returns an Option<T>
+    /// where T is a String.
     func testSwiftCallRustReturnOptionString() throws {
         let string = rust_reflect_option_string("hello world")
         XCTAssertEqual(string!.toString(), "hello world")
@@ -118,7 +100,7 @@ class OptionTests: XCTestCase {
     
     func testSwiftCallRustWithOptionOpaqueRustCopyType() throws {
         let val = new_opaque_rust_copy_type(123)
-        let reflect: OptTestOpaqueRustCopyType? = rust_reflect_option_opaque_rust_copy_type(val)
+        let _: OptTestOpaqueRustCopyType? = rust_reflect_option_opaque_rust_copy_type(val)
         
         // TODO: Support methods on generic types
         // XCTAssertEqual(reflect!.field(), 123)
@@ -127,7 +109,7 @@ class OptionTests: XCTestCase {
     
     func testSwiftCallRustWithOptionGenericOpaqueRustType() throws {
         let val = new_generic_opaque_rust_type(123)
-        let reflect = rust_reflect_option_generic_opaque_rust_type(val)
+        let _: OptTestGenericOpaqueRustType<UInt8>? = rust_reflect_option_generic_opaque_rust_type(val)
         
         // TODO: Support methods on generic types
         // XCTAssertEqual(reflect!.field(), 123)
@@ -136,7 +118,7 @@ class OptionTests: XCTestCase {
     
      func testSwiftCallRustWithOptionGenericOpaqueRustCopyType() throws {
         let val = new_generic_opaque_rust_copy_type(123)
-        let reflect: OptTestGenericOpaqueRustCopyType? = rust_reflect_option_generic_opaque_rust_copy_type(val)
+        let _: OptTestGenericOpaqueRustCopyType? = rust_reflect_option_generic_opaque_rust_copy_type(val)
          
         // TODO: Support methods on generic types
         // XCTAssertEqual(reflect!.field(), 123)
@@ -166,7 +148,7 @@ class OptionTests: XCTestCase {
         XCTAssertEqual(reflected.f64, 123.4)
         XCTAssertEqual(reflected.boolean, true)
     }
-    
+ 
     func testStructWithOptionFieldsNone() {
         let val = StructWithOptionFields(
             u8: nil, i8: nil, u16: nil, i16: nil,
@@ -211,10 +193,6 @@ class OptionTests: XCTestCase {
         
         XCTAssertEqual(reflectedSome!.field, 123)
         XCTAssertNil(reflectedNone)
-    }
-    
-    func testRustCallSwiftReturnOption() {
-        run_option_tests()
     }
 }
 

--- a/crates/swift-bridge-build/src/generate_core.rs
+++ b/crates/swift-bridge-build/src/generate_core.rs
@@ -1,6 +1,9 @@
 use crate::generate_core::boxed_fn_support::{
     C_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN, SWIFT_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN,
 };
+use crate::generate_core::option_support::{
+    swift_option_primitive_support, C_OPTION_PRIMITIVE_SUPPORT,
+};
 use crate::generate_core::result_support::{C_RESULT_SUPPORT, SWIFT_RUST_RESULT};
 use std::path::Path;
 
@@ -11,6 +14,7 @@ const STRING_SWIFT: &'static str = include_str!("./generate_core/string.swift");
 const RUST_VEC_SWIFT: &'static str = include_str!("./generate_core/rust_vec.swift");
 
 mod boxed_fn_support;
+mod option_support;
 mod result_support;
 
 pub(super) fn write_core_swift_and_c(out_dir: &Path) {
@@ -22,6 +26,8 @@ pub(super) fn write_core_swift_and_c(out_dir: &Path) {
     swift += &SWIFT_CALLBACK_SUPPORT_NO_ARGS_NO_RETURN;
     swift += "\n";
     swift += &SWIFT_RUST_RESULT;
+    swift += "\n";
+    swift += &swift_option_primitive_support();
 
     std::fs::write(core_swift_out, swift).unwrap();
 
@@ -77,21 +83,9 @@ typedef struct RustStr { uint8_t* const start; uintptr_t len; } RustStr;
 typedef struct __private__FfiSlice { void* const start; uintptr_t len; } __private__FfiSlice;
 void* __swift_bridge__null_pointer(void);
 
-typedef struct __private__OptionU8 { uint8_t val; bool is_some; } __private__OptionU8;
-typedef struct __private__OptionI8 { int8_t val; bool is_some; } __private__OptionI8;
-typedef struct __private__OptionU16 { uint16_t val; bool is_some; } __private__OptionU16;
-typedef struct __private__OptionI16 { int16_t val; bool is_some; } __private__OptionI16;
-typedef struct __private__OptionU32 { uint32_t val; bool is_some; } __private__OptionU32;
-typedef struct __private__OptionI32 { int32_t val; bool is_some; } __private__OptionI32;
-typedef struct __private__OptionU64 { uint64_t val; bool is_some; } __private__OptionU64;
-typedef struct __private__OptionI64 { int64_t val; bool is_some; } __private__OptionI64;
-typedef struct __private__OptionUsize { uintptr_t val; bool is_some; } __private__OptionUsize;
-typedef struct __private__OptionIsize { intptr_t val; bool is_some; } __private__OptionIsize;
-typedef struct __private__OptionF32 { float val; bool is_some; } __private__OptionF32;
-typedef struct __private__OptionF64 { double val; bool is_some; } __private__OptionF64;
-typedef struct __private__OptionBool { bool val; bool is_some; } __private__OptionBool;
 "#
     .to_string();
+    header += &C_OPTION_PRIMITIVE_SUPPORT;
 
     for (rust_ty, c_ty) in vec![
         ("u8", "uint8_t"),

--- a/crates/swift-bridge-build/src/generate_core/option_support.rs
+++ b/crates/swift-bridge-build/src/generate_core/option_support.rs
@@ -1,0 +1,67 @@
+pub(super) fn swift_option_primitive_support() -> String {
+    let types = [
+        ("U8", "UInt8", "123"),
+        ("I8", "Int8", "123"),
+        ("U16", "UInt16", "123"),
+        ("I16", "Int16", "123"),
+        ("U32", "UInt32", "123"),
+        ("I32", "Int32", "123"),
+        ("U64", "UInt64", "123"),
+        ("I64", "Int64", "123"),
+        ("Usize", "UInt", "123"),
+        ("Isize", "Int", "123"),
+        ("F32", "Float", "123.4"),
+        ("F64", "Double", "123.4"),
+        ("Bool", "Bool", "false"),
+    ];
+    let mut all = "".to_string();
+
+    for (suffix, inner_ty, unused_none) in types {
+        let option_ffi_ty = format!("__private__Option{suffix}");
+
+        all += &format!(
+            r#"
+extension {option_ffi_ty} {{
+    func intoSwiftRepr() -> Optional<{inner_ty}> {{
+        if self.is_some {{
+            return self.val 
+        }} else {{
+            return nil
+        }}
+    }}
+
+    init(_ val: Optional<{inner_ty}>) {{
+        if let val = val {{
+            self = Self(val: val, is_some: true) 
+        }} else {{
+            self = Self(val: {unused_none}, is_some: false) 
+        }}
+    }}
+}}
+extension Optional where Wrapped == {inner_ty} {{
+    func intoFfiRepr() -> {option_ffi_ty} {{
+        {option_ffi_ty}(self) 
+    }}
+}}
+"#
+        );
+    }
+
+    all
+}
+
+pub(super) const C_OPTION_PRIMITIVE_SUPPORT: &'static str = r#"
+typedef struct __private__OptionU8 { uint8_t val; bool is_some; } __private__OptionU8;
+typedef struct __private__OptionI8 { int8_t val; bool is_some; } __private__OptionI8;
+typedef struct __private__OptionU16 { uint16_t val; bool is_some; } __private__OptionU16;
+typedef struct __private__OptionI16 { int16_t val; bool is_some; } __private__OptionI16;
+typedef struct __private__OptionU32 { uint32_t val; bool is_some; } __private__OptionU32;
+typedef struct __private__OptionI32 { int32_t val; bool is_some; } __private__OptionI32;
+typedef struct __private__OptionU64 { uint64_t val; bool is_some; } __private__OptionU64;
+typedef struct __private__OptionI64 { int64_t val; bool is_some; } __private__OptionI64;
+typedef struct __private__OptionUsize { uintptr_t val; bool is_some; } __private__OptionUsize;
+typedef struct __private__OptionIsize { intptr_t val; bool is_some; } __private__OptionIsize;
+typedef struct __private__OptionF32 { float val; bool is_some; } __private__OptionF32;
+typedef struct __private__OptionF64 { double val; bool is_some; } __private__OptionF64;
+typedef struct __private__OptionBool { bool val; bool is_some; } __private__OptionBool;
+"#;

--- a/crates/swift-bridge-build/src/generate_core/rust_vec.swift
+++ b/crates/swift-bridge-build/src/generate_core/rust_vec.swift
@@ -1,6 +1,3 @@
-// TODO:
-//  Implement iterator https://developer.apple.com/documentation/swift/iteratorprotocol
-
 public class RustVec<T: Vectorizable> {
     var ptr: UnsafeMutableRawPointer
     var isOwned: Bool = true

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -22,12 +22,12 @@ pub(crate) use self::shared_struct::{SharedStruct, StructFields, StructSwiftRepr
 
 pub(crate) mod boxed_fn;
 mod bridgeable_pointer;
-mod bridgeable_primitive;
 mod bridgeable_result;
 pub mod bridgeable_str;
 pub mod bridgeable_string;
 pub mod bridged_opaque_type;
 mod bridged_option;
+mod built_in_primitive;
 mod shared_enum;
 pub(crate) mod shared_struct;
 
@@ -1151,22 +1151,7 @@ impl BridgedType {
                 StdLibType::Vec(ty) => {
                     format!("RustVec<{}>", ty.ty.to_swift_type(type_pos, types))
                 }
-                StdLibType::Option(opt) => match type_pos {
-                    TypePosition::FnArg(func_host_lang, _)
-                    | TypePosition::FnReturn(func_host_lang) => {
-                        if func_host_lang.is_swift() {
-                            opt.ty.to_swift_type(type_pos, types)
-                        } else {
-                            format!("Optional<{}>", opt.ty.to_swift_type(type_pos, types))
-                        }
-                    }
-                    TypePosition::SharedStructField => {
-                        format!("Optional<{}>", opt.ty.to_swift_type(type_pos, types))
-                    }
-                    TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
-                        unimplemented!()
-                    }
-                },
+                StdLibType::Option(opt) => opt.to_swift_type(type_pos, types),
                 StdLibType::Result(result) => result.to_swift_type(type_pos, types),
                 StdLibType::BoxedFnOnce(boxed_fn) => boxed_fn.to_swift_type().to_string(),
             },

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_primitive.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_primitive.rs
@@ -1,9 +1,0 @@
-// /// `impl BridgeableType for {u8, i8, u16, i16 ... etc}`
-// TODO: Write this macro
-// macro_rules! make_bridgeable_primitive {
-//     ($type:ty) => {
-//         impl BridgeableType for $type {
-//             //
-//         }
-//     };
-// }

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_option.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_option.rs
@@ -1,4 +1,6 @@
+use crate::bridged_type::built_in_primitive::BuiltInPrimitive;
 use crate::bridged_type::{BridgedType, CustomBridgedType, SharedType, StdLibType, TypePosition};
+use crate::parse::TypeDeclarations;
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::ops::Deref;
@@ -146,7 +148,16 @@ impl BridgedOption {
                 | StdLibType::F32
                 | StdLibType::F64
                 | StdLibType::Bool => {
-                    quote! { if #expression.is_some { Some(#expression.val) } else { None } }
+                    quote! {
+                        {
+                            let val = #expression;
+                            if val.is_some {
+                                Some(val.val)
+                            } else {
+                                None
+                            }
+                        }
+                    }
                 }
                 StdLibType::Pointer(_) => {
                     todo!("Option<*const T> and Option<*mut T> are not yet supported.")
@@ -207,7 +218,7 @@ impl BridgedOption {
                 | StdLibType::F32
                 | StdLibType::F64
                 | StdLibType::Bool => {
-                    format!("{{ let val = {expression}; if val.is_some {{ return val.val }} else {{ return nil }} }}()", expression = expression)
+                    format!("{expression}.intoSwiftRepr()")
                 }
                 StdLibType::Pointer(_) => {
                     todo!("Support Option<*const T> and Option<*mut T>")
@@ -252,15 +263,6 @@ impl BridgedOption {
         expression: &str,
         type_pos: TypePosition,
     ) -> String {
-        let convert_primitive = move |primitive_kind: &str, unused_none: &str| {
-            format!(
-                "{{ let val = {expression}; return __private__Option{primitive_kind}(val: val ?? {unused_none}, is_some: val != nil); }}()",
-                primitive_kind = primitive_kind,
-                expression = expression,
-                unused_none = unused_none
-            )
-        };
-
         match self.ty.deref() {
             BridgedType::Bridgeable(b) => {
                 b.convert_option_swift_expression_to_ffi_type(expression, type_pos)
@@ -269,19 +271,21 @@ impl BridgedOption {
                 StdLibType::Null => {
                     todo!("Option<()> is not yet supported")
                 }
-                StdLibType::U8 => convert_primitive("U8", "123"),
-                StdLibType::I8 => convert_primitive("I8", "123"),
-                StdLibType::U16 => convert_primitive("U16", "123"),
-                StdLibType::I16 => convert_primitive("I16", "123"),
-                StdLibType::U32 => convert_primitive("U32", "123"),
-                StdLibType::I32 => convert_primitive("I32", "123"),
-                StdLibType::U64 => convert_primitive("U64", "123"),
-                StdLibType::I64 => convert_primitive("I64", "123"),
-                StdLibType::Usize => convert_primitive("Usize", "123"),
-                StdLibType::Isize => convert_primitive("Isize", "123"),
-                StdLibType::F32 => convert_primitive("F32", "123.4"),
-                StdLibType::F64 => convert_primitive("F64", "123.4"),
-                StdLibType::Bool => convert_primitive("Bool", "false"),
+                StdLibType::U8
+                | StdLibType::I8
+                | StdLibType::U16
+                | StdLibType::I16
+                | StdLibType::U32
+                | StdLibType::I32
+                | StdLibType::U64
+                | StdLibType::I64
+                | StdLibType::Usize
+                | StdLibType::Isize
+                | StdLibType::F32
+                | StdLibType::F64
+                | StdLibType::Bool => {
+                    format!("{expression}.intoFfiRepr()")
+                }
                 StdLibType::Pointer(_) => {
                     todo!("Option<*const T> and Option<*mut T> are not yet supported")
                 }
@@ -322,6 +326,84 @@ impl BridgedOption {
                     ffi_name = ffi_name,
                     expression = expression
                 )
+            }
+        }
+    }
+
+    pub fn to_swift_type(&self, type_pos: TypePosition, types: &TypeDeclarations) -> String {
+        match type_pos {
+            TypePosition::FnArg(func_host_lang, _) => {
+                if func_host_lang.is_swift() {
+                    self.to_ffi_compatible_swift_type(&types)
+                } else {
+                    format!("Optional<{}>", self.ty.to_swift_type(type_pos, types))
+                }
+            }
+            TypePosition::FnReturn(func_host_lang) => {
+                if func_host_lang.is_swift() {
+                    self.to_ffi_compatible_swift_type(&types)
+                } else {
+                    format!("Optional<{}>", self.ty.to_swift_type(type_pos, types))
+                }
+            }
+            TypePosition::SharedStructField => {
+                format!("Optional<{}>", self.ty.to_swift_type(type_pos, types))
+            }
+            TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
+                unimplemented!()
+            }
+        }
+    }
+
+    fn to_ffi_compatible_swift_type(&self, _types: &TypeDeclarations) -> String {
+        match self.ty.deref() {
+            BridgedType::StdLib(stdlib_type) => match stdlib_type {
+                StdLibType::Null => {
+                    todo!()
+                }
+                StdLibType::U8
+                | StdLibType::I8
+                | StdLibType::U16
+                | StdLibType::I16
+                | StdLibType::U32
+                | StdLibType::I32
+                | StdLibType::U64
+                | StdLibType::I64
+                | StdLibType::Usize
+                | StdLibType::Isize
+                | StdLibType::F32
+                | StdLibType::F64
+                | StdLibType::Bool => BuiltInPrimitive::new_with_stdlib_type(stdlib_type)
+                    .unwrap()
+                    .to_option_ffi_repr_name()
+                    .to_string(),
+                StdLibType::Pointer(_) => {
+                    todo!()
+                }
+                StdLibType::RefSlice(_) => {
+                    todo!()
+                }
+                StdLibType::Str => {
+                    todo!()
+                }
+                StdLibType::Vec(_) => {
+                    todo!()
+                }
+                StdLibType::BoxedFnOnce(_) => {
+                    todo!()
+                }
+                StdLibType::Option(_) => {
+                    todo!()
+                }
+                StdLibType::Result(_) => {
+                    todo!()
+                }
+            },
+            BridgedType::Foreign(_) => {
+                todo!()
+            }
+            BridgedType::Bridgeable(_) => {
+                todo!()
             }
         }
     }

--- a/crates/swift-bridge-ir/src/bridged_type/built_in_primitive.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/built_in_primitive.rs
@@ -1,0 +1,74 @@
+// /// `impl BridgeableType for {u8, i8, u16, i16 ... etc}`
+// TODO: Write this macro
+// macro_rules! make_bridgeable_primitive {
+//     ($type:ty) => {
+//         impl BridgeableType for $type {
+//             //
+//         }
+//     };
+// }
+
+use crate::bridged_type::StdLibType;
+
+/// Primitive types such as `()`, `u8` and `bool`.
+pub(crate) enum BuiltInPrimitive {
+    Null,
+    U8,
+    I8,
+    U16,
+    I16,
+    U32,
+    I32,
+    U64,
+    I64,
+    Usize,
+    Isize,
+    F32,
+    F64,
+    Bool,
+}
+
+impl BuiltInPrimitive {
+    /// U8 -> __private__OptionU8
+    pub fn to_option_ffi_repr_name(&self) -> &'static str {
+        match self {
+            BuiltInPrimitive::Null => "__private__OptionNull",
+            BuiltInPrimitive::U8 => "__private__OptionU8",
+            BuiltInPrimitive::I8 => "__private__OptionI8",
+            BuiltInPrimitive::U16 => "__private__OptionU16",
+            BuiltInPrimitive::I16 => "__private__OptionI16",
+            BuiltInPrimitive::U32 => "__private__OptionU32",
+            BuiltInPrimitive::I32 => "__private__OptionI32",
+            BuiltInPrimitive::U64 => "__private__OptionU64",
+            BuiltInPrimitive::I64 => "__private__OptionI64",
+            BuiltInPrimitive::Usize => "__private__OptionUsize",
+            BuiltInPrimitive::Isize => "__private__OptionIsize",
+            BuiltInPrimitive::F32 => "__private__OptionF32",
+            BuiltInPrimitive::F64 => "__private__OptionF64",
+            BuiltInPrimitive::Bool => "__private__OptionBool",
+        }
+    }
+
+    /// TODO: Temporary... we can delete this when we delete `BridgedType::StdLib`.
+    /// See: https://github.com/chinedufn/swift-bridge/issues/186
+    pub fn new_with_stdlib_type(ty: &StdLibType) -> Option<Self> {
+        let ty = match ty {
+            StdLibType::Null => Self::Null,
+            StdLibType::U8 => Self::U8,
+            StdLibType::I8 => Self::I8,
+            StdLibType::U16 => Self::U16,
+            StdLibType::I16 => Self::I16,
+            StdLibType::U32 => Self::U32,
+            StdLibType::I32 => Self::I32,
+            StdLibType::U64 => Self::U64,
+            StdLibType::I64 => Self::I64,
+            StdLibType::Usize => Self::Usize,
+            StdLibType::Isize => Self::Isize,
+            StdLibType::F32 => Self::F32,
+            StdLibType::F64 => Self::F64,
+            StdLibType::Bool => Self::Bool,
+            _ => None?,
+        };
+        Some(ty)
+    }
+}

--- a/crates/swift-integration-tests/src/option.rs
+++ b/crates/swift-integration-tests/src/option.rs
@@ -109,20 +109,60 @@ mod ffi {
             arg: Option<OptionStruct>,
         ) -> Option<OptionStruct>;
 
-        fn run_option_tests();
+        fn test_rust_calls_swift_option_primitive();
     }
 
     extern "Swift" {
-        // TODO: Change these to use the same reflect pattern that we use above when we support
-        //  extern "Swift" fn optional args.
-        // fn create_swift_option_u8_some() -> Option<u8>;
-        // fn create_swift_option_u8_none() -> Option<u8>;
+        fn swift_reflect_option_u8(arg: Option<u8>) -> Option<u8>;
+        fn swift_reflect_option_i8(arg: Option<i8>) -> Option<i8>;
+        fn swift_reflect_option_u16(arg: Option<u16>) -> Option<u16>;
+        fn swift_reflect_option_i16(arg: Option<i16>) -> Option<i16>;
+        fn swift_reflect_option_u32(arg: Option<u32>) -> Option<u32>;
+        fn swift_reflect_option_i32(arg: Option<i32>) -> Option<i32>;
+        fn swift_reflect_option_u64(arg: Option<u64>) -> Option<u64>;
+        fn swift_reflect_option_i64(arg: Option<i64>) -> Option<i64>;
+        fn swift_reflect_option_usize(arg: Option<usize>) -> Option<usize>;
+        fn swift_reflect_option_isize(arg: Option<isize>) -> Option<isize>;
+        fn swift_reflect_option_f32(arg: Option<f32>) -> Option<f32>;
+        fn swift_reflect_option_f64(arg: Option<f64>) -> Option<f64>;
+        fn swift_reflect_option_bool(arg: Option<bool>) -> Option<bool>;
     }
 }
 
-fn run_option_tests() {
-    // assert_eq!(ffi::create_swift_option_u8_some(), Some(55));
-    // assert_eq!(ffi::create_swift_option_u8_none(), None);
+fn test_rust_calls_swift_option_primitive() {
+    assert_eq!(ffi::swift_reflect_option_u8(Some(55)), Some(55));
+    assert_eq!(ffi::swift_reflect_option_u8(None), None);
+
+    assert_eq!(ffi::swift_reflect_option_i8(Some(55)), Some(55));
+    assert_eq!(ffi::swift_reflect_option_i8(None), None);
+
+    assert_eq!(ffi::swift_reflect_option_u16(Some(55)), Some(55));
+    assert_eq!(ffi::swift_reflect_option_u16(None), None);
+
+    assert_eq!(ffi::swift_reflect_option_i16(Some(55)), Some(55));
+    assert_eq!(ffi::swift_reflect_option_i16(None), None);
+
+    assert_eq!(ffi::swift_reflect_option_u32(Some(55)), Some(55));
+    assert_eq!(ffi::swift_reflect_option_u32(None), None);
+
+    assert_eq!(ffi::swift_reflect_option_i32(Some(55)), Some(55));
+    assert_eq!(ffi::swift_reflect_option_i32(None), None);
+
+    assert_eq!(ffi::swift_reflect_option_u64(Some(55)), Some(55));
+    assert_eq!(ffi::swift_reflect_option_u64(None), None);
+
+    assert_eq!(ffi::swift_reflect_option_i64(Some(55)), Some(55));
+    assert_eq!(ffi::swift_reflect_option_i64(None), None);
+
+    assert_eq!(ffi::swift_reflect_option_f32(Some(55.)), Some(55.));
+    assert_eq!(ffi::swift_reflect_option_f32(None), None);
+
+    assert_eq!(ffi::swift_reflect_option_f64(Some(55.)), Some(55.));
+    assert_eq!(ffi::swift_reflect_option_f64(None), None);
+
+    assert_eq!(ffi::swift_reflect_option_bool(Some(true)), Some(true));
+    assert_eq!(ffi::swift_reflect_option_bool(Some(false)), Some(false));
+    assert_eq!(ffi::swift_reflect_option_bool(None), None);
 }
 
 pub struct OptTestOpaqueRustType {


### PR DESCRIPTION
This commit adds support for Option<PrimitiveType> in `extern "Swift"`
functions.

For example, the following is now possible:

```rust
mod ffi {
    extern "Swift" {
        fn my_func(arg: Option<u8>) -> Option<bool>;
    }
}
```
