### PR TITLE
async: Fix returning Result<(), OpaqueType>

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
@@ -180,5 +180,9 @@ class AsyncTests: XCTestCase {
     func testSwiftCallsRustAsyncFnRetStruct() async throws {
         let _: AsyncRustFnReturnStruct = await rust_async_return_struct()
     }
+    
+    func testSwiftCallsRustAsyncFnReturnResultNullOpaqueRust() async throws {
+        try await rust_async_func_return_result_null_opaque_rust()
+    }
 }
 

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/AsyncTests.swift
@@ -182,7 +182,14 @@ class AsyncTests: XCTestCase {
     }
     
     func testSwiftCallsRustAsyncFnReturnResultNullOpaqueRust() async throws {
-        try await rust_async_func_return_result_null_opaque_rust()
+        try await rust_async_func_return_result_null_opaque_rust(true)
+        
+        do {
+            try await rust_async_func_return_result_null_opaque_rust(false)
+            XCTFail()
+        } catch let error as AsyncResultOpaqueRustType2 {
+            XCTAssertEqual(error.val(), 111)
+        }
     }
 }
 

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
@@ -190,6 +190,9 @@ impl BuiltInResult {
                 if self.is_custom_result_type() {
                     return format!("{}${}", SWIFT_BRIDGE_PREFIX, self.custom_c_struct_name());
                 }
+                if self.ok_ty.can_be_encoded_with_zero_bytes() {
+                    return "UnsafeMutableRawPointer?".to_string();
+                }
                 "__private__ResultPtrAndPtr".to_string()
             }
         }
@@ -441,11 +444,25 @@ typedef struct {c_enum_name}{{{c_tag_name} tag; union {c_fields_name} payload;}}
         let ok = self.ok_ty.to_swift_type(type_pos, types);
         let err = self.err_ty.to_swift_type(type_pos, types);
 
+        let (ok_val, err_val, condition) = if self.ok_ty.can_be_encoded_with_zero_bytes() {
+            (
+                ok,
+                format!("{err}(ptr: rustFnRetVal!)"),
+                "rustFnRetVal == nil",
+            )
+        } else {
+            (
+                format!("{ok}(ptr: rustFnRetVal.ok_or_err!)"),
+                format!("{err}(ptr: rustFnRetVal.ok_or_err!)"),
+                "rustFnRetVal.is_ok",
+            )
+        };
+
         format!(
-            r#"if rustFnRetVal.is_ok {{
-        wrapper.cb(.success({ok}(ptr: rustFnRetVal.ok_or_err!)))
+            r#"if {condition} {{
+        wrapper.cb(.success({ok_val}))
     }} else {{
-        wrapper.cb(.failure({err}(ptr: rustFnRetVal.ok_or_err!)))
+        wrapper.cb(.failure({err_val}))
     }}"#
         )
     }

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/async_function_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/async_function_codegen_tests.rs
@@ -949,3 +949,103 @@ void __swift_bridge__$some_function(void* callback_wrapper, void __swift_bridge_
         .test();
     }
 }
+
+/// Verify that we generate the correct code for extern "Rust" async functions that returns a Result<(), OpaqueRustType>.
+mod extern_rust_async_function_returns_result_null_opaque {
+    use super::*;
+
+    fn bridge_module() -> TokenStream {
+        quote! {
+            #[swift_bridge::bridge]
+            mod ffi {
+                extern "Rust" {
+                    type ErrorType;
+                    async fn some_function() -> Result<(), ErrorType>;
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::Contains(quote! {
+            pub extern "C" fn __swift_bridge__some_function(
+                callback_wrapper: *mut std::ffi::c_void,
+                callback: extern "C" fn(*mut std::ffi::c_void, *mut super::ErrorType) -> (),
+            ) {
+                let callback_wrapper = swift_bridge::async_support::SwiftCallbackWrapper(callback_wrapper);
+                let fut = super::some_function();
+                let task = async move {
+                    let val = match fut.await {
+                        Ok(ok) => std::ptr::null_mut(),
+                        Err(err) => Box::into_raw(Box::new({
+                            let val: super::ErrorType = err;
+                            val
+                        })) as *mut super::ErrorType
+                    };
+                    let callback_wrapper = callback_wrapper;
+                    let callback_wrapper = callback_wrapper.0;
+                    (callback)(callback_wrapper, val)
+                };
+                swift_bridge::async_support::ASYNC_RUNTIME.spawn_task(Box::pin(task))
+            }
+        })
+    }
+
+    // TODO: Replace `Error` with the concrete error type `ErrorType`.
+    // As of Feb 2023 using the concrete error type leads to a compile time error.
+    // This seems like a bug in the Swift compiler.
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(
+            r#"
+public func some_function() async throws -> () {
+    func onComplete(cbWrapperPtr: UnsafeMutableRawPointer?, rustFnRetVal: UnsafeMutableRawPointer?) {
+        let wrapper = Unmanaged<CbWrapper$some_function>.fromOpaque(cbWrapperPtr!).takeRetainedValue()
+        if rustFnRetVal == nil {
+            wrapper.cb(.success(()))
+        } else {
+            wrapper.cb(.failure(ErrorType(ptr: rustFnRetVal!)))
+        }
+    }
+
+    return try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<(), Error>) in
+        let callback = { rustFnRetVal in
+            continuation.resume(with: rustFnRetVal)
+        }
+
+        let wrapper = CbWrapper$some_function(cb: callback)
+        let wrapperPtr = Unmanaged.passRetained(wrapper).toOpaque()
+
+        __swift_bridge__$some_function(wrapperPtr, onComplete)
+    })
+}
+class CbWrapper$some_function {
+    var cb: (Result<(), Error>) -> ()
+
+    public init(cb: @escaping (Result<(), Error>) -> ()) {
+        self.cb = cb
+    }
+}
+"#,
+        )
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::ContainsAfterTrim(
+            r#"
+void __swift_bridge__$some_function(void* callback_wrapper, void __swift_bridge__$some_function$async(void* callback_wrapper, void* ret));
+    "#,
+        )
+    }
+
+    #[test]
+    fn extern_rust_async_function_returns_result_null_opaque() {
+        CodegenTest {
+            bridge_module: bridge_module().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}

--- a/crates/swift-integration-tests/src/async_function.rs
+++ b/crates/swift-integration-tests/src/async_function.rs
@@ -13,6 +13,8 @@ mod ffi {
         async fn rust_async_func_reflect_result_opaque_rust(
             arg: Result<AsyncResultOpaqueRustType1, AsyncResultOpaqueRustType2>,
         ) -> Result<AsyncResultOpaqueRustType1, AsyncResultOpaqueRustType2>;
+        async fn rust_async_func_return_result_null_opaque_rust(
+        ) -> Result<(), AsyncResultOpaqueRustType2>;
     }
 
     extern "Rust" {
@@ -175,4 +177,9 @@ async fn rust_async_func_return_result_null_and_transparent_enum(
             123,
         ))
     }
+}
+
+async fn rust_async_func_return_result_null_opaque_rust() -> Result<(), AsyncResultOpaqueRustType2>
+{
+    Ok(())
 }

--- a/crates/swift-integration-tests/src/async_function.rs
+++ b/crates/swift-integration-tests/src/async_function.rs
@@ -14,6 +14,7 @@ mod ffi {
             arg: Result<AsyncResultOpaqueRustType1, AsyncResultOpaqueRustType2>,
         ) -> Result<AsyncResultOpaqueRustType1, AsyncResultOpaqueRustType2>;
         async fn rust_async_func_return_result_null_opaque_rust(
+            succeed: bool,
         ) -> Result<(), AsyncResultOpaqueRustType2>;
     }
 
@@ -179,7 +180,12 @@ async fn rust_async_func_return_result_null_and_transparent_enum(
     }
 }
 
-async fn rust_async_func_return_result_null_opaque_rust() -> Result<(), AsyncResultOpaqueRustType2>
-{
-    Ok(())
+async fn rust_async_func_return_result_null_opaque_rust(
+    succeed: bool,
+) -> Result<(), AsyncResultOpaqueRustType2> {
+    if succeed {
+        Ok(())
+    } else {
+        Err(AsyncResultOpaqueRustType2(111))
+    }
 }


### PR DESCRIPTION
Fixes #220 

This supports bridges of the form:
```rust
#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        type ErrorType;
        async fn some_function() -> Result<(), ErrorType>;
    }
}

async fn some_function() -> Result<(), ErrorType> {
  Ok(())
}
```

