### PR TITLE
Swift `Vec<primitive>` Return Type and Function Argument

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Vec.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Vec.swift
@@ -1,6 +1,12 @@
 import Foundation
 
-func swift_arg_vec_u8(vec _: RustVec<UInt8>) {}
+func swift_arg_vec_u8(vec _: RustVec<UInt8>) {
+    assert(vec[0] == 1)
+    assert(vec[1] == 2)
+    assert(vec[2] == 3)
+    assert(vec[3] == 4)
+    assert(vec[4] == 5)
+}
 
 func swift_return_vec_u8() -> RustVec<UInt8> {
     let vec = RustVec<UInt8>()

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Vec.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Vec.swift
@@ -1,10 +1,3 @@
-//
-//  String.swift
-//  SwiftRustIntegrationTestRunner
-//
-//  Created by Frankie Nwafili on 2/18/22.
-//
-
 import Foundation
 
 func send_bytes(vec _: RustVec<UInt8>) {}

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Vec.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Vec.swift
@@ -1,0 +1,18 @@
+//
+//  String.swift
+//  SwiftRustIntegrationTestRunner
+//
+//  Created by Frankie Nwafili on 2/18/22.
+//
+
+import Foundation
+
+func send_bytes(vec _: RustVec<UInt8>) {}
+
+func receive_bytes() -> RustVec<UInt8> {
+    let vec = RustVec<UInt8>()
+    for i in 0 ... 4 {
+        vec.push(value: UInt8(i))
+    }
+    return vec
+}

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Vec.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Vec.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-func send_bytes(vec _: RustVec<UInt8>) {}
+func swift_arg_vec_u8(vec _: RustVec<UInt8>) {}
 
-func receive_bytes() -> RustVec<UInt8> {
+func swift_return_vec_u8() -> RustVec<UInt8> {
     let vec = RustVec<UInt8>()
     for i in 0 ... 4 {
         vec.push(value: UInt8(i))

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/VecTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/VecTests.swift
@@ -123,6 +123,11 @@ class VecTests: XCTestCase {
         XCTAssertEqual(RustVec<Float>().len(), 0);
         XCTAssertEqual(RustVec<Double>().len(), 0);
     }
+
+    /// Verify that Rust can pass `RustVec`s to and receive `RustVec`s from Swift.
+    func testRustCallsSwiftRustVecFunctions() {
+        run_vec_tests()
+    }
 }
 
 

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -1158,9 +1158,25 @@ impl BridgedType {
                         unimplemented!()
                     }
                 },
-                StdLibType::Vec(ty) => {
-                    format!("RustVec<{}>", ty.ty.to_swift_type(type_pos, types))
-                }
+                StdLibType::Vec(ty) => match type_pos {
+                    TypePosition::FnArg(func_host_lang, _) => {
+                        if func_host_lang.is_rust() {
+                            format!("RustVec<{}>", ty.ty.to_swift_type(type_pos, types))
+                        } else {
+                            "UnsafeMutableRawPointer".to_string()
+                        }
+                    },
+                    TypePosition::FnReturn(func_host_lang) => {
+                        if func_host_lang.is_rust() {
+                            format!("RustVec<{}>", ty.ty.to_swift_type(type_pos, types))
+                        } else {
+                            "UnsafeMutableRawPointer".to_string()
+                        }
+                    }
+                    _ => {
+                        format!("RustVec<{}>", ty.ty.to_swift_type(type_pos, types))
+                    }
+                },
                 StdLibType::Option(opt) => opt.to_swift_type(type_pos, types),
                 StdLibType::Result(result) => result.to_swift_type(type_pos, types),
                 StdLibType::BoxedFnOnce(boxed_fn) => boxed_fn.to_swift_type().to_string(),

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -1165,7 +1165,7 @@ impl BridgedType {
                         } else {
                             "UnsafeMutableRawPointer".to_string()
                         }
-                    },
+                    }
                     TypePosition::FnReturn(func_host_lang) => {
                         if func_host_lang.is_rust() {
                             format!("RustVec<{}>", ty.ty.to_swift_type(type_pos, types))

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/vec_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/vec_codegen_tests.rs
@@ -586,7 +586,7 @@ func __swift_bridge__some_function () -> UnsafeMutableRawPointer {
     }
 
     fn expected_c_header() -> ExpectedCHeader {
-        ExpectedCHeader::ContainsAfterTrim("")
+        ExpectedCHeader::ExactAfterTrim("")
     }
 
     #[test]

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/vec_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/vec_codegen_tests.rs
@@ -643,7 +643,7 @@ func __swift_bridge__some_function (_ arg: UnsafeMutableRawPointer) {
     }
 
     fn expected_c_header() -> ExpectedCHeader {
-        ExpectedCHeader::ContainsAfterTrim("")
+        ExpectedCHeader::ExactAfterTrim("")
     }
 
     #[test]

--- a/crates/swift-integration-tests/src/vec.rs
+++ b/crates/swift-integration-tests/src/vec.rs
@@ -31,13 +31,13 @@ mod ffi {
     }
 
     extern "Swift" {
-        fn receive_bytes() -> Vec<u8>;
-        fn send_bytes(vec: Vec<u8>);
+        fn swift_return_vec_u8() -> Vec<u8>;
+        fn swift_arg_vec_u8(vec: Vec<u8>);
     }
 }
 
 fn run_vec_tests() {
-    let vec = ffi::receive_bytes();
+    let vec = ffi::swift_return_vec_u8();
     assert_eq!(vec.len(), 5);
     assert_eq!(vec[0], 0);
     assert_eq!(vec[1], 1);
@@ -46,7 +46,7 @@ fn run_vec_tests() {
     assert_eq!(vec[4], 4);
 
     let vec: Vec<u8> = vec![1, 2, 3, 4, 5];
-    ffi::send_bytes(vec);
+    ffi::swift_arg_vec_u8(vec);
 }
 
 pub struct ARustTypeInsideVecT {

--- a/crates/swift-integration-tests/src/vec.rs
+++ b/crates/swift-integration-tests/src/vec.rs
@@ -25,6 +25,28 @@ mod ffi {
             arg: Vec<TransparentEnumInsideVecT>,
         ) -> Vec<TransparentEnumInsideVecT>;
     }
+
+    extern "Rust" {
+        fn run_vec_tests();
+    }
+
+    extern "Swift" {
+        fn receive_bytes() -> Vec<u8>;
+        fn send_bytes(vec: Vec<u8>);
+    }
+}
+
+fn run_vec_tests() {
+    let vec = ffi::receive_bytes();
+    assert_eq!(vec.len(), 5);
+    assert_eq!(vec[0], 0);
+    assert_eq!(vec[1], 1);
+    assert_eq!(vec[2], 2);
+    assert_eq!(vec[3], 3);
+    assert_eq!(vec[4], 4);
+
+    let vec: Vec<u8> = vec![1, 2, 3, 4, 5];
+    ffi::send_bytes(vec);
 }
 
 pub struct ARustTypeInsideVecT {


### PR DESCRIPTION
Fixes #228.

This enables the following use case:
```rust
// Rust
fn main() {
    let bytes = ffi::receive_bytes();
    println!("bytes: {:?}", bytes);

    let vec: Vec<u8> = vec![6, 1, 2, 3, 4, 5];
    ffi::send_bytes(vec);
}

#[swift_bridge::bridge]
mod ffi {
    extern "Swift" {
        fn receive_bytes() -> Vec<u8>;
        fn send_bytes(vec: Vec<u8>);
    }
}
```

```swift
// Swift
func send_bytes(vec: RustVec<UInt8>) {
    print("Received \(vec.len()) bytes from Rust")
    for val in vec {
        print(val)
    }
}

func receive_bytes() -> RustVec<UInt8> {
    let vec = RustVec<UInt8>()
    for i in 0 ... 4 {
        vec.push(value: UInt8(i))
    }
    return vec
}
```

This is chiefly intended for easy bidirectional byte exchanges but should work for all primitive types, at least the ones I tested with.

The codegen tests pass but I was unable to get the integration tests to run: They also fail for me on `master` and I don't understand enough of how they work to properly debug them. The (_very_ long) error messages ends with this, which seems to be the culprit:
> field has incomplete type 'struct __swift_bridge__$tuple$I32ResultTestOpaqueRustTypeString'

I attempted to add some integration tests for both directions anyway, but given that I'm operating 'blind' on that part I can't assure you whether these work or not.

I'm rather certain that there's still issues with my PR given that this is my first time dealing with this kind of interop work, so by all means do let me know how to address the current weaknesses/problems and I'll do my best to resolve them.