### PR TITLE
Add `RustVec<T>.as_ptr` method

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/VecTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/VecTests.swift
@@ -36,6 +36,12 @@ class VecTests: XCTestCase {
         vec.push(value: 222)
         XCTAssertEqual(vec.get(index: 1), 222)
     }
+    func testRustVecU8AsPtr() throws {
+        let vec = RustVec<UInt8>()
+        vec.push(value: 10)
+        let ptr = vec.as_ptr()
+        XCTAssertEqual(ptr.pointee, 10)
+    }
     func testRustVecU8Iterator() throws {
         let vec = RustVec<UInt8>()
         vec.push(value: 111)

--- a/crates/swift-bridge-build/src/generate_core.rs
+++ b/crates/swift-bridge-build/src/generate_core.rs
@@ -143,8 +143,6 @@ fn conform_to_vectorizable(swift_ty: &str, rust_ty: &str) -> String {
     format!(
         r#"
 extension {swift_ty}: Vectorizable {{
-    public typealias Elem = {swift_ty}
-
     public static func vecOfSelfNew() -> UnsafeMutableRawPointer {{
         __swift_bridge__$Vec_{rust_ty}$new()
     }}
@@ -184,8 +182,8 @@ extension {swift_ty}: Vectorizable {{
         }}
     }}
 
-    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Elem> {{
-        UnsafePointer<Elem>(OpaquePointer(__swift_bridge__$Vec_{rust_ty}$as_ptr(vecPtr)))
+    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Self> {{
+        UnsafePointer<Self>(OpaquePointer(__swift_bridge__$Vec_{rust_ty}$as_ptr(vecPtr)))
     }}
 
     public static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt {{

--- a/crates/swift-bridge-build/src/generate_core.rs
+++ b/crates/swift-bridge-build/src/generate_core.rs
@@ -143,6 +143,8 @@ fn conform_to_vectorizable(swift_ty: &str, rust_ty: &str) -> String {
     format!(
         r#"
 extension {swift_ty}: Vectorizable {{
+    public typealias Elem = {swift_ty}
+
     public static func vecOfSelfNew() -> UnsafeMutableRawPointer {{
         __swift_bridge__$Vec_{rust_ty}$new()
     }}
@@ -180,6 +182,10 @@ extension {swift_ty}: Vectorizable {{
         }} else {{
             return nil
         }}
+    }}
+
+    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Elem> {{
+        UnsafePointer<Elem>(OpaquePointer(__swift_bridge__$Vec_{rust_ty}$as_ptr(vecPtr)))
     }}
 
     public static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt {{

--- a/crates/swift-bridge-build/src/generate_core/rust_string.swift
+++ b/crates/swift-bridge-build/src/generate_core/rust_string.swift
@@ -87,8 +87,8 @@ extension RustString: Vectorizable {
         }
     }
 
-    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<UInt8> {
-        UnsafePointer<UInt8>(OpaquePointer(__swift_bridge__$Vec_RustString$as_ptr(vecPtr)))
+    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<RustStringRef> {
+        UnsafePointer<RustStringRef>(OpaquePointer(__swift_bridge__$Vec_RustString$as_ptr(vecPtr)))
     }
 
     public static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt {

--- a/crates/swift-bridge-build/src/generate_core/rust_string.swift
+++ b/crates/swift-bridge-build/src/generate_core/rust_string.swift
@@ -87,6 +87,10 @@ extension RustString: Vectorizable {
         }
     }
 
+    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<UInt8> {
+        UnsafePointer<UInt8>(OpaquePointer(__swift_bridge__$Vec_RustString$as_ptr(vecPtr)))
+    }
+
     public static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt {
         __swift_bridge__$Vec_RustString$len(vecPtr)
     }

--- a/crates/swift-bridge-build/src/generate_core/rust_vec.swift
+++ b/crates/swift-bridge-build/src/generate_core/rust_vec.swift
@@ -1,5 +1,4 @@
 public class RustVec<T: Vectorizable> {
-    public typealias Elem = T
     var ptr: UnsafeMutableRawPointer
     var isOwned: Bool = true
 
@@ -24,8 +23,8 @@ public class RustVec<T: Vectorizable> {
          T.vecOfSelfGet(vecPtr: ptr, index: index)
     }
 
-    public func as_ptr() -> UnsafePointer<T> {
-        UnsafePointer<T>(OpaquePointer(T.vecOfSelfAsPtr(vecPtr: ptr)))
+    public func as_ptr() -> UnsafePointer<T.SelfRef> {
+        UnsafePointer<T.SelfRef>(OpaquePointer(T.vecOfSelfAsPtr(vecPtr: ptr)))
     }
 
     /// Rust returns a UInt, but we cast to an Int because many Swift APIs such as
@@ -91,7 +90,6 @@ extension UnsafeBufferPointer {
 }
 
 public protocol Vectorizable {
-    associatedtype Elem
     associatedtype SelfRef
     associatedtype SelfRefMut
 
@@ -107,7 +105,7 @@ public protocol Vectorizable {
 
     static func vecOfSelfGetMut(vecPtr: UnsafeMutableRawPointer, index: UInt) -> Optional<SelfRefMut>
 
-    static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Elem>
+    static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<SelfRef>
 
     static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt
 }

--- a/crates/swift-bridge-build/src/generate_core/rust_vec.swift
+++ b/crates/swift-bridge-build/src/generate_core/rust_vec.swift
@@ -1,4 +1,5 @@
 public class RustVec<T: Vectorizable> {
+    public typealias Elem = T
     var ptr: UnsafeMutableRawPointer
     var isOwned: Bool = true
 
@@ -21,6 +22,10 @@ public class RustVec<T: Vectorizable> {
 
     public func get(index: UInt) -> Optional<T.SelfRef> {
          T.vecOfSelfGet(vecPtr: ptr, index: index)
+    }
+
+    public func as_ptr() -> UnsafePointer<T> {
+        UnsafePointer<T>(OpaquePointer(T.vecOfSelfAsPtr(vecPtr: ptr)))
     }
 
     /// Rust returns a UInt, but we cast to an Int because many Swift APIs such as
@@ -86,6 +91,7 @@ extension UnsafeBufferPointer {
 }
 
 public protocol Vectorizable {
+    associatedtype Elem
     associatedtype SelfRef
     associatedtype SelfRefMut
 
@@ -100,6 +106,8 @@ public protocol Vectorizable {
     static func vecOfSelfGet(vecPtr: UnsafeMutableRawPointer, index: UInt) -> Optional<SelfRef>
 
     static func vecOfSelfGetMut(vecPtr: UnsafeMutableRawPointer, index: UInt) -> Optional<SelfRefMut>
+
+    static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Elem>
 
     static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt
 }

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/vec_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/vec_codegen_tests.rs
@@ -93,8 +93,6 @@ mod extern_rust_type_vec_support {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 extension MyRustType: Vectorizable {
-    public typealias Elem = MyRustType
-
     public static func vecOfSelfNew() -> UnsafeMutableRawPointer {
         __swift_bridge__$Vec_MyRustType$new()
     }
@@ -134,8 +132,8 @@ extension MyRustType: Vectorizable {
         }
     }
 
-    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Elem> {
-        UnsafePointer<Elem>(OpaquePointer(__swift_bridge__$Vec_MyRustType$as_ptr(vecPtr)))
+    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<MyRustTypeRef> {
+        UnsafePointer<MyRustTypeRef>(OpaquePointer(__swift_bridge__$Vec_MyRustType$as_ptr(vecPtr)))
     }
 
     public static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt {
@@ -366,8 +364,6 @@ mod transparent_enum_vec_support {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 extension SomeEnum: Vectorizable {
-    public typealias Elem = SomeEnum
-
     public static func vecOfSelfNew() -> UnsafeMutableRawPointer {
         __swift_bridge__$Vec_SomeEnum$new()
     }
@@ -395,8 +391,8 @@ extension SomeEnum: Vectorizable {
         return maybeEnum.intoSwiftRepr()
     }
 
-    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Elem> {
-        UnsafePointer<Elem>(OpaquePointer(__swift_bridge__$Vec_SomeEnum$as_ptr(vecPtr)))
+    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Self> {
+        UnsafePointer<Self>(OpaquePointer(__swift_bridge__$Vec_SomeEnum$as_ptr(vecPtr)))
     }
 
     public static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt {

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/vec_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/vec_codegen_tests.rs
@@ -93,6 +93,8 @@ mod extern_rust_type_vec_support {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 extension MyRustType: Vectorizable {
+    public typealias Elem = MyRustType
+
     public static func vecOfSelfNew() -> UnsafeMutableRawPointer {
         __swift_bridge__$Vec_MyRustType$new()
     }
@@ -130,6 +132,10 @@ extension MyRustType: Vectorizable {
         } else {
             return MyRustTypeRefMut(ptr: pointer!)
         }
+    }
+
+    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Elem> {
+        UnsafePointer<Elem>(OpaquePointer(__swift_bridge__$Vec_MyRustType$as_ptr(vecPtr)))
     }
 
     public static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt {
@@ -360,6 +366,8 @@ mod transparent_enum_vec_support {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 extension SomeEnum: Vectorizable {
+    public typealias Elem = SomeEnum
+
     public static func vecOfSelfNew() -> UnsafeMutableRawPointer {
         __swift_bridge__$Vec_SomeEnum$new()
     }
@@ -385,6 +393,10 @@ extension SomeEnum: Vectorizable {
     public static func vecOfSelfGetMut(vecPtr: UnsafeMutableRawPointer, index: UInt) -> Optional<Self> {
         let maybeEnum = __swift_bridge__$Vec_SomeEnum$get_mut(vecPtr, index)
         return maybeEnum.intoSwiftRepr()
+    }
+
+    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Elem> {
+        UnsafePointer<Elem>(OpaquePointer(__swift_bridge__$Vec_SomeEnum$as_ptr(vecPtr)))
     }
 
     public static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt {

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
@@ -96,6 +96,8 @@ impl SwiftBridgeModule {
             format!(
                 r#"
 extension {enum_name}: Vectorizable {{
+    public typealias Elem = {enum_name}
+
     public static func vecOfSelfNew() -> UnsafeMutableRawPointer {{
         __swift_bridge__$Vec_{enum_name}$new()
     }}
@@ -121,6 +123,10 @@ extension {enum_name}: Vectorizable {{
     public static func vecOfSelfGetMut(vecPtr: UnsafeMutableRawPointer, index: UInt) -> Optional<Self> {{
         let maybeEnum = __swift_bridge__$Vec_{enum_name}$get_mut(vecPtr, index)
         return maybeEnum.intoSwiftRepr()
+    }}
+
+    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Elem> {{
+        UnsafePointer<Elem>(OpaquePointer(__swift_bridge__$Vec_{enum_name}$as_ptr(vecPtr)))
     }}
 
     public static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt {{

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
@@ -96,8 +96,6 @@ impl SwiftBridgeModule {
             format!(
                 r#"
 extension {enum_name}: Vectorizable {{
-    public typealias Elem = {enum_name}
-
     public static func vecOfSelfNew() -> UnsafeMutableRawPointer {{
         __swift_bridge__$Vec_{enum_name}$new()
     }}
@@ -125,8 +123,8 @@ extension {enum_name}: Vectorizable {{
         return maybeEnum.intoSwiftRepr()
     }}
 
-    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Elem> {{
-        UnsafePointer<Elem>(OpaquePointer(__swift_bridge__$Vec_{enum_name}$as_ptr(vecPtr)))
+    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Self> {{
+        UnsafePointer<Self>(OpaquePointer(__swift_bridge__$Vec_{enum_name}$as_ptr(vecPtr)))
     }}
 
     public static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt {{

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/vec.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/vec.rs
@@ -4,8 +4,6 @@ use proc_macro2::Ident;
 pub(super) fn generate_vectorizable_extension(ty: &Ident) -> String {
     format!(
         r#"extension {ty}: Vectorizable {{
-    public typealias Elem = {ty}
-
     public static func vecOfSelfNew() -> UnsafeMutableRawPointer {{
         __swift_bridge__$Vec_{ty}$new()
     }}
@@ -45,8 +43,8 @@ pub(super) fn generate_vectorizable_extension(ty: &Ident) -> String {
         }}
     }}
 
-    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Elem> {{
-        UnsafePointer<Elem>(OpaquePointer(__swift_bridge__$Vec_{ty}$as_ptr(vecPtr)))
+    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<{ty}Ref> {{
+        UnsafePointer<{ty}Ref>(OpaquePointer(__swift_bridge__$Vec_{ty}$as_ptr(vecPtr)))
     }}
 
     public static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt {{
@@ -70,8 +68,6 @@ mod tests {
     fn generates_vectorizable_extension() {
         let expected = r#"
 extension ARustType: Vectorizable {
-    public typealias Elem = ARustType
-
     public static func vecOfSelfNew() -> UnsafeMutableRawPointer {
         __swift_bridge__$Vec_ARustType$new()
     }
@@ -111,8 +107,8 @@ extension ARustType: Vectorizable {
         }
     }
 
-    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Elem> {
-        UnsafePointer<Elem>(OpaquePointer(__swift_bridge__$Vec_ARustType$as_ptr(vecPtr)))
+    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<ARustTypeRef> {
+        UnsafePointer<ARustTypeRef>(OpaquePointer(__swift_bridge__$Vec_ARustType$as_ptr(vecPtr)))
     }
 
     public static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt {

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/vec.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/vec.rs
@@ -4,6 +4,8 @@ use proc_macro2::Ident;
 pub(super) fn generate_vectorizable_extension(ty: &Ident) -> String {
     format!(
         r#"extension {ty}: Vectorizable {{
+    public typealias Elem = {ty}
+
     public static func vecOfSelfNew() -> UnsafeMutableRawPointer {{
         __swift_bridge__$Vec_{ty}$new()
     }}
@@ -43,6 +45,10 @@ pub(super) fn generate_vectorizable_extension(ty: &Ident) -> String {
         }}
     }}
 
+    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Elem> {{
+        UnsafePointer<Elem>(OpaquePointer(__swift_bridge__$Vec_{ty}$as_ptr(vecPtr)))
+    }}
+
     public static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt {{
         __swift_bridge__$Vec_{ty}$len(vecPtr)
     }}
@@ -64,6 +70,8 @@ mod tests {
     fn generates_vectorizable_extension() {
         let expected = r#"
 extension ARustType: Vectorizable {
+    public typealias Elem = ARustType
+
     public static func vecOfSelfNew() -> UnsafeMutableRawPointer {
         __swift_bridge__$Vec_ARustType$new()
     }
@@ -101,6 +109,10 @@ extension ARustType: Vectorizable {
         } else {
             return ARustTypeRefMut(ptr: pointer!)
         }
+    }
+
+    public static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<Elem> {
+        UnsafePointer<Elem>(OpaquePointer(__swift_bridge__$Vec_ARustType$as_ptr(vecPtr)))
     }
 
     public static func vecOfSelfLen(vecPtr: UnsafeMutableRawPointer) -> UInt {

--- a/src/std_bridge/string.rs
+++ b/src/std_bridge/string.rs
@@ -17,8 +17,6 @@ mod ffi {
 
         fn as_str(&self) -> &str;
 
-        fn as_ptr(&self) -> *const u8;
-
         fn trim(&self) -> &str;
     }
 }
@@ -48,10 +46,6 @@ impl RustString {
 
     fn as_str(&self) -> &str {
         self.0.as_str()
-    }
-
-    fn as_ptr(&self) -> *const u8 {
-        self.0.as_ptr()
     }
 
     fn trim(&self) -> &str {

--- a/src/std_bridge/string.rs
+++ b/src/std_bridge/string.rs
@@ -17,6 +17,8 @@ mod ffi {
 
         fn as_str(&self) -> &str;
 
+        fn as_ptr(&self) -> *const u8;
+
         fn trim(&self) -> &str;
     }
 }
@@ -46,6 +48,10 @@ impl RustString {
 
     fn as_str(&self) -> &str {
         self.0.as_str()
+    }
+
+    fn as_ptr(&self) -> *const u8 {
+        self.0.as_ptr()
     }
 
     fn trim(&self) -> &str {


### PR DESCRIPTION
This PR adds a method to the `Vectorizable` protocol:

```swift
static func vecOfSelfAsPtr(vecPtr: UnsafeMutableRawPointer) -> UnsafePointer<SelfRef>
```

My reason for adding this method was to be able to easily pass a serialized Protobuf object back and forth between Rust and Swift. Motivating example:

```rust
// rust

// Receives a serialized protobuf message and returns a serialized protobuf message
fn send_serialized_proto(bytes: &[u8]) -> Option<Vec<u8>> {
    // ...
}
```

Without `.as_ptr()`, it was necessary to return the raw pointer from Rust, which meant also returning the length separately, so using the Rust method was a bit less ergonomic on both sides. Here's how it looks now:

```swift
// swift

let message = My_Proto_Message()
// ...
guard let input = message.serializedData() else { ... }

guard let output: RustVec<UInt8>? = data.withUnsafeBytes {
    (ptr: UnsafeRawBufferPointer) -> RustVec<UInt8>? in
    let u8ptr = ptr.bindMemory(to: UInt8.self)
    return send_serialized_proto(u8ptr)
} else { ... }

do {
    let response = try My_Proto_Response.init(
        serializedData: Data(
            // The `.as_ptr()` method keeps this very straightforward
            bytes: output.as_ptr(),
            count: output.len()
        )
    )
} catch { ... }

// ...
```