### PR TITLE
Support `RustString` in extern Swift functions

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/String.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/String.swift
@@ -10,3 +10,7 @@ import Foundation
 func create_swift_string() -> String {
     "hello"
 }
+
+func reflect_swift_string(arg: RustString) -> RustString {
+    arg
+}

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/String.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/String.swift
@@ -11,6 +11,6 @@ func create_swift_string() -> String {
     "hello"
 }
 
-func reflect_swift_string(arg: RustString) -> RustString {
+func reflect_rust_string(arg: RustString) -> RustString {
     arg
 }

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/StringTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/StringTests.swift
@@ -40,7 +40,7 @@ class StringTests: XCTestCase {
     
     func testRustStringToString() throws {
         let string = "hi"
-        
+
         XCTAssertEqual(
             create_string(string).toString(),
             "hi"

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
@@ -49,7 +49,13 @@ impl BridgeableType for BridgedString {
 
     fn to_swift_type(&self, type_pos: TypePosition, _types: &TypeDeclarations) -> String {
         match type_pos {
-            TypePosition::FnArg(_func_host_lang, _) => "GenericIntoRustString".to_string(),
+            TypePosition::FnArg(func_host_lang, _) => {
+                if func_host_lang.is_rust() {
+                    "GenericIntoRustString".to_string()
+                } else {
+                    "UnsafeMutableRawPointer".to_string()
+                }
+            }
             TypePosition::FnReturn(func_host_lang) => {
                 if func_host_lang.is_rust() {
                     "RustString".to_string()

--- a/crates/swift-integration-tests/src/string.rs
+++ b/crates/swift-integration-tests/src/string.rs
@@ -8,7 +8,7 @@ mod ffi {
 
     extern "Swift" {
         fn create_swift_string() -> String;
-        fn reflect_swift_string(arg: String) -> String;
+        fn reflect_rust_string(arg: String) -> String;
     }
 }
 
@@ -18,7 +18,7 @@ fn run_string_tests() {
     assert_eq!(&string, "hello");
 
     let foo = "foo";
-    let string = ffi::reflect_swift_string(foo.to_string());
+    let string = ffi::reflect_rust_string(foo.to_string());
     assert_eq!(string.len(), 3);
     assert_eq!(&string, foo);
 }

--- a/crates/swift-integration-tests/src/string.rs
+++ b/crates/swift-integration-tests/src/string.rs
@@ -8,6 +8,7 @@ mod ffi {
 
     extern "Swift" {
         fn create_swift_string() -> String;
+        fn reflect_swift_string(arg: String) -> String;
     }
 }
 
@@ -15,6 +16,11 @@ fn run_string_tests() {
     let string = ffi::create_swift_string();
     assert_eq!(string.len(), 5);
     assert_eq!(&string, "hello");
+
+    let foo = "foo";
+    let string = ffi::reflect_swift_string(foo.to_string());
+    assert_eq!(string.len(), 3);
+    assert_eq!(&string, foo);
 }
 
 fn create_string(str: &str) -> String {


### PR DESCRIPTION
Related to #201. This commit adds support `RustString`  in extern Swift functions.

Here's an example of using this.

```Swift
//Swift
func reflect_swift_string(arg: RustString) -> RustString {
    arg
}

```

```Rust
//Rust
#[swift_bridge::bridge]
mod ffi {
    extern "Swift" {
        fn reflect_swift_string(arg: String) -> String;
    }
}

let foo = "foo";
let string = ffi::reflect_swift_string(foo.to_string());
assert_eq!(string.len(), 3);
assert_eq!(&string, foo);
```