### PR TITLE
Support returning `Result<tuple, Any Type>` from Rust functions

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
@@ -158,4 +158,38 @@ class ResultTests: XCTestCase {
             }
         }
     }
+    
+    /// Verify that we can receive a Result<(primitive type, OpaqueRustType, String), TransparentEnum> from Rust
+    func testResultTupleTransparentEnum() throws {
+        XCTContext.runActivity(named: "Should return a tuple type") {
+            _ in
+            do {
+                let tuple: (Int32, ResultTestOpaqueRustType, RustString) = try rust_func_return_result_tuple_transparent_enum(true)
+                XCTAssertEqual(tuple.0, 123)
+                XCTAssertEqual(tuple.1.val(), ResultTestOpaqueRustType(123).val())
+                XCTAssertEqual(tuple.2.toString(), "hello")
+            } catch {
+                XCTFail()
+            }
+        }
+        
+        XCTContext.runActivity(named: "Should throw an error") {
+            _ in
+            do {
+                let _: (Int32, ResultTestOpaqueRustType, RustString) = try rust_func_return_result_tuple_transparent_enum(false)
+                XCTFail("The function should have returned an error.")
+            } catch let error as ResultTransparentEnum {
+                switch error {
+                case .NamedField(let data):
+                    XCTAssertEqual(data, -123)
+                case .UnnamedFields(_, _):
+                    XCTFail()
+                case .NoFields:
+                    XCTFail()
+                }
+            } catch {
+                XCTFail()
+            }
+        }
+    }
 }

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
@@ -45,15 +45,15 @@ impl BridgeableType for BuiltInPointer {
         todo!()
     }
 
-    fn generate_custom_rust_ffi_type(
+    fn generate_custom_rust_ffi_types(
         &self,
         _swift_bridge_path: &Path,
         _types: &TypeDeclarations,
-    ) -> Option<TokenStream> {
+    ) -> Option<Vec<TokenStream>> {
         None
     }
 
-    fn generate_custom_c_ffi_type(&self, _types: &TypeDeclarations) -> Option<String> {
+    fn generate_custom_c_ffi_types(&self, _types: &TypeDeclarations) -> Option<Vec<String>> {
         None
     }
 
@@ -251,7 +251,7 @@ impl BridgeableType for BuiltInPointer {
         todo!()
     }
 
-    fn to_alpha_numeric_underscore_name(&self) -> String {
+    fn to_alpha_numeric_underscore_name(&self, _types: &TypeDeclarations) -> String {
         todo!()
     }
 }

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
@@ -28,15 +28,15 @@ impl BridgeableType for BridgedString {
         true
     }
 
-    fn generate_custom_rust_ffi_type(
+    fn generate_custom_rust_ffi_types(
         &self,
         _swift_bridge_path: &Path,
         _types: &TypeDeclarations,
-    ) -> Option<TokenStream> {
+    ) -> Option<Vec<TokenStream>> {
         None
     }
 
-    fn generate_custom_c_ffi_type(&self, _types: &TypeDeclarations) -> Option<String> {
+    fn generate_custom_c_ffi_types(&self, _types: &TypeDeclarations) -> Option<Vec<String>> {
         None
     }
 
@@ -291,7 +291,7 @@ impl BridgeableType for BridgedString {
         false
     }
 
-    fn to_alpha_numeric_underscore_name(&self) -> String {
+    fn to_alpha_numeric_underscore_name(&self, _types: &TypeDeclarations) -> String {
         "String".to_string()
     }
 }

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
@@ -38,15 +38,15 @@ impl BridgeableType for OpaqueForeignType {
         true
     }
 
-    fn generate_custom_rust_ffi_type(
+    fn generate_custom_rust_ffi_types(
         &self,
         _swift_bridge_path: &Path,
         _types: &TypeDeclarations,
-    ) -> Option<TokenStream> {
+    ) -> Option<Vec<TokenStream>> {
         None
     }
 
-    fn generate_custom_c_ffi_type(&self, _types: &TypeDeclarations) -> Option<String> {
+    fn generate_custom_c_ffi_types(&self, _types: &TypeDeclarations) -> Option<Vec<String>> {
         None
     }
 
@@ -626,7 +626,7 @@ impl BridgeableType for OpaqueForeignType {
         self.has_swift_bridge_copy_annotation
     }
 
-    fn to_alpha_numeric_underscore_name(&self) -> String {
+    fn to_alpha_numeric_underscore_name(&self, _types: &TypeDeclarations) -> String {
         if self.generics.len() >= 1 {
             todo!()
         }

--- a/crates/swift-bridge-ir/src/bridged_type/built_in_tuple.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/built_in_tuple.rs
@@ -71,29 +71,29 @@ impl BridgeableType for BuiltInTuple {
         todo!();
     }
 
-    fn generate_custom_rust_ffi_type(
+    fn generate_custom_rust_ffi_types(
         &self,
         swift_bridge_path: &Path,
         types: &TypeDeclarations,
-    ) -> Option<TokenStream> {
+    ) -> Option<Vec<TokenStream>> {
         let combined_types_tokens = self
             .0
             .combine_field_types_into_ffi_name_tokens(swift_bridge_path, types);
         let prefixed_ty_name = self.prefixed_ty_name(types);
-        Some(quote! {
+        Some(vec![quote! {
             #[repr(C)]
             #[doc(hidden)]
             pub struct #prefixed_ty_name ( #(#combined_types_tokens),* );
-        })
+        }])
     }
 
-    fn generate_custom_c_ffi_type(&self, types: &TypeDeclarations) -> Option<String> {
+    fn generate_custom_c_ffi_types(&self, types: &TypeDeclarations) -> Option<Vec<String>> {
         let combined_types = self.0.combine_field_types_into_ffi_name_string(types);
         let fields: Vec<String> = self.0.combine_field_types_into_c_type(types);
         let fields = fields.join("; ");
         let fields = fields + ";";
         let c_decl = format!("typedef struct __swift_bridge__$tuple${combined_types} {{ {fields} }} __swift_bridge__$tuple${combined_types};");
-        Some(c_decl)
+        Some(vec![c_decl])
     }
 
     fn to_rust_type_path(&self, types: &TypeDeclarations) -> TokenStream {
@@ -334,8 +334,9 @@ impl BridgeableType for BuiltInTuple {
         todo!();
     }
 
-    fn to_alpha_numeric_underscore_name(&self) -> String {
-        todo!();
+    fn to_alpha_numeric_underscore_name(&self, types: &TypeDeclarations) -> String {
+        let fields_name = self.0.to_alpha_numeric_underscore_name(types);
+        "Tuple".to_string() + &fields_name
     }
 }
 

--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
@@ -84,7 +84,7 @@ impl UnnamedStructFields {
             .map(|field| {
                 BridgedType::new_with_type(&field.ty, types)
                     .unwrap()
-                    .to_alpha_numeric_underscore_name()
+                    .to_alpha_numeric_underscore_name(types)
             })
             .fold("".to_string(), |sum, s| sum + &s)
     }
@@ -222,6 +222,24 @@ impl UnnamedStructFields {
         } else {
             None
         }
+    }
+
+    /// Example
+    ///
+    /// (i32, u32) becomes I32U32
+    /// (OpaqueRustType, u8) becomes OpaqueRustTypeU8
+    pub fn to_alpha_numeric_underscore_name(&self, types: &TypeDeclarations) -> String {
+        let names: String = self
+            .0
+            .iter()
+            .enumerate()
+            .map(|(_idx, field)| {
+                BridgedType::new_with_type(&field.ty, types)
+                    .unwrap()
+                    .to_alpha_numeric_underscore_name(types)
+            })
+            .fold("".to_string(), |sum, s| sum + &s);
+        return names;
     }
 }
 

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -366,6 +366,7 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
         }
         for custom_type_declaration in custom_type_declarations {
             header += &custom_type_declaration;
+            header += "\n";
         }
         header
     }
@@ -410,8 +411,10 @@ fn declare_custom_c_ffi_types(
 ) {
     if let ReturnType::Type(_, ty) = &func.func.sig.output {
         if let Some(ty) = BridgedType::new_with_type(&ty, types) {
-            if let Some(declaration) = &ty.generate_custom_c_ffi_type(types) {
-                custom_type_declarations.insert(declaration.clone());
+            if let Some(declarations) = &ty.generate_custom_c_ffi_types(types) {
+                for declaration in declarations {
+                    custom_type_declarations.insert(declaration.clone());
+                }
             }
         }
     }
@@ -420,8 +423,10 @@ fn declare_custom_c_ffi_types(
             FnArg::Receiver(_receiver) => {}
             FnArg::Typed(pat_ty) => {
                 let ty = BridgedType::new_with_type(&pat_ty.ty, types).unwrap();
-                if let Some(declaration) = ty.generate_custom_c_ffi_type(types) {
-                    custom_type_declarations.insert(declaration.clone());
+                if let Some(declarations) = ty.generate_custom_c_ffi_types(types) {
+                    for declaration in declarations {
+                        custom_type_declarations.insert(declaration.clone());
+                    }
                 }
             }
         };

--- a/crates/swift-bridge-ir/src/parsed_extern_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn.rs
@@ -167,8 +167,10 @@ impl ParsedExternFn {
             if ret.can_be_encoded_with_zero_bytes() {
                 return quote! {};
             }
-            if let Some(tokens) = ret.generate_custom_rust_ffi_type(swift_bridge_path, types) {
-                custom_type_definitions.insert(tokens.to_string(), tokens);
+            if let Some(tokens) = ret.generate_custom_rust_ffi_types(swift_bridge_path, types) {
+                for token in tokens.into_iter() {
+                    custom_type_definitions.insert(token.to_string(), token);
+                }
             }
             let ty = ret.to_ffi_compatible_rust_type(swift_bridge_path, types);
             quote! { -> #ty }

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_param_names_and_types.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_extern_c_param_names_and_types.rs
@@ -44,9 +44,11 @@ impl ParsedExternFn {
                     if !pat_ty_is_self {
                         if let Some(built_in) = BridgedType::new_with_type(&pat_ty.ty, types) {
                             if let Some(tokens) =
-                                built_in.generate_custom_rust_ffi_type(swift_bridge_path, types)
+                                built_in.generate_custom_rust_ffi_types(swift_bridge_path, types)
                             {
-                                custom_type_definitions.insert(tokens.to_string(), tokens);
+                                for token in tokens.into_iter() {
+                                    custom_type_definitions.insert(token.to_string(), token);
+                                }
                             }
                             if built_in.can_be_encoded_with_zero_bytes() {
                                 continue;

--- a/crates/swift-bridge-macro/tests/ui/incorrect-return-type.stderr
+++ b/crates/swift-bridge-macro/tests/ui/incorrect-return-type.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> tests/ui/incorrect-return-type.rs:6:1
    |
 6  |   #[swift_bridge::bridge]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^ expected struct `SomeType`, found `&SomeType`
+   |   ^^^^^^^^^^^^^^^^^^^^^^^ expected `SomeType`, found `&SomeType`
 ...
 9  |           type SomeType;
    |  ______________-
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
   --> tests/ui/incorrect-return-type.rs:6:1
    |
 6  |   #[swift_bridge::bridge]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^ expected struct `SomeType`, found enum `Option`
+   |   ^^^^^^^^^^^^^^^^^^^^^^^ expected `SomeType`, found `Option<SomeType>`
 ...
 9  |           type SomeType;
    |  ______________-

--- a/crates/swift-integration-tests/src/result.rs
+++ b/crates/swift-integration-tests/src/result.rs
@@ -66,6 +66,12 @@ mod ffi {
         fn same_custom_result_returned_twice_first() -> Result<SameEnum, SameEnum>;
         fn same_custom_result_returned_twice_second() -> Result<SameEnum, SameEnum>;
     }
+
+    extern "Rust" {
+        fn rust_func_return_result_tuple_transparent_enum(
+            succeed: bool,
+        ) -> Result<(i32, ResultTestOpaqueRustType, String), ResultTransparentEnum>;
+    }
 }
 
 fn rust_func_takes_result_string(arg: Result<String, String>) {
@@ -174,4 +180,14 @@ fn same_custom_result_returned_twice_first() -> Result<ffi::SameEnum, ffi::SameE
 
 fn same_custom_result_returned_twice_second() -> Result<ffi::SameEnum, ffi::SameEnum> {
     todo!()
+}
+
+fn rust_func_return_result_tuple_transparent_enum(
+    succeed: bool,
+) -> Result<(i32, ResultTestOpaqueRustType, String), ffi::ResultTransparentEnum> {
+    if succeed {
+        Ok((123, ResultTestOpaqueRustType::new(123), "hello".to_string()))
+    } else {
+        Err(ffi::ResultTransparentEnum::NamedField { data: -123 })
+    }
 }


### PR DESCRIPTION
This commit adds support for returning `Result<tuple, Any Type>` from Rust functions. Note that this doesn't support returning `Result<Any Type, tuple>` from Rust functions.

Here's an example of using this.

```Rust
#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        fn rust_func_return_result_tuple_transparent_enum(
            succeed: bool,
        ) -> Result<(i32, ResultTestOpaqueRustType, String), ResultTransparentEnum>;
    }
}
```

```Swift
//...
do {
    //...
    let tuple: (Int32, ResultTestOpaqueRustType, RustString) = try rust_func_return_result_tuple_transparent_enum(true)
    //...
} catch {
    //...
}
//...
```

