### PR TITLE
Add test cases for Option<&T> and fix rust codegen

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
@@ -106,13 +106,13 @@ class OptionTests: XCTestCase {
         let val = OptTestOpaqueRefRustType.new(123)
         let opt_ref = val.field_ref()
 
-        let reflect = rust_reflect_option_ref_opaque_rust_type(opt_ref)
+        var reflect = rust_reflect_option_ref_opaque_rust_type(opt_ref)
         XCTAssertEqual(reflect!.field(), 123)
         XCTAssertNil(rust_reflect_option_ref_opaque_rust_type(nil))
-        let reflect = nil
+        reflect = nil
         
-        let second_reference = rust_reflect_option_ref_opaque_rust_type(opt_ref)
-        XCTAssertEqual(second_reference!.field(), 123)
+        reflect = rust_reflect_option_ref_opaque_rust_type(opt_ref)
+        XCTAssertEqual(reflect!.field(), 123)
     }
     
     func testSwiftCallRustWithOptionOpaqueRustCopyType() throws {

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OptionTests.swift
@@ -97,6 +97,23 @@ class OptionTests: XCTestCase {
         
         XCTAssertNil(rust_reflect_option_opaque_rust_type(nil))
     }
+
+    /// Verify that we can pass and receive an `Option<&RustType>`.
+    ///
+    /// We deinitialize the first reference and create a second to confirm that
+    /// deinitializing the reference does not deinitialize the Rust type.
+    func testSwiftCallRustWithOptionRefOpaqueRustType() throws {
+        let val = OptTestOpaqueRefRustType.new(123)
+        let opt_ref = val.field_ref()
+
+        let reflect = rust_reflect_option_ref_opaque_rust_type(opt_ref)
+        XCTAssertEqual(reflect!.field(), 123)
+        XCTAssertNil(rust_reflect_option_ref_opaque_rust_type(nil))
+        let reflect = nil
+        
+        let second_reference = rust_reflect_option_ref_opaque_rust_type(opt_ref)
+        XCTAssertEqual(second_reference!.field(), 123)
+    }
     
     func testSwiftCallRustWithOptionOpaqueRustCopyType() throws {
         let val = new_opaque_rust_copy_type(123)

--- a/crates/swift-integration-tests/src/option.rs
+++ b/crates/swift-integration-tests/src/option.rs
@@ -38,7 +38,6 @@ mod ffi {
         type OptTestOpaqueRefRustType;
 
         #[swift_bridge(init)]
-        #[swift_bridge(associated_to = OptTestOpaqueRustType)]
         fn new(field: u8) -> OptTestOpaqueRustType;
         fn field(self: &OptTestOpaqueRustType) -> u8;
 

--- a/crates/swift-integration-tests/src/option.rs
+++ b/crates/swift-integration-tests/src/option.rs
@@ -35,10 +35,16 @@ mod ffi {
 
     extern "Rust" {
         type OptTestOpaqueRustType;
+        type OptTestOpaqueRefRustType;
 
         #[swift_bridge(init)]
+        #[swift_bridge(associated_to = OptTestOpaqueRustType)]
         fn new(field: u8) -> OptTestOpaqueRustType;
-        fn field(&self) -> u8;
+        fn field(self: &OptTestOpaqueRustType) -> u8;
+
+        #[swift_bridge(associated_to = OptTestOpaqueRefRustType)]
+        fn new(field: u8) -> OptTestOpaqueRefRustType;
+        fn field_ref(self: &OptTestOpaqueRefRustType) -> Option<&OptTestOpaqueRustType>;
     }
 
     extern "Rust" {
@@ -84,6 +90,10 @@ mod ffi {
         fn rust_reflect_option_opaque_rust_type(
             arg: Option<OptTestOpaqueRustType>,
         ) -> Option<OptTestOpaqueRustType>;
+
+        fn rust_reflect_option_ref_opaque_rust_type(
+            arg: Option<&OptTestOpaqueRustType>,
+        ) -> Option<&OptTestOpaqueRustType>;
 
         fn rust_reflect_option_opaque_rust_copy_type(
             arg: Option<OptTestOpaqueRustCopyType>,
@@ -178,6 +188,22 @@ impl OptTestOpaqueRustType {
     }
 }
 
+pub struct OptTestOpaqueRefRustType {
+    field: Option<OptTestOpaqueRustType>,
+}
+
+impl OptTestOpaqueRefRustType {
+    fn new(field: u8) -> Self {
+        Self {
+            field: Some(OptTestOpaqueRustType::new(field)),
+        }
+    }
+
+    fn field_ref(&self) -> Option<&OptTestOpaqueRustType> {
+        self.field.as_ref()
+    }
+}
+
 #[derive(Copy, Clone)]
 pub struct OptTestOpaqueRustCopyType {
     #[allow(unused)]
@@ -240,6 +266,12 @@ fn rust_reflect_option_vector_rust_type(arg: Option<Vec<u16>>) -> Option<Vec<u16
 fn rust_reflect_option_opaque_rust_type(
     arg: Option<OptTestOpaqueRustType>,
 ) -> Option<OptTestOpaqueRustType> {
+    arg
+}
+
+fn rust_reflect_option_ref_opaque_rust_type(
+    arg: Option<&OptTestOpaqueRustType>,
+) -> Option<&OptTestOpaqueRustType> {
     arg
 }
 


### PR DESCRIPTION
Add test cases for Option<&T> and fix rust codegen

Currently swift-bridge only has tests for Option<T> - this adds test
cases for Option<&T> and fixes a bug in rust codegen that does not
correctly translate Option<&T>.

This is now possible:

```rust
mod ffi {
  extern "Rust" {
    type MyStruct;

    fn my_func(arg: Option<&MyStruct>) -> Option<&MyStruct>;
  }
}
```