### PR TITLE
added missing source

### DIFF
--- a/book/src/building/swiftc-and-cargo/README.md
+++ b/book/src/building/swiftc-and-cargo/README.md
@@ -122,7 +122,7 @@ set -e
 
 cargo build --target x86_64-apple-darwin
 swiftc -L target/x86_64-apple-darwin/debug/ -lswift_and_rust -import-objc-header bridging-header.h \
-  main.swift lib.swift ./generated/swift-and-rust/swift-and-rust.swift
+  main.swift lib.swift ./generated/swift-and-rust/swift-and-rust.swift ./generated/SwiftBridgeCore.swift
 ```
 
 ```sh


### PR DESCRIPTION
in build-swiftc-links-rust.sh, the command
swiftc -L target/x86_64-apple-darwin/debug/ -lswift_and_rust -import-objc-header bridging-header.h \
  main.swift lib.swift ./generated/swift-and-rust/swift-and-rust.swift 
is missing the source ./generated/SwiftBridgeCore.swift