### PR TITLE
Update incorrect-return-type.stderr

### DIFF
--- a/crates/swift-bridge-macro/tests/ui/incorrect-return-type.stderr
+++ b/crates/swift-bridge-macro/tests/ui/incorrect-return-type.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> tests/ui/incorrect-return-type.rs:6:1
    |
 6  |   #[swift_bridge::bridge]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^ expected struct `SomeType`, found `&SomeType`
+   |   ^^^^^^^^^^^^^^^^^^^^^^^ expected `SomeType`, found `&SomeType`
 ...
 9  |           type SomeType;
    |  ______________-
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
   --> tests/ui/incorrect-return-type.rs:6:1
    |
 6  |   #[swift_bridge::bridge]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^ expected struct `SomeType`, found enum `Option`
+   |   ^^^^^^^^^^^^^^^^^^^^^^^ expected `SomeType`, found `Option<SomeType>`
 ...
 9  |           type SomeType;
    |  ______________-


### PR DESCRIPTION
This commit fixes failing the UI test caused by updating rustc version 1.69.

If you want to know more detail, please see #213.