### PR TITLE
Generate include corresponding to each field in tuples

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/TupleTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/TupleTests.swift
@@ -27,6 +27,13 @@ final class TupleTest: XCTestCase {
             XCTAssertEqual(tuple.1.toString(), "foo")
             XCTAssertEqual(tuple.2, 128)
         }
+        XCTContext.runActivity(named: "Verify that we can pass and return a (F64, UInt, Bool).") {
+            _ in
+            let tuple = rust_reflect_tuple_f64_and_usize_and_bool((0.1, 123, true))
+            XCTAssertEqual(tuple.0, 0.1)
+            XCTAssertEqual(tuple.1, 123)
+            XCTAssertEqual(tuple.2, true)
+        }
     }
     
     /// Verify that Rust can call Swift functions that accept and return Tuples.

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
@@ -81,7 +81,7 @@ impl BridgeableType for BuiltInPointer {
         todo!()
     }
 
-    fn to_c_include(&self) -> Option<&'static str> {
+    fn to_c_include(&self, _types: &TypeDeclarations) -> Option<Vec<&'static str>> {
         todo!()
     }
 

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
@@ -66,7 +66,7 @@ impl BridgeableType for BridgedString {
         "void*".to_string()
     }
 
-    fn to_c_include(&self) -> Option<&'static str> {
+    fn to_c_include(&self, _types: &TypeDeclarations) -> Option<Vec<&'static str>> {
         None
     }
 

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
@@ -145,7 +145,7 @@ impl BridgeableType for OpaqueForeignType {
         }
     }
 
-    fn to_c_include(&self) -> Option<&'static str> {
+    fn to_c_include(&self, _types: &TypeDeclarations) -> Option<Vec<&'static str>> {
         None
     }
 

--- a/crates/swift-bridge-ir/src/bridged_type/built_in_tuple.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/built_in_tuple.rs
@@ -136,8 +136,8 @@ impl BridgeableType for BuiltInTuple {
         format!("struct {}", ty_name)
     }
 
-    fn to_c_include(&self) -> Option<&'static str> {
-        todo!()
+    fn to_c_include(&self, types: &TypeDeclarations) -> Option<Vec<&'static str>> {
+        self.0.to_c_include(types)
     }
 
     fn to_ffi_compatible_rust_type(

--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
@@ -207,6 +207,22 @@ impl UnnamedStructFields {
             })
             .collect()
     }
+    pub fn to_c_include(&self, types: &TypeDeclarations) -> Option<Vec<&'static str>> {
+        let mut includes = vec![];
+        for field in self.0.iter() {
+            let ty = BridgedType::new_with_type(&field.ty, types).unwrap();
+            if let Some(field_includes) = ty.to_c_include(types) {
+                for include in field_includes {
+                    includes.push(include);
+                }
+            }
+        }
+        if includes.len() > 0 {
+            Some(includes)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -71,8 +71,10 @@ impl SwiftBridgeModule {
                                     for field in f.iter() {
                                         let ty = BridgedType::new_with_type(&field.ty, &self.types)
                                             .unwrap();
-                                        if let Some(include) = ty.to_c_include() {
-                                            bookkeeping.includes.insert(include);
+                                        if let Some(includes) = ty.to_c_include(&self.types) {
+                                            for include in includes {
+                                                bookkeeping.includes.insert(include);
+                                            }
                                         }
 
                                         let name = field.swift_name_string();
@@ -84,8 +86,10 @@ impl SwiftBridgeModule {
                                     for (idx, field) in types.iter().enumerate() {
                                         let ty = BridgedType::new_with_type(&field.ty, &self.types)
                                             .unwrap();
-                                        if let Some(include) = ty.to_c_include() {
-                                            bookkeeping.includes.insert(include);
+                                        if let Some(includes) = ty.to_c_include(&self.types) {
+                                            for include in includes {
+                                                bookkeeping.includes.insert(include);
+                                            }
                                         }
 
                                         let name = format!("_{}", idx);
@@ -177,8 +181,10 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                                                 &self.types,
                                             )
                                             .unwrap();
-                                            if let Some(include) = ty.to_c_include() {
-                                                bookkeeping.includes.insert(include);
+                                            if let Some(includes) = ty.to_c_include(&self.types) {
+                                                for include in includes {
+                                                    bookkeeping.includes.insert(include);
+                                                }
                                             }
                                             let ty = ty.to_c(&self.types);
                                             let field_name = named_field.name.to_string();
@@ -197,8 +203,10 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                                                 &self.types,
                                             )
                                             .unwrap();
-                                            if let Some(include) = ty.to_c_include() {
-                                                bookkeeping.includes.insert(include);
+                                            if let Some(includes) = ty.to_c_include(&self.types) {
+                                                for include in includes {
+                                                    bookkeeping.includes.insert(include);
+                                                }
                                             }
                                             let ty = ty.to_c(&self.types);
                                             params.push(format!("{} _{};", ty, unnamed_field.idx));

--- a/crates/swift-bridge-ir/src/parsed_extern_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn.rs
@@ -401,7 +401,7 @@ impl ParsedExternFn {
 
         if let ReturnType::Type(_, ty) = &self.func.sig.output {
             if let Some(ty) = BridgedType::new_with_type(&ty, types) {
-                if let Some(include) = ty.to_c_include() {
+                if let Some(include) = ty.to_c_include(types) {
                     includes.push(include);
                 }
             }
@@ -410,7 +410,7 @@ impl ParsedExternFn {
         for param in &self.func.sig.inputs {
             if let FnArg::Typed(pat_ty) = param {
                 if let Some(ty) = BridgedType::new_with_type(&pat_ty.ty, types) {
-                    if let Some(include) = ty.to_c_include() {
+                    if let Some(include) = ty.to_c_include(types) {
                         includes.push(include);
                     }
                 }
@@ -418,7 +418,7 @@ impl ParsedExternFn {
         }
 
         if includes.len() > 0 {
-            Some(includes)
+            Some(includes.into_iter().flatten().collect())
         } else {
             None
         }

--- a/crates/swift-integration-tests/src/tuple.rs
+++ b/crates/swift-integration-tests/src/tuple.rs
@@ -9,6 +9,9 @@ mod ffi {
         fn rust_reflect_tuple_opaque_rust_and_string_and_primitive(
             tuple: (TupleTestOpaqueRustType, String, u8),
         ) -> (TupleTestOpaqueRustType, String, u8);
+        fn rust_reflect_tuple_f64_and_usize_and_bool(
+            tuple: (f64, usize, bool),
+        ) -> (f64, usize, bool);
     }
     extern "Swift" {
         fn swift_reflect_tuple_primitives(arg: (i32, u32)) -> (i32, u32);
@@ -36,6 +39,10 @@ fn rust_reflect_tuple_primitives(tuple: (i16, u32)) -> (i16, u32) {
 fn rust_reflect_tuple_opaque_rust_and_string_and_primitive(
     tuple: (TupleTestOpaqueRustType, String, u8),
 ) -> (TupleTestOpaqueRustType, String, u8) {
+    tuple
+}
+
+fn rust_reflect_tuple_f64_and_usize_and_bool(tuple: (f64, usize, bool)) -> (f64, usize, bool) {
     tuple
 }
 


### PR DESCRIPTION
This commit adds support for generating a `#include<~>` corresponding to each field in tuples. 

Here's an example.

```rust
#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        fn some_function(arg1: (i32, bool)) -> (i32, bool);
    }
}
```

Generates the following c header file:
```c
#include <stdint.h>
#include <stdbool.h>
//...
```
