### PR TITLE
Support tuples from Swift -> Rust

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Tuple.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Tuple.swift
@@ -10,3 +10,11 @@ import Foundation
 func swift_reflect_tuple_primitives(arg: (Int32, UInt32)) -> (Int32, UInt32) {
     arg
 }
+
+func swift_reflect_opaque_and_primitive_tuple(arg: (TupleTestOpaqueRustType, Int32)) -> (TupleTestOpaqueRustType, Int32) {
+    arg
+}
+
+func swift_reflect_struct_and_enum_and_string(arg: (TupleTestStruct, TupleTestEnum, RustString)) -> (TupleTestStruct, TupleTestEnum, RustString) {
+    arg
+}

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -1864,7 +1864,7 @@ impl BridgedType {
             },
             BridgedType::Foreign(ty) => match ty {
                 CustomBridgedType::Shared(ty) => match ty {
-                    SharedType::Struct(_ty) => todo!(),
+                    SharedType::Struct(ty) => ty.name.to_string(),
                     SharedType::Enum(ty) => ty.name.to_string(),
                 },
             },

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
@@ -315,7 +315,10 @@ impl BridgeableType for OpaqueForeignType {
                                 expression, expression
                             )
                         } else {
-                            todo!()
+                            format!(
+                                "{{{}.isOwned = false; return {}.ptr;}}()",
+                                expression, expression
+                            )
                         }
                     }
                     TypePosition::SharedStructField => {

--- a/crates/swift-integration-tests/src/tuple.rs
+++ b/crates/swift-integration-tests/src/tuple.rs
@@ -1,5 +1,14 @@
 #[swift_bridge::bridge]
 mod ffi {
+    enum TupleTestEnum {
+        NamedField { data: i32 },
+        UnnamedFields(u8, String),
+        NoFields,
+    }
+    #[swift_bridge(swift_repr = "struct")]
+    struct TupleTestStruct {
+        field: u8,
+    }
     extern "Rust" {
         type TupleTestOpaqueRustType;
         #[swift_bridge(init)]
@@ -15,6 +24,12 @@ mod ffi {
     }
     extern "Swift" {
         fn swift_reflect_tuple_primitives(arg: (i32, u32)) -> (i32, u32);
+        fn swift_reflect_opaque_and_primitive_tuple(
+            arg: (TupleTestOpaqueRustType, i32),
+        ) -> (TupleTestOpaqueRustType, i32);
+        fn swift_reflect_struct_and_enum_and_string(
+            arg: (TupleTestStruct, TupleTestEnum, String),
+        ) -> (TupleTestStruct, TupleTestEnum, String);
     }
     extern "Rust" {
         fn test_rust_calls_swift_tuples();
@@ -50,4 +65,20 @@ fn test_rust_calls_swift_tuples() {
     let val = ffi::swift_reflect_tuple_primitives((-123, 123));
     assert_eq!(val.0, -123);
     assert_eq!(val.1, 123);
+
+    let val = ffi::swift_reflect_opaque_and_primitive_tuple((TupleTestOpaqueRustType(123), -123));
+    assert_eq!(val.0 .0, 123);
+    assert_eq!(val.1, -123);
+
+    let val = ffi::swift_reflect_struct_and_enum_and_string((
+        ffi::TupleTestStruct { field: 123 },
+        ffi::TupleTestEnum::NamedField { data: -123 },
+        "hello, world".to_string(),
+    ));
+    assert_eq!(val.0.field, 123);
+    assert!(matches!(
+        val.1,
+        ffi::TupleTestEnum::NamedField { data: -123 }
+    ));
+    assert_eq!(val.2, "hello, world".to_string());
 }


### PR DESCRIPTION
This commit supports for returning and taking tuples from Swift -> Rust.
```rust
#[swift_bridge::bridge]
mod ffi {
    enum TupleTestEnum {
        NamedField { data: i32 },
        UnnamedFields(u8, String),
        NoFields,
    }
    #[swift_bridge(swift_repr = "struct")]
    struct TupleTestStruct {
        field: u8,
    }
    extern "Rust" {
        type TupleTestOpaqueRustType;
        #[swift_bridge(init)]
        fn new(val: i32) -> TupleTestOpaqueRustType;
    }
    extern "Swift" {
        fn swift_reflect_opaque_and_primitive_tuple(
            arg: (TupleTestOpaqueRustType, i32),
        ) -> (TupleTestOpaqueRustType, i32);
        fn swift_reflect_struct_and_enum_and_string(
            arg: (TupleTestStruct, TupleTestEnum, String),
        ) -> (TupleTestStruct, TupleTestEnum, String);
    }
}
```

```rust
//...
let val = ffi::swift_reflect_opaque_and_primitive_tuple((TupleTestOpaqueRustType(123), -123));
//...
let val = ffi::swift_reflect_struct_and_enum_and_string((
        ffi::TupleTestStruct { field: 123 },
        ffi::TupleTestEnum::NamedField { data: -123 },
        "hello, world".to_string(),
    ));
//...
```