### PR TITLE
Add support for #[derive(Debug, serde::Serialize, serde::Deserialize)] to SharedStruct

### DIFF
--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
@@ -257,6 +257,9 @@ pub(crate) struct SharedStruct {
 pub(crate) struct StructDerives {
     pub copy: bool,
     pub clone: bool,
+    pub debug: bool,
+    pub serialize: bool,
+    pub deserialize: bool,
 }
 
 impl SharedStruct {

--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens/shared_struct.rs
@@ -98,6 +98,15 @@ impl SwiftBridgeModule {
         if shared_struct.derives.clone {
             derives.push(quote! {Clone});
         }
+        if shared_struct.derives.debug {
+            derives.push(quote! {Debug});
+        }
+        if shared_struct.derives.serialize {
+            derives.push(quote! {serde::Serialize});
+        }
+        if shared_struct.derives.deserialize {
+            derives.push(quote! {serde::Deserialize});
+        }
 
         let definition = quote! {
             #[derive(#(#derives),*)]

--- a/crates/swift-bridge-ir/src/parse/parse_struct.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_struct.rs
@@ -38,6 +38,9 @@ impl Default for StructDerives {
         StructDerives {
             copy: false,
             clone: false,
+            debug: false,
+            serialize: false,
+            deserialize: false,
         }
     }
 }
@@ -133,6 +136,9 @@ impl<'a> SharedStructDeclarationParser<'a> {
                             match derive.to_token_stream().to_string().as_str() {
                                 "Copy" => attribs.derives.copy = true,
                                 "Clone" => attribs.derives.clone = true,
+                                "Debug" => attribs.derives.debug = true,
+                                "serde :: Serialize" => attribs.derives.serialize = true,
+                                "serde :: Deserialize" => attribs.derives.deserialize = true,
                                 _ => {}
                             }
                         }
@@ -353,6 +359,9 @@ mod tests {
 
                 #[derive(Clone)]
                 struct Bar;
+
+                #[derive(serde::Deserialize)]
+                struct Baz;
             }
         };
 
@@ -367,6 +376,11 @@ mod tests {
 
         assert_eq!(ty2.derives.copy, false);
         assert_eq!(ty2.derives.clone, true);
+
+        let ty3 = module.types.types()[2].unwrap_shared_struct();
+
+        assert_eq!(ty3.derives.copy, false);
+        assert_eq!(ty3.derives.deserialize, true);
     }
 
     /// Verify that we properly parse multiple comma separated struct attributes.

--- a/crates/swift-integration-tests/src/struct_attributes/derive.rs
+++ b/crates/swift-integration-tests/src/struct_attributes/derive.rs
@@ -25,4 +25,10 @@ mod ffi {
     struct StructDeriveClone3 {
         field: String,
     }
+
+    #[swift_bridge(swift_repr = "struct")]
+    #[derive(serde::Deserialize)]
+    struct StructDeriveDeserialize {
+        field: String,
+    }
 }


### PR DESCRIPTION
Expanding on https://github.com/chinedufn/swift-bridge/pull/198

Let me know if this is heading toward the right direction, I can add more tests later.