### PR TITLE
Fix `improper_ctypes` warning

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/SharedStruct.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/SharedStruct.swift
@@ -11,7 +11,10 @@ func rust_calls_swift_struct_with_no_fields(arg: StructWithNoFields) -> StructWi
     arg
 }
 
-func rust_calls_struct_repr_struct_one_primitive_field(arg: StructReprStructWithOnePrimitiveField) -> StructReprStructWithOnePrimitiveField {
+func rust_calls_swift_struct_repr_struct_one_primitive_field(arg: StructReprStructWithOnePrimitiveField) -> StructReprStructWithOnePrimitiveField {
     arg
 }
 
+func rust_calls_swift_struct_repr_struct_one_string_field(arg: StructReprStructWithOneStringField) -> StructReprStructWithOneStringField {
+    arg
+}

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedStructTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SharedStructTests.swift
@@ -34,6 +34,16 @@ class SharedStructTests: XCTestCase {
         XCTAssertEqual(val.named_field, 56)
     }
     
+    /// Verify that we can pass a transparent struct that contains a String back and forth between Rust and Swift.
+    /// `SharedStruct { field: String }`.
+    func testStructReprStructWithOneStringField() {
+        let val = rust_calls_swift_struct_repr_struct_one_string_field(
+            arg: StructReprStructWithOneStringField(field: "hello world".intoRustString())
+        );
+        XCTAssertEqual(val.field.toString(), "hello world")
+    }
+   
+    
     /// Verify that we can create a tuple struct.
     func testTupleStruct() {
         let val = StructReprStructTupleStruct(_0: 11, _1: 22)

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/function_attribute_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/function_attribute_codegen_tests.rs
@@ -429,6 +429,8 @@ mod function_attribute_swift_name_extern_rust {
             pub fn call_swift_from_rust() -> String {
                 unsafe { Box::from_raw(unsafe {__swift_bridge__call_swift_from_rust () }).0 }
             }
+
+            #[allow(improper_ctypes)]
             extern "C" {
                 #[link_name = "__swift_bridge__$call_swift_from_rust"]
                 fn __swift_bridge__call_swift_from_rust() -> * mut swift_bridge::string::RustString;

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_rust_type_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_rust_type_codegen_tests.rs
@@ -422,6 +422,7 @@ mod extern_swift_freestanding_fn_with_owned_opaque_rust_type_arg {
                 })) as *mut super::MyType ) }
             }
 
+            #[allow(improper_ctypes)]
             extern "C" {
                 #[link_name = "__swift_bridge__$some_function"]
                 fn __swift_bridge__some_function (arg: *mut super::MyType);

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_swift_type_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_swift_type_codegen_tests.rs
@@ -32,6 +32,7 @@ mod extern_swift_freestanding_fn_with_owned_opaque_swift_type_arg {
                 }
             }
 
+            #[allow(improper_ctypes)]
             extern "C" {
                 #[link_name = "__swift_bridge__$some_function"]
                 fn __swift_bridge__some_function (arg: MyType);

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/vec_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/vec_codegen_tests.rs
@@ -566,6 +566,8 @@ mod extern_swift_fn_return_vec_of_primitive_rust_type {
                 pub fn some_function() -> Vec<u8> {
                     unsafe { *Box::from_raw(unsafe { __swift_bridge__some_function() }) }
                 }
+
+                #[allow(improper_ctypes)]
                 extern "C" {
                     #[link_name = "__swift_bridge__$some_function"]
                     fn __swift_bridge__some_function() -> *mut Vec<u8>;
@@ -623,6 +625,8 @@ mod extern_swift_fn_arg_vec_of_primitive_rust_type {
                 pub fn some_function(arg: Vec<u8>) {
                     unsafe { __swift_bridge__some_function(Box::into_raw(Box::new(arg))) }
                 }
+
+                #[allow(improper_ctypes)]
                 extern "C" {
                     #[link_name = "__swift_bridge__$some_function"]
                     fn __swift_bridge__some_function(arg: *mut Vec<u8>);

--- a/crates/swift-bridge-macro/tests/ui/incorrect-return-type.stderr
+++ b/crates/swift-bridge-macro/tests/ui/incorrect-return-type.stderr
@@ -29,3 +29,7 @@ error[E0308]: mismatched types
    = note: expected struct `SomeType`
                 found enum `Option<SomeType>`
    = note: this error originates in the attribute macro `swift_bridge::bridge` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider using `Option::expect` to unwrap the `Option<SomeType>` value, panicking if the value is an `Option::None`
+   |
+6  | #[swift_bridge::bridge].expect("REASON")
+   |                        +++++++++++++++++

--- a/crates/swift-integration-tests/src/shared_types/shared_struct.rs
+++ b/crates/swift-integration-tests/src/shared_types/shared_struct.rs
@@ -17,6 +17,11 @@ mod ffi {
     #[swift_bridge(swift_repr = "struct")]
     struct StructReprStructTupleStruct(u8, u32);
 
+    #[swift_bridge(swift_repr = "struct")]
+    struct StructReprStructWithOneStringField {
+        field: String,
+    }
+
     extern "Rust" {
         fn test_rust_calls_swift();
 
@@ -34,15 +39,19 @@ mod ffi {
     extern "Swift" {
         fn rust_calls_swift_struct_with_no_fields(arg: StructWithNoFields) -> StructWithNoFields;
 
-        fn rust_calls_struct_repr_struct_one_primitive_field(
+        fn rust_calls_swift_struct_repr_struct_one_primitive_field(
             arg: StructReprStructWithOnePrimitiveField,
         ) -> StructReprStructWithOnePrimitiveField;
+
+        fn rust_calls_swift_struct_repr_struct_one_string_field(
+            arg: StructReprStructWithOneStringField,
+        ) -> StructReprStructWithOneStringField;
     }
 }
 
 fn test_rust_calls_swift() {
     self::tests::test_rust_calls_swift_struct_with_no_fields();
-    self::tests::test_rust_calls_struct_repr_struct_one_primitive_field();
+    self::tests::test_rust_calls_swift_struct_repr_struct_one_primitive_field();
 }
 
 fn swift_calls_rust_struct_with_no_fields(arg: ffi::StructWithNoFields) -> ffi::StructWithNoFields {
@@ -70,10 +79,10 @@ mod tests {
             ffi::rust_calls_swift_struct_with_no_fields(ffi::StructWithNoFields);
     }
 
-    pub(super) fn test_rust_calls_struct_repr_struct_one_primitive_field() {
+    pub(super) fn test_rust_calls_swift_struct_repr_struct_one_primitive_field() {
         let arg = ffi::StructReprStructWithOnePrimitiveField { named_field: 10 };
 
-        let val = ffi::rust_calls_struct_repr_struct_one_primitive_field(arg);
+        let val = ffi::rust_calls_swift_struct_repr_struct_one_primitive_field(arg);
 
         assert_eq!(val.named_field, 10);
     }

--- a/examples/async-functions/build.sh
+++ b/examples/async-functions/build.sh
@@ -10,4 +10,5 @@ cargo build -p async-functions
 swiftc -L ../../target/debug \
   -lasync_functions \
   -import-objc-header bridging-header.h \
+  -framework CoreFoundation -framework SystemConfiguration \
   main.swift ./generated/SwiftBridgeCore.swift ./generated/async-functions/async-functions.swift


### PR DESCRIPTION
This commit fixes an `improper_ctypes` warning when bridging transparent
structs that contain non FFI safe types.

While transparent structs that contained non FFI safe types were being
passed in an FFI safe way before this commit, the Rust compiler could
not know that what we were doing was FFI safe.

This commit uses `#[allow(improper_ctypes)]` to silence the lint.

## Illustration

Before this commit the following bridge module:

```rust
#[swift_bridge::bridge]
mod ffi {
    struct SharedStruct {
        field: String
    }

    extern "Swift" {
        fn swift_func() -> SharedStruct;
    }
}
```

would lead to the following warning:

```console
warning: `extern` block uses type `RustString`, which is not FFI-safe
 --> my_file.rs:4:12
  |
4 |     struct SharedStruct {
  |            ^^^^^^^^^^^^ not FFI-safe
  |
  = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
  = note: this struct has unspecified layout
  = note: `#[warn(improper_ctypes)]` on by default
```

This warning was a bit misleading in that it made it seem like the
`RustString` needed a `#[repr(C)]` annotation.

The real issue was that the generated FFI representation type:

```rust
#[repr(C)]
struct __swift_bridge__SharedStruct {
    field: *mut std::string::RustString
}
```
was triggering a warning because the Rust compiler can't know that the
non-FFI safe `std::string::RustString` is not being dereferenced on the
Swift side.