### PR TITLE
Improve the error message in SharedStructDeclarationParser when an un…

### DIFF
--- a/book/src/bridge-module/transparent-types/structs/README.md
+++ b/book/src/bridge-module/transparent-types/structs/README.md
@@ -7,7 +7,7 @@ You can define structs whos fields can be accessed by both Rust and Swift.
 
 #[swift_bridge::bridge]
 mod ffi {
-    #[swift_bridge::bridge(swift_repr = "struct")]
+    #[swift_bridge(swift_repr = "struct")]
     struct SomeSharedStruct {
         some_field: u8,
         another_field: Option<u64>
@@ -37,7 +37,7 @@ func another_function() -> SomeSharedStruct {
 
 ### Struct Attributes
 
-#### #[swift_bridge::bridge(already_declared)]
+#### #[swift_bridge(already_declared)]
 
 ```rust
 #[swift_bridge::bridge]
@@ -63,7 +63,7 @@ mod ffi_2 {
 }
 ```
 
-#### #[swift_bridge::bridge(swift_repr = "...")]
+#### #[swift_bridge(swift_repr = "...")]
 
 _Valid values are "struct" or "class"._
 

--- a/crates/swift-bridge-ir/src/parse/parse_struct.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_struct.rs
@@ -139,7 +139,13 @@ impl<'a> SharedStructDeclarationParser<'a> {
                     }
                     _ => todo!("Push parse error that derive attribute is in incorrect format"),
                 },
-                _ => todo!("Push unsupported attribute error."),
+                attr_name => {
+                    todo!(
+                        "Push unsupported attribute error. Found unsupported attribute \"{}\" on struct \"{}\". Consult the swift-bridge manual for supported struct attributes.",
+                        attr_name,
+                        item_struct.ident.to_string(),
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
…supported attribute is found

The panic message now contains the name of the unsupported attribute as well as the name of the struct that the attribute was found on.

This commit also updates the documentation to fix faulty struct attributes.