### PR TITLE
Swift Option<String> and Option<&str>

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Option.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Option.swift
@@ -47,3 +47,22 @@ func swift_reflect_option_bool(arg: Optional<Bool>) -> Optional<Bool> {
     arg
 }
 
+
+func swift_reflect_option_string(arg: Optional<RustString>) -> Optional<RustString> {
+    arg
+}
+// TODO: Change `swift_arg_option_str` `swift_reflect_option_str` once we support Swift returning `-> &str` via RustStr
+// For now we return true if the arg is Some and false if arg is None
+//func swift_reflect_option_str(arg: Optional<RustStr>) -> Optional<RustStr> {
+//    arg
+//}
+func swift_arg_option_str(arg: Optional<RustStr>) -> Bool {
+    if let val = arg {
+        assert(val.toString() == "this is an option str")
+        return true
+    } else {
+        return false
+    }
+    
+}
+

--- a/crates/swift-bridge-ir/src/bridged_type/boxed_fn.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/boxed_fn.rs
@@ -99,12 +99,20 @@ impl BridgeableBoxedFnOnce {
     }
 
     /// arg0: UInt8, arg1: SomeType, ...
-    pub fn params_to_swift_types(&self, types: &TypeDeclarations) -> String {
+    pub fn params_to_swift_types(
+        &self,
+        types: &TypeDeclarations,
+        swift_bridge_path: &Path,
+    ) -> String {
         self.params
             .iter()
             .enumerate()
             .map(|(idx, ty)| {
-                let ty = ty.to_swift_type(TypePosition::FnArg(HostLang::Rust, idx), types);
+                let ty = ty.to_swift_type(
+                    TypePosition::FnArg(HostLang::Rust, idx),
+                    types,
+                    swift_bridge_path,
+                );
 
                 format!("_ arg{idx}: {ty}")
             })

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_pointer.rs
@@ -73,7 +73,12 @@ impl BridgeableType for BuiltInPointer {
         }
     }
 
-    fn to_swift_type(&self, _type_pos: TypePosition, _types: &TypeDeclarations) -> String {
+    fn to_swift_type(
+        &self,
+        _type_pos: TypePosition,
+        _types: &TypeDeclarations,
+        _swift_bridge_path: &Path,
+    ) -> String {
         todo!()
     }
 
@@ -112,6 +117,7 @@ impl BridgeableType for BuiltInPointer {
 
     fn to_ffi_compatible_option_swift_type(
         &self,
+        _type_pos: TypePosition,
         _swift_bridge_path: &Path,
         _types: &TypeDeclarations,
     ) -> String {
@@ -176,6 +182,7 @@ impl BridgeableType for BuiltInPointer {
         _expression: &str,
         _type_pos: TypePosition,
         _types: &TypeDeclarations,
+        _swift_bridge_path: &Path,
     ) -> String {
         todo!()
     }

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_str.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_str.rs
@@ -1,2 +1,4 @@
+// TODO: impl BridgeableType for BridgedStr { }
+#[allow(unused)]
 #[derive(Debug)]
 pub(crate) struct BridgeableStr;

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
@@ -69,7 +69,12 @@ impl BridgeableType for OpaqueForeignType {
         }
     }
 
-    fn to_swift_type(&self, type_pos: TypePosition, types: &TypeDeclarations) -> String {
+    fn to_swift_type(
+        &self,
+        type_pos: TypePosition,
+        types: &TypeDeclarations,
+        swift_bridge_path: &Path,
+    ) -> String {
         if self.host_lang.is_rust() {
             match type_pos {
                 TypePosition::FnArg(func_host_lang, _) | TypePosition::FnReturn(func_host_lang) => {
@@ -90,7 +95,10 @@ impl BridgeableType for OpaqueForeignType {
                             "{}{}",
                             class_name,
                             self.generics
-                                .angle_bracketed_generic_concrete_swift_types_string(types)
+                                .angle_bracketed_generic_concrete_swift_types_string(
+                                    types,
+                                    swift_bridge_path
+                                )
                         )
                     } else {
                         format!("UnsafeMutableRawPointer")
@@ -108,7 +116,10 @@ impl BridgeableType for OpaqueForeignType {
                         "{}{}",
                         class_name,
                         self.generics
-                            .angle_bracketed_generic_concrete_swift_types_string(types)
+                            .angle_bracketed_generic_concrete_swift_types_string(
+                                types,
+                                swift_bridge_path
+                            )
                     )
                 }
                 TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
@@ -209,6 +220,7 @@ impl BridgeableType for OpaqueForeignType {
 
     fn to_ffi_compatible_option_swift_type(
         &self,
+        _type_pos: TypePosition,
         _swift_bridge_path: &Path,
         _types: &TypeDeclarations,
     ) -> String {
@@ -482,6 +494,7 @@ impl BridgeableType for OpaqueForeignType {
         expression: &str,
         type_pos: TypePosition,
         _types: &TypeDeclarations,
+        _swift_bridge_path: &Path,
     ) -> String {
         let mut ty_name = self.ty.to_string();
 

--- a/crates/swift-bridge-ir/src/bridged_type/built_in_tuple.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/built_in_tuple.rs
@@ -104,14 +104,20 @@ impl BridgeableType for BuiltInTuple {
         }
     }
 
-    fn to_swift_type(&self, type_pos: TypePosition, types: &TypeDeclarations) -> String {
+    fn to_swift_type(
+        &self,
+        type_pos: TypePosition,
+        types: &TypeDeclarations,
+        swift_bridge_path: &Path,
+    ) -> String {
         match type_pos {
             TypePosition::FnArg(host_lang, _) => {
                 if host_lang.is_swift() {
                     let field_signatures = self.0.combine_field_types_into_ffi_name_string(types);
                     format!("__swift_bridge__$tuple${field_signatures}")
                 } else {
-                    self.0.to_swift_tuple_signature(type_pos, types)
+                    self.0
+                        .to_swift_tuple_signature(type_pos, types, swift_bridge_path)
                 }
             }
             TypePosition::FnReturn(host_lang) => {
@@ -119,7 +125,8 @@ impl BridgeableType for BuiltInTuple {
                     let field_signatures = self.0.combine_field_types_into_ffi_name_string(types);
                     format!("__swift_bridge__$tuple${field_signatures}")
                 } else {
-                    self.0.to_swift_tuple_signature(type_pos, types)
+                    self.0
+                        .to_swift_tuple_signature(type_pos, types, swift_bridge_path)
                 }
             }
             TypePosition::SharedStructField => todo!(),
@@ -161,6 +168,7 @@ impl BridgeableType for BuiltInTuple {
 
     fn to_ffi_compatible_option_swift_type(
         &self,
+        _type_pos: TypePosition,
         _swift_bridge_path: &Path,
         _types: &TypeDeclarations,
     ) -> String {
@@ -256,10 +264,14 @@ impl BridgeableType for BuiltInTuple {
         expression: &str,
         type_pos: TypePosition,
         types: &TypeDeclarations,
+        swift_bridge_path: &Path,
     ) -> String {
-        let converted_fields: Vec<String> = self
-            .0
-            .convert_ffi_expression_to_swift_type(expression, type_pos, types);
+        let converted_fields: Vec<String> = self.0.convert_ffi_expression_to_swift_type(
+            expression,
+            type_pos,
+            types,
+            swift_bridge_path,
+        );
         let converted_fields = converted_fields.join(", ");
 
         return format!(

--- a/crates/swift-bridge-ir/src/bridged_type/shared_enum/enum_variant.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_enum/enum_variant.rs
@@ -120,6 +120,7 @@ impl EnumVariant {
         &self,
         types: &TypeDeclarations,
         enum_name: String,
+        swift_bridge_path: &Path,
     ) -> String {
         let converted_fields: Vec<String> = self
             .fields
@@ -136,6 +137,7 @@ impl EnumVariant {
                     ),
                     TypePosition::SharedStructField,
                     types,
+                    swift_bridge_path,
                 );
                 norm_field.struct_field_setter_string(field)
             })

--- a/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/shared_struct.rs
@@ -57,6 +57,7 @@ impl UnnamedStructFields {
         &self,
         type_pos: TypePosition,
         types: &TypeDeclarations,
+        swift_bridge_path: &Path,
     ) -> String {
         let names: Vec<String> = self
             .0
@@ -65,7 +66,7 @@ impl UnnamedStructFields {
             .map(|(_idx, field)| {
                 BridgedType::new_with_type(&field.ty, types)
                     .unwrap()
-                    .to_swift_type(type_pos, types)
+                    .to_swift_type(type_pos, types, swift_bridge_path)
             })
             .collect();
         let names = names.join(", ");
@@ -127,14 +128,19 @@ impl UnnamedStructFields {
         _expression: &str,
         type_pos: TypePosition,
         types: &TypeDeclarations,
+        swift_bridge_path: &Path,
     ) -> Vec<String> {
         self.0
             .iter()
             .enumerate()
             .map(|(idx, field)| {
                 let ty = BridgedType::new_with_type(&field.ty, types).unwrap();
-                let converted_field =
-                    ty.convert_ffi_value_to_swift_value(&format!("val._{idx}"), type_pos, types);
+                let converted_field = ty.convert_ffi_value_to_swift_value(
+                    &format!("val._{idx}"),
+                    type_pos,
+                    types,
+                    swift_bridge_path,
+                );
                 converted_field
             })
             .collect()
@@ -465,6 +471,7 @@ impl SharedStruct {
         &self,
         expression: &str,
         types: &TypeDeclarations,
+        swift_bridge_path: &Path,
     ) -> String {
         let name = self.swift_name_string();
         let struct_name = &name;
@@ -481,6 +488,7 @@ impl SharedStruct {
                     &format!("val.{field_name}", field_name = field_name),
                     TypePosition::SharedStructField,
                     types,
+                    swift_bridge_path,
                 );
 
                 format!(

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/string_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/string_codegen_tests.rs
@@ -263,15 +263,15 @@ func __swift_bridge__some_function () -> UnsafeMutableRawPointer {
     }
 }
 
-/// Test code generation for Swift function that takes and returns an owned String argument.
-mod extern_swift_func_takes_and_returns_string {
+/// Test code generation for Swift function that takes an owned String argument.
+mod extern_swift_func_takes_string_arg {
     use super::*;
 
     fn bridge_module_tokens() -> TokenStream {
         quote! {
             mod foo {
                 extern "Swift" {
-                    fn some_function (value: String) -> String;
+                    fn some_function (value: String);
                 }
             }
         }
@@ -279,9 +279,11 @@ mod extern_swift_func_takes_and_returns_string {
 
     fn expected_rust_tokens() -> ExpectedRustTokens {
         ExpectedRustTokens::Contains(quote! {
-            pub fn some_function (value: String) -> String {
+            pub fn some_function (value: String)  {
                 unsafe {
-                    Box :: from_raw (unsafe { __swift_bridge__some_function (swift_bridge :: string :: RustString (value) . box_into_raw ()) }) . 0
+                    __swift_bridge__some_function (
+                        swift_bridge :: string :: RustString (value) . box_into_raw ()
+                    )
                 }
             }
         })
@@ -290,8 +292,8 @@ mod extern_swift_func_takes_and_returns_string {
     const EXPECTED_SWIFT_CODE: ExpectedSwiftCode = ExpectedSwiftCode::ContainsAfterTrim(
         r#"
 @_cdecl("__swift_bridge__$some_function")
-func __swift_bridge__some_function (_ value: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
-    { let rustString = some_function(value: RustString(ptr: value)).intoRustString(); rustString.isOwned = false; return rustString.ptr }()
+func __swift_bridge__some_function (_ value: UnsafeMutableRawPointer) {
+    some_function(value: RustString(ptr: value))
 }
 "#,
     );

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -532,7 +532,6 @@ mod tests {
         assert_trimmed_generated_contains_trimmed_expected,
         assert_trimmed_generated_equals_trimmed_expected,
     };
-    use crate::SwiftBridgeModule;
 
     use super::*;
 

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/opaque_copy_type.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/opaque_copy_type.rs
@@ -32,7 +32,7 @@ pub(super) fn generate_opaque_copy_struct(
     if class_methods.owned_self_methods.len() > 0 {};
 
     let struct_definition = if !ty.attributes.already_declared {
-        generate_struct_definition(ty, types)
+        generate_struct_definition(ty, types, swift_bridge_path)
     } else {
         "".to_string()
     };
@@ -47,6 +47,7 @@ pub(super) fn generate_opaque_copy_struct(
 fn generate_struct_definition(
     ty: &OpaqueForeignTypeDeclaration,
     types: &TypeDeclarations,
+    swift_bridge_path: &Path,
 ) -> String {
     let type_name = ty.ty.to_string();
     let generics = ty.generics.angle_bracketed_generic_placeholders_string();
@@ -85,7 +86,9 @@ fn generate_struct_definition(
         )
     } else {
         let ffi_repr_name = ty.ffi_repr_name_string();
-        let bounds = ty.generics.rust_opaque_type_swift_generic_bounds(types);
+        let bounds = ty
+            .generics
+            .rust_opaque_type_swift_generic_bounds(types, swift_bridge_path);
 
         format!(
             r#"extension {type_name}
@@ -105,7 +108,7 @@ extension {ffi_repr_name}: SwiftBridgeGenericCopyTypeFfiRepr {{}}"#,
             bounds = bounds,
             generics = ty
                 .generics
-                .angle_bracketed_generic_concrete_swift_types_string(types),
+                .angle_bracketed_generic_concrete_swift_types_string(types, swift_bridge_path),
         )
     };
 

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_enum.rs
@@ -23,7 +23,11 @@ impl SwiftBridgeModule {
                     for named_field in named_fields {
                         let ty = BridgedType::new_with_type(&named_field.ty, &self.types)
                             .unwrap()
-                            .to_swift_type(TypePosition::SharedStructField, &self.types);
+                            .to_swift_type(
+                                TypePosition::SharedStructField,
+                                &self.types,
+                                &self.swift_bridge_path,
+                            );
                         params.push(format!("{}: {}", named_field.name, ty))
                     }
                     let params = params.join(", ");
@@ -39,7 +43,11 @@ impl SwiftBridgeModule {
                     for unnamed_field in unnamed_fields {
                         let ty = BridgedType::new_with_type(&unnamed_field.ty, &self.types)
                             .unwrap()
-                            .to_swift_type(TypePosition::SharedStructField, &self.types);
+                            .to_swift_type(
+                                TypePosition::SharedStructField,
+                                &self.types,
+                                &self.swift_bridge_path,
+                            );
                         params.push(ty);
                     }
                     let params = params.join(", ");
@@ -78,8 +86,11 @@ impl SwiftBridgeModule {
         }
 
         for variant in shared_enum.variants.iter() {
-            let convert_ffi_variant_to_swift =
-                variant.convert_ffi_expression_to_swift(&self.types, format!("{}", enum_name));
+            let convert_ffi_variant_to_swift = variant.convert_ffi_expression_to_swift(
+                &self.types,
+                format!("{}", enum_name),
+                &self.swift_bridge_path,
+            );
             convert_ffi_repr_to_swift += &convert_ffi_variant_to_swift;
         }
         if convert_ffi_repr_to_swift.len() > 0 {

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/shared_struct.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/shared_struct.rs
@@ -44,8 +44,11 @@ impl SwiftBridgeModule {
 
                 let convert_swift_to_ffi_repr =
                     shared_struct.convert_swift_to_ffi_repr("self", &self.types);
-                let convert_ffi_repr_to_swift =
-                    shared_struct.convert_ffi_expression_to_swift("self", &self.types);
+                let convert_ffi_repr_to_swift = shared_struct.convert_ffi_expression_to_swift(
+                    "self",
+                    &self.types,
+                    &self.swift_bridge_path,
+                );
 
                 // No need to generate any code. Swift will automatically generate a
                 //  struct from our C header typedef that we generate for this struct.
@@ -113,7 +116,11 @@ extension {option_ffi_name} {{
             params += &format!(
                 "{}: {},",
                 field.swift_name_string(),
-                bridged_ty.to_swift_type(TypePosition::SharedStructField, &self.types)
+                bridged_ty.to_swift_type(
+                    TypePosition::SharedStructField,
+                    &self.types,
+                    &self.swift_bridge_path
+                )
             );
         }
 
@@ -160,7 +167,11 @@ extension {option_ffi_name} {{
             fields += &format!(
                 "    public var {}: {}\n",
                 field.swift_name_string(),
-                bridged_ty.to_swift_type(TypePosition::SharedStructField, &self.types)
+                bridged_ty.to_swift_type(
+                    TypePosition::SharedStructField,
+                    &self.types,
+                    &self.swift_bridge_path
+                )
             );
         }
 

--- a/crates/swift-bridge-ir/src/codegen/generate_swift/swift_class.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift/swift_class.rs
@@ -28,6 +28,7 @@ pub(super) fn generate_swift_class(
         &class_methods.ref_self_methods,
         &class_methods.ref_mut_self_methods,
         types,
+        swift_bridge_path,
     )
 }
 
@@ -39,6 +40,7 @@ fn create_class_declaration(
     ref_self_methods: &[String],
     ref_mut_self_methods: &[String],
     types: &TypeDeclarations,
+    swift_bridge_path: &Path,
 ) -> String {
     let type_name = &ty.ty_name_ident().to_string();
     let generics = ty.generics.angle_bracketed_generic_placeholders_string();
@@ -194,7 +196,9 @@ where {swift_generic_bounds} {{
     }}
 }}"#,
             type_name = type_name,
-            swift_generic_bounds = ty.generics.rust_opaque_type_swift_generic_bounds(types),
+            swift_generic_bounds = ty
+                .generics
+                .rust_opaque_type_swift_generic_bounds(types, swift_bridge_path),
             free_func_name = ty.free_rust_opaque_type_ffi_name()
         );
     }

--- a/crates/swift-bridge-ir/src/parse/parse_struct.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_struct.rs
@@ -187,7 +187,7 @@ impl<'a> SharedStructDeclarationParser<'a> {
 mod tests {
     use super::*;
     use crate::test_utils::{parse_errors, parse_ok};
-    use quote::{quote, ToTokens};
+    use quote::quote;
 
     /// Verify that we can parse a struct with no fields.
     /// Structs with no fields always have an implicit `swift_repr = "struct"`.

--- a/crates/swift-bridge-ir/src/parse/type_declarations/generics.rs
+++ b/crates/swift-bridge-ir/src/parse/type_declarations/generics.rs
@@ -4,7 +4,7 @@ use crate::TypeDeclarations;
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::ops::Deref;
-use syn::TypeParam;
+use syn::{Path, TypeParam};
 
 pub(crate) const GENERIC_PLACEHOLDERS: [&'static str; 8] = ["A", "B", "C", "D", "E", "F", "G", "H"];
 
@@ -20,7 +20,11 @@ impl OpaqueRustTypeGenerics {
 
     /// For Rust type `SomeType<u32, u64>`:
     /// A == UInt32, B == UInt64
-    pub(crate) fn rust_opaque_type_swift_generic_bounds(&self, types: &TypeDeclarations) -> String {
+    pub(crate) fn rust_opaque_type_swift_generic_bounds(
+        &self,
+        types: &TypeDeclarations,
+        swift_bridge_path: &Path,
+    ) -> String {
         if self.generics.len() == 0 {
             return "".to_string();
         }
@@ -37,7 +41,11 @@ impl OpaqueRustTypeGenerics {
                         .unwrap()
                         // TODO: FnReturn isn't the real position.. Add a
                         //  new variant that makes more sense for our use case (generic bounds).
-                        .to_swift_type(TypePosition::FnReturn(HostLang::Rust), types)
+                        .to_swift_type(
+                            TypePosition::FnReturn(HostLang::Rust),
+                            types,
+                            swift_bridge_path
+                        )
                 )
             })
             .collect();
@@ -67,6 +75,7 @@ impl OpaqueRustTypeGenerics {
     pub(crate) fn angle_bracketed_generic_concrete_swift_types_string(
         &self,
         types: &TypeDeclarations,
+        swift_bridge_path: &Path,
     ) -> String {
         if self.generics.len() == 0 {
             return "".to_string();
@@ -82,7 +91,11 @@ impl OpaqueRustTypeGenerics {
                         .unwrap()
                         // TODO: FnReturn isn't the real position.. Add a
                         //  new variant that makes more sense for our use case (generic bounds).
-                        .to_swift_type(TypePosition::FnReturn(HostLang::Rust), types)
+                        .to_swift_type(
+                            TypePosition::FnReturn(HostLang::Rust),
+                            types,
+                            swift_bridge_path
+                        )
                 )
             })
             .collect();

--- a/crates/swift-bridge-ir/src/parsed_extern_fn/to_swift_func.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn/to_swift_func.rs
@@ -10,6 +10,7 @@ impl ParsedExternFn {
         &self,
         include_receiver_if_present: bool,
         types: &TypeDeclarations,
+        swift_bridge_path: &Path,
     ) -> String {
         let mut params: Vec<String> = vec![];
 
@@ -40,7 +41,11 @@ impl ParsedExternFn {
                             }
                         }
 
-                        built_in.to_swift_type(TypePosition::FnArg(self.host_lang, arg_idx), types)
+                        built_in.to_swift_type(
+                            TypePosition::FnArg(self.host_lang, arg_idx),
+                            types,
+                            swift_bridge_path,
+                        )
                     } else {
                         todo!("Push to ParsedErrors")
                     };
@@ -71,7 +76,7 @@ impl ParsedExternFn {
         include_receiver_if_present: bool,
         include_var_name: bool,
         types: &TypeDeclarations,
-        _swift_bridge_path: &Path,
+        swift_bridge_path: &Path,
     ) -> String {
         let mut args = vec![];
         let inputs = &self.func.sig.inputs;
@@ -120,6 +125,7 @@ impl ParsedExternFn {
                                         &arg,
                                         TypePosition::FnArg(self.host_lang, arg_idx),
                                         types,
+                                        swift_bridge_path,
                                     )
                                 }
                             }
@@ -139,7 +145,11 @@ impl ParsedExternFn {
         args.join(", ")
     }
 
-    pub fn to_swift_return_type(&self, types: &TypeDeclarations) -> String {
+    pub fn to_swift_return_type(
+        &self,
+        types: &TypeDeclarations,
+        swift_bridge_path: &Path,
+    ) -> String {
         match &self.func.sig.output {
             ReturnType::Default => "".to_string(),
             ReturnType::Type(_, ty) => {
@@ -155,7 +165,11 @@ impl ParsedExternFn {
                     format!(
                         " {}-> {}",
                         maybe_throws,
-                        built_in.to_swift_type(TypePosition::FnReturn(self.host_lang,), types)
+                        built_in.to_swift_type(
+                            TypePosition::FnReturn(self.host_lang,),
+                            types,
+                            swift_bridge_path
+                        )
                     )
                 } else {
                     todo!("Push ParsedErrors")
@@ -208,7 +222,7 @@ mod tests {
 
         for (idx, expected) in expected.into_iter().enumerate() {
             assert_eq!(
-                functions[idx].to_swift_return_type(&module.types),
+                functions[idx].to_swift_return_type(&module.types, &module.swift_bridge_path),
                 format!(" -> {}", expected)
             );
         }
@@ -237,7 +251,11 @@ mod tests {
 
         for method in methods {
             assert_eq!(
-                method.to_swift_param_names_and_types(false, &module.types),
+                method.to_swift_param_names_and_types(
+                    false,
+                    &module.types,
+                    &module.swift_bridge_path
+                ),
                 ""
             );
         }
@@ -265,7 +283,11 @@ mod tests {
 
         for (idx, expected) in expected.into_iter().enumerate() {
             assert_eq!(
-                functions[idx].to_swift_param_names_and_types(false, &module.types),
+                functions[idx].to_swift_param_names_and_types(
+                    false,
+                    &module.types,
+                    &module.swift_bridge_path
+                ),
                 format!("_ other: {}", expected)
             );
         }

--- a/crates/swift-integration-tests/src/function_attributes/args_into.rs
+++ b/crates/swift-integration-tests/src/function_attributes/args_into.rs
@@ -26,6 +26,7 @@ fn test_args_into(_some_arg: TypeA, _another_arg: TypeB) {}
 struct TypeA;
 
 enum TypeB {
+    #[allow(unused)]
     Foo(u8),
 }
 

--- a/crates/swift-integration-tests/src/opaque_type_attributes/already_declared.rs
+++ b/crates/swift-integration-tests/src/opaque_type_attributes/already_declared.rs
@@ -47,8 +47,10 @@ mod ffi2 {
 
 pub struct AlreadyDeclaredTypeTest;
 
+#[allow(dead_code)]
 #[derive(Copy, Clone)]
 pub struct AlreadyDeclaredCopyTypeTest([u16; 2]);
+
 impl AlreadyDeclaredTypeTest {
     fn new() -> Self {
         AlreadyDeclaredTypeTest

--- a/crates/swift-integration-tests/src/option.rs
+++ b/crates/swift-integration-tests/src/option.rs
@@ -135,6 +135,11 @@ mod ffi {
         fn swift_reflect_option_f32(arg: Option<f32>) -> Option<f32>;
         fn swift_reflect_option_f64(arg: Option<f64>) -> Option<f64>;
         fn swift_reflect_option_bool(arg: Option<bool>) -> Option<bool>;
+
+        fn swift_reflect_option_string(arg: Option<String>) -> Option<String>;
+        // TODO: Change to `swift_reflect_option_str` once we support Swift returning `-> &str`
+        fn swift_arg_option_str(arg: Option<&str>) -> bool;
+        // fn swift_reflect_option_str(arg: Option<&str>) -> Option<&str>;
     }
 }
 
@@ -172,6 +177,21 @@ fn test_rust_calls_swift_option_primitive() {
     assert_eq!(ffi::swift_reflect_option_bool(Some(true)), Some(true));
     assert_eq!(ffi::swift_reflect_option_bool(Some(false)), Some(false));
     assert_eq!(ffi::swift_reflect_option_bool(None), None);
+
+    assert_eq!(ffi::swift_reflect_option_string(None), None);
+    assert_eq!(
+        ffi::swift_reflect_option_string(Some("hello".to_string())),
+        Some("hello".to_string())
+    );
+
+    // TODO: Change to `swift_reflect_option_str` once we support Swift returning `-> &str`
+    assert_eq!(ffi::swift_arg_option_str(None), false);
+    assert_eq!(
+        ffi::swift_arg_option_str(Some("this is an option str")),
+        true
+    );
+    // assert_eq!(ffi::swift_reflect_option_str(None), None);
+    // assert_eq!(ffi::swift_reflect_option_str(Some("a str")), Some("a str"));
 }
 
 pub struct OptTestOpaqueRustType {


### PR DESCRIPTION
Swift Option<String> and Option<&str>

This commit adds support for passing `Option<String>` to and from
`extern "Swift"` functions, as well as for passing `Option<&str>` to
extern "Swift" functions.

For example, the following is now possible:

```rust
#[swift_bridge::bridge]
mod ffi {
    extern "Swift" {
        fn opt_string_function(arg: Option<String>) -> Option<String>;

        fn opt_str_function(arg: Option<&str>);
    }
}
```

Note that you can not yet return `-> Option<&str>` from Swift.

This is an uncommon use case, so we're waiting until someone actually
needs it.