### PR TITLE
Fix returning Result<Vec<>, ...> from Rust

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
@@ -158,4 +158,21 @@ class ResultTests: XCTestCase {
             }
         }
     }
+
+    /// Verify that we can receive a Result<Vec<>, OpaqueRust> from Rust
+    func testSwiftCallRustResultVecUInt32Rust() throws {
+        let vec = try! rust_func_return_result_of_vec_u32()
+        XCTAssertEqual(vec.len(), 3)
+        for (i, value) in vec.enumerated() {
+            XCTAssertEqual(UInt32(i), value)
+        }
+    }
+    
+    func testSwiftCallRustResultVecOpaqueRust() throws {
+        let vec = try! rust_func_return_result_of_vec_opaque()
+        XCTAssertEqual(vec.len(), 3)
+        for (i, value) in vec.enumerated() {
+            XCTAssertEqual(UInt32(i), value.val())
+        }
+    }
 }

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -481,6 +481,7 @@ impl BridgeableType for BridgedType {
 
     fn is_passed_via_pointer(&self) -> bool {
         match self {
+            BridgedType::StdLib(StdLibType::Vec(_)) => true,
             BridgedType::StdLib(_) => false,
             BridgedType::Foreign(_) => false,
             BridgedType::Bridgeable(ty) => ty.is_passed_via_pointer(),

--- a/crates/swift-integration-tests/src/result.rs
+++ b/crates/swift-integration-tests/src/result.rs
@@ -66,6 +66,12 @@ mod ffi {
         fn same_custom_result_returned_twice_first() -> Result<SameEnum, SameEnum>;
         fn same_custom_result_returned_twice_second() -> Result<SameEnum, SameEnum>;
     }
+
+    extern "Rust" {
+        fn rust_func_return_result_of_vec_u32() -> Result<Vec<u32>, ResultTestOpaqueRustType>;
+        fn rust_func_return_result_of_vec_opaque(
+        ) -> Result<Vec<ResultTestOpaqueRustType>, ResultTestOpaqueRustType>;
+    }
 }
 
 fn rust_func_takes_result_string(arg: Result<String, String>) {
@@ -174,4 +180,17 @@ fn same_custom_result_returned_twice_first() -> Result<ffi::SameEnum, ffi::SameE
 
 fn same_custom_result_returned_twice_second() -> Result<ffi::SameEnum, ffi::SameEnum> {
     todo!()
+}
+
+fn rust_func_return_result_of_vec_u32() -> Result<Vec<u32>, ResultTestOpaqueRustType> {
+    Ok(vec![0, 1, 2])
+}
+
+fn rust_func_return_result_of_vec_opaque(
+) -> Result<Vec<ResultTestOpaqueRustType>, ResultTestOpaqueRustType> {
+    Ok(vec![
+        ResultTestOpaqueRustType::new(0),
+        ResultTestOpaqueRustType::new(1),
+        ResultTestOpaqueRustType::new(2),
+    ])
 }


### PR DESCRIPTION
Fixes #217 