### PR TITLE
Make extern Swift functions public to prevent stripping in Release builds 

### DIFF
--- a/crates/swift-bridge-ir/src/codegen/codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests.rs
@@ -52,6 +52,7 @@ mod string_codegen_tests;
 mod transparent_enum_codegen_tests;
 mod transparent_struct_codegen_tests;
 mod vec_codegen_tests;
+mod visibility_codegen_tests;
 
 struct CodegenTest {
     bridge_module: BridgeModule,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/boxed_fnonce_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/boxed_fnonce_codegen_tests.rs
@@ -55,7 +55,7 @@ mod test_swift_takes_no_args_no_return_callback {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
+public func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
     { let cb0 = __private__RustFnOnceCallbackNoArgsNoRet(ptr: callback); let _ = some_function(callback: { cb0.call() }) }()
 }
 "#,
@@ -149,7 +149,7 @@ class __private__RustFnOnceCallback$some_function$param0 {
             "#,
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
+public func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
     { let cb0 = __private__RustFnOnceCallback$some_function$param0(ptr: callback); let _ = some_function(callback: { arg0 in cb0.call(arg0) }) }()
 }
 "#,
@@ -248,7 +248,7 @@ class __private__RustFnOnceCallback$some_function$param0 {
             "#,
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
+public func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
     { let cb0 = __private__RustFnOnceCallback$some_function$param0(ptr: callback); let _ = some_function(callback: { cb0.call() }) }()
 }
 "#,
@@ -351,7 +351,7 @@ class __private__RustFnOnceCallback$some_function$param0 {
             "#,
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
+public func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
     { let cb0 = __private__RustFnOnceCallback$some_function$param0(ptr: callback); let _ = some_function(callback: { arg0 in cb0.call(arg0) }) }()
 }
 "#,
@@ -457,7 +457,7 @@ class __private__RustFnOnceCallback$some_function$param0 {
             "#,
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
+public func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
     { let cb0 = __private__RustFnOnceCallback$some_function$param0(ptr: callback); let _ = some_function(callback: { cb0.call() }) }()
 }
 "#,
@@ -566,7 +566,7 @@ class __private__RustFnOnceCallback$some_function$param0 {
             "#,
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
+public func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
     { let cb0 = __private__RustFnOnceCallback$some_function$param0(ptr: callback); let _ = some_function(callback: { arg0 in cb0.call(arg0) }) }()
 }
 "#,
@@ -690,7 +690,7 @@ class __private__RustFnOnceCallback$some_function$param1 {
             "#,
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ arg0: UnsafeMutableRawPointer, _ arg1: UnsafeMutableRawPointer, _ arg2: UnsafeMutableRawPointer) {
+public func __swift_bridge__some_function (_ arg0: UnsafeMutableRawPointer, _ arg1: UnsafeMutableRawPointer, _ arg2: UnsafeMutableRawPointer) {
     { let cb0 = __private__RustFnOnceCallbackNoArgsNoRet(ptr: arg0); let cb1 = __private__RustFnOnceCallback$some_function$param1(ptr: arg1); let cb2 = __private__RustFnOnceCallbackNoArgsNoRet(ptr: arg2); let _ = some_function(arg0: { cb0.call() }, arg1: { arg0 in cb1.call(arg0) }, arg2: { cb2.call() }) }()
 }
 "#,
@@ -793,7 +793,7 @@ class __private__RustFnOnceCallback$some_function$param0 {
             "#,
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
+public func __swift_bridge__some_function (_ callback: UnsafeMutableRawPointer) {
     { let cb0 = __private__RustFnOnceCallback$some_function$param0(ptr: callback); let _ = some_function(callback: { arg0, arg1 in cb0.call(arg0, arg1) }) }()
 }
 "#,
@@ -865,7 +865,7 @@ mod test_swift_method_takes_no_args_no_return_callback {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 @_cdecl("__swift_bridge__$SomeType$some_method")
-func __swift_bridge__SomeType_some_method (_ this: UnsafeMutableRawPointer, _ callback: UnsafeMutableRawPointer) {
+public func __swift_bridge__SomeType_some_method (_ this: UnsafeMutableRawPointer, _ callback: UnsafeMutableRawPointer) {
     { let cb1 = __private__RustFnOnceCallbackNoArgsNoRet(ptr: callback); let _ = Unmanaged<SomeType>.fromOpaque(this).takeUnretainedValue().some_method(callback: { cb1.call() }) }()
 }
 "#,
@@ -967,7 +967,7 @@ class __private__RustFnOnceCallback$SomeType$some_method$param1 {
             "#,
             r#"
 @_cdecl("__swift_bridge__$SomeType$some_method")
-func __swift_bridge__SomeType_some_method (_ this: UnsafeMutableRawPointer, _ callback: UnsafeMutableRawPointer) {
+public func __swift_bridge__SomeType_some_method (_ this: UnsafeMutableRawPointer, _ callback: UnsafeMutableRawPointer) {
     { let cb1 = __private__RustFnOnceCallback$SomeType$some_method$param1(ptr: callback); let _ = Unmanaged<SomeType>.fromOpaque(this).takeUnretainedValue().some_method(callback: { arg0 in cb1.call(arg0) }) }()
 }
 "#,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/built_in_tuple_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/built_in_tuple_codegen_tests.rs
@@ -316,7 +316,7 @@ mod extern_swift_tuple_primitives {
         ExpectedSwiftCode::ContainsManyAfterTrim(vec![
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ arg: __swift_bridge__$tuple$I32U8) -> __swift_bridge__$tuple$I32U8 {
+public func __swift_bridge__some_function (_ arg: __swift_bridge__$tuple$I32U8) -> __swift_bridge__$tuple$I32U8 {
     { let val = some_function(arg: { let val = arg; return (val._0, val._1); }()); return __swift_bridge__$tuple$I32U8(_0: val.0, _1: val.1); }()
 }
 "#,
@@ -389,7 +389,7 @@ mod extern_swift_tuple_opaque_and_string {
         ExpectedSwiftCode::ContainsManyAfterTrim(vec![
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ arg: __swift_bridge__$tuple$SomeTypeString) -> __swift_bridge__$tuple$SomeTypeString {
+public func __swift_bridge__some_function (_ arg: __swift_bridge__$tuple$SomeTypeString) -> __swift_bridge__$tuple$SomeTypeString {
     { let val = some_function(arg: { let val = arg; return (SomeType(ptr: val._0), RustString(ptr: val._1)); }()); return __swift_bridge__$tuple$SomeTypeString(_0: {val.0.isOwned = false; return val.0.ptr;}(), _1: { let rustString = val.1.intoRustString(); rustString.isOwned = false; return rustString.ptr }()); }()
 }
 "#,
@@ -464,7 +464,7 @@ mod extern_swift_tuple_transparent_struct_and_transparent_enum {
         ExpectedSwiftCode::ContainsManyAfterTrim(vec![
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ arg: __swift_bridge__$tuple$SomeStructSomeEnum) -> __swift_bridge__$tuple$SomeStructSomeEnum {
+public func __swift_bridge__some_function (_ arg: __swift_bridge__$tuple$SomeStructSomeEnum) -> __swift_bridge__$tuple$SomeStructSomeEnum {
     { let val = some_function(arg: { let val = arg; return (val._0.intoSwiftRepr(), val._1.intoSwiftRepr()); }()); return __swift_bridge__$tuple$SomeStructSomeEnum(_0: val.0.intoFfiRepr(), _1: val.1.intoFfiRepr()); }()
 }
 "#,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/extern_swift_function_opaque_swift_type_return_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/extern_swift_function_opaque_swift_type_return_codegen_tests.rs
@@ -37,7 +37,7 @@ mod test_extern_swift_freestanding_function_owned_opaque_swift_type_return {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function () -> UnsafeMutableRawPointer {
+public func __swift_bridge__some_function () -> UnsafeMutableRawPointer {
     Unmanaged.passRetained(some_function()).toOpaque()
 }
 "#,
@@ -97,7 +97,7 @@ mod test_extern_swift_method_owned_opaque_swift_type_return {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 @_cdecl("__swift_bridge__$SomeType$some_method")
-func __swift_bridge__SomeType_some_method (_ this: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+public func __swift_bridge__SomeType_some_method (_ this: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     Unmanaged.passRetained(Unmanaged<SomeType>.fromOpaque(this).takeUnretainedValue().some_method()).toOpaque()
 }
 "#,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/function_attribute_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/function_attribute_codegen_tests.rs
@@ -445,7 +445,7 @@ public func callRustFromSwift() -> RustString {
     RustString(ptr: __swift_bridge__$call_rust_from_swift())
 }
 @_cdecl("__swift_bridge__$call_swift_from_rust")
-func __swift_bridge__call_swift_from_rust () -> UnsafeMutableRawPointer {
+public func __swift_bridge__call_swift_from_rust () -> UnsafeMutableRawPointer {
     { let rustString = callSwiftFromRust().intoRustString(); rustString.isOwned = false; return rustString.ptr }()
 }
 "#,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_rust_type_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_rust_type_codegen_tests.rs
@@ -433,7 +433,7 @@ mod extern_swift_freestanding_fn_with_owned_opaque_rust_type_arg {
     const EXPECTED_SWIFT: ExpectedSwiftCode = ExpectedSwiftCode::ContainsAfterTrim(
         r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ arg: UnsafeMutableRawPointer) {
+public func __swift_bridge__some_function (_ arg: UnsafeMutableRawPointer) {
     some_function(arg: MyType(ptr: arg))
 }
 "#,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_swift_type_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_swift_type_codegen_tests.rs
@@ -46,7 +46,7 @@ mod extern_swift_freestanding_fn_with_owned_opaque_swift_type_arg {
     const EXPECTED_SWIFT_CODE: ExpectedSwiftCode = ExpectedSwiftCode::ContainsAfterTrim(
         r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ arg: UnsafeMutableRawPointer) {
+public func __swift_bridge__some_function (_ arg: UnsafeMutableRawPointer) {
     some_function(arg: Unmanaged<MyType>.fromOpaque(arg).takeRetainedValue())
 }
 "#,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/option_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/option_codegen_tests.rs
@@ -119,7 +119,7 @@ mod extern_swift_fn_option_primitive {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ arg: __private__OptionU8) -> __private__OptionF32 {
+public func __swift_bridge__some_function (_ arg: __private__OptionU8) -> __private__OptionF32 {
     some_function(arg: arg.intoSwiftRepr()).intoFfiRepr()
 }
 "#,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/single_representation_type_elision_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/single_representation_type_elision_codegen_tests.rs
@@ -54,7 +54,7 @@ public func rust_function(_ arg1: (), _ arg2: ()) -> () {
 "#,
             r#"
 @_cdecl("__swift_bridge__$swift_function")
-func __swift_bridge__swift_function () {
+public func __swift_bridge__swift_function () {
     swift_function(arg1: (), arg2: ())
 }
 "#,
@@ -140,7 +140,7 @@ public func rust_function(_ arg1: UnitStruct1, _ arg2: UnitStruct2, _ arg3: Unit
 "#,
             r#"
 @_cdecl("__swift_bridge__$swift_function")
-func __swift_bridge__swift_function () {
+public func __swift_bridge__swift_function () {
     { let _ = swift_function(arg1: UnitStruct1(), arg2: UnitStruct2(), arg3: UnitStruct3()); }()
 }
 "#,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/string_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/string_codegen_tests.rs
@@ -243,7 +243,7 @@ mod extern_swift_func_returns_string {
     const EXPECTED_SWIFT_CODE: ExpectedSwiftCode = ExpectedSwiftCode::ContainsAfterTrim(
         r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function () -> UnsafeMutableRawPointer {
+public func __swift_bridge__some_function () -> UnsafeMutableRawPointer {
     { let rustString = some_function().intoRustString(); rustString.isOwned = false; return rustString.ptr }()
 }
 "#,
@@ -290,7 +290,7 @@ mod extern_swift_func_takes_and_returns_string {
     const EXPECTED_SWIFT_CODE: ExpectedSwiftCode = ExpectedSwiftCode::ContainsAfterTrim(
         r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ value: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+public func __swift_bridge__some_function (_ value: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
     { let rustString = some_function(value: RustString(ptr: value)).intoRustString(); rustString.isOwned = false; return rustString.ptr }()
 }
 "#,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_struct_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/transparent_struct_codegen_tests.rs
@@ -370,7 +370,7 @@ mod extern_swift_fn_arg_swift_repr_struct {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ arg: __swift_bridge__$SomeStruct) {
+public func __swift_bridge__some_function (_ arg: __swift_bridge__$SomeStruct) {
     some_function(arg: arg.intoSwiftRepr())
 }
 "#,
@@ -487,7 +487,7 @@ mod extern_swift_return_swift_repr_struct {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function () -> __swift_bridge__$SomeStruct {
+public func __swift_bridge__some_function () -> __swift_bridge__$SomeStruct {
     some_function().intoFfiRepr()
 }
 "#,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/vec_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/vec_codegen_tests.rs
@@ -580,7 +580,7 @@ mod extern_swift_fn_return_vec_of_primitive_rust_type {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function () -> UnsafeMutableRawPointer {
+public func __swift_bridge__some_function () -> UnsafeMutableRawPointer {
     { let val = some_function(); val.isOwned = false; return val.ptr }()
 }
 "#,
@@ -639,7 +639,7 @@ mod extern_swift_fn_arg_vec_of_primitive_rust_type {
         ExpectedSwiftCode::ContainsAfterTrim(
             r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ arg: UnsafeMutableRawPointer) {
+public func __swift_bridge__some_function (_ arg: UnsafeMutableRawPointer) {
     some_function(arg: RustVec(ptr: arg))
 }
 "#,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/visibility_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/visibility_codegen_tests.rs
@@ -1,0 +1,49 @@
+use super::{CodegenTest, ExpectedCHeader, ExpectedRustTokens, ExpectedSwiftCode};
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Verify that extern "Swift" methods are declared `public` to prevent them from
+/// being stripped by the Swift compiler when building in `Release` mode.
+mod visibility_codegen_tests {
+    use super::*;
+
+    fn bridge_module_tokens() -> TokenStream {
+        quote! {
+            mod ffi {
+                extern "Swift" {
+                    fn some_function();
+                }
+            }
+        }
+    }
+
+    fn expected_rust_tokens() -> ExpectedRustTokens {
+        ExpectedRustTokens::SkipTest
+    }
+
+    fn expected_swift_code() -> ExpectedSwiftCode {
+        ExpectedSwiftCode::ContainsAfterTrim(
+            r#"
+@_cdecl("__swift_bridge__$some_function")
+public func __swift_bridge__some_function () {
+    some_function()
+}
+"#,
+        )
+    }
+
+    fn expected_c_header() -> ExpectedCHeader {
+        ExpectedCHeader::SkipTest
+    }
+
+    #[test]
+    fn test_visibility_codegen_tests() {
+        CodegenTest {
+            bridge_module: bridge_module_tokens().into(),
+            expected_rust_tokens: expected_rust_tokens(),
+            expected_swift_code: expected_swift_code(),
+            expected_c_header: expected_c_header(),
+        }
+        .test();
+    }
+}

--- a/crates/swift-bridge-ir/src/codegen/generate_swift.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift.rs
@@ -317,7 +317,7 @@ class __private__RustFnOnceCallback{maybe_associated_ty}${fn_name}$param{idx} {{
 
     let generated_func = format!(
         r#"@_cdecl("{link_name}")
-func {prefixed_fn_name} ({params}){ret} {{
+public func {prefixed_fn_name} ({params}){ret} {{
     {call_fn}
 }}{rust_fn_once_callback_classes}
 "#,
@@ -429,7 +429,7 @@ public func foo() {
 
         let expected = r#"
 @_cdecl("__swift_bridge__$foo")
-func __swift_bridge__foo () {
+public func __swift_bridge__foo () {
     foo()
 } 
 "#;
@@ -452,7 +452,7 @@ func __swift_bridge__foo () {
 
         let expected = r#"
 @_cdecl("__swift_bridge__$foo")
-func __swift_bridge__foo () -> __private__FfiSlice {
+public func __swift_bridge__foo () -> __private__FfiSlice {
     foo().toFfiSlice()
 } 
 "#;
@@ -476,7 +476,7 @@ func __swift_bridge__foo () -> __private__FfiSlice {
 
         let expected = r#"
 @_cdecl("__swift_bridge__$MyType$foo")
-func __swift_bridge__MyType_foo (_ this: UnsafeMutableRawPointer) -> __private__FfiSlice {
+public func __swift_bridge__MyType_foo (_ this: UnsafeMutableRawPointer) -> __private__FfiSlice {
     Unmanaged<MyType>.fromOpaque(this).takeUnretainedValue().foo().toFfiSlice()
 }
 "#;
@@ -594,7 +594,7 @@ func __swift_bridge__Foo__free (ptr: UnsafeMutableRawPointer) {
 
         let expected = r#"
 @_cdecl("__swift_bridge__$Foo$new")
-func __swift_bridge__Foo_new (_ a: UInt8) -> UnsafeMutableRawPointer {
+public func __swift_bridge__Foo_new (_ a: UInt8) -> UnsafeMutableRawPointer {
     Unmanaged.passRetained(Foo(a: a)).toOpaque()
 }
 "#;
@@ -701,12 +701,12 @@ extension Foo {
 
         let expected = r#"
 @_cdecl("__swift_bridge__$Foo$push")
-func __swift_bridge__Foo_push (_ this: UnsafeMutableRawPointer, _ arg: UInt8) {
+public func __swift_bridge__Foo_push (_ this: UnsafeMutableRawPointer, _ arg: UInt8) {
     Unmanaged<Foo>.fromOpaque(this).takeUnretainedValue().push(arg: arg)
 }
 
 @_cdecl("__swift_bridge__$Foo$pop")
-func __swift_bridge__Foo_pop (_ this: UnsafeMutableRawPointer) {
+public func __swift_bridge__Foo_pop (_ this: UnsafeMutableRawPointer) {
     Unmanaged<Foo>.fromOpaque(this).takeUnretainedValue().pop()
 }
 "#;
@@ -833,7 +833,7 @@ extension FooRef {
 
         let expected = r#"
 @_cdecl("__swift_bridge__$Foo$bar")
-func __swift_bridge__Foo_bar (_ arg: UInt8) {
+public func __swift_bridge__Foo_bar (_ arg: UInt8) {
     Foo::bar(arg: arg)
 }
 "#;
@@ -925,7 +925,7 @@ func void_pointer() -> UnsafeRawPointer {
 
         let expected = r#"
 @_cdecl("__swift_bridge__$void_pointer")
-func __swift_bridge__void_pointer (_ arg: UnsafeRawPointer) {
+public func __swift_bridge__void_pointer (_ arg: UnsafeRawPointer) {
     void_pointer(arg: arg)
 }
 "#;
@@ -1004,7 +1004,7 @@ func some_function() -> Foo {
 
         let expected = r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function () {
+public func __swift_bridge__some_function () {
     someFunctionSwiftName()
 }
 "#;


### PR DESCRIPTION
I had a quick stab at fixing #166, if I have understood [the instructions](https://github.com/chinedufn/swift-bridge/issues/166#issuecomment-1428821701) correctly this would resolve the issue at the cost of changing the visibility of functions in the module.

@chinedufn let me know if I'm on the right track here.

So far I have only added tests for the `swift-bridge-ir` crate, I'm guessing it might make sense to also add a small repro example to run `xcodebuild` in release mode on CI. 