### PR TITLE
Fix dead_code warning when returning Result with bridged type in error case

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Result.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner/Result.swift
@@ -35,6 +35,9 @@ extension AsyncResultOpaqueRustType2: Error {}
 extension ResultTransparentEnum: @unchecked Sendable {}
 extension ResultTransparentEnum: Error {}
 
+extension ResultTransparentStruct: @unchecked Sendable {}
+extension ResultTransparentStruct: Error {}
+
 extension SameEnum: @unchecked Sendable {}
 extension SameEnum: Error {}
 

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
@@ -193,6 +193,46 @@ class ResultTests: XCTestCase {
         }
     }
 
+    /// Verify that we can receive a Result<(), TransparentStruct> from Rust
+    func testResultNullTransparentStruct() throws {
+        try! rust_func_return_result_null_transparent_struct(true)
+
+        do {
+            try rust_func_return_result_null_transparent_struct(false)
+            XCTFail("The function should have returned an error.")
+        } catch let error as ResultTransparentStruct {
+            XCTAssertEqual(error.inner.toString(), "failed")
+        }
+
+        XCTContext.runActivity(named: "Should return a Unit type") {
+            _ in
+            do {
+                let _ :() = try rust_func_return_result_unit_type_enum_opaque_rust(true)
+            } catch {
+                XCTFail()
+            }
+        }
+
+        XCTContext.runActivity(named: "Should throw an error") {
+            _ in
+            do {
+                let _ :() = try rust_func_return_result_unit_type_enum_opaque_rust(false)
+                XCTFail("The function should have returned an error.")
+            } catch let error as ResultTransparentEnum {
+                switch error {
+                case .NamedField(let data):
+                    XCTAssertEqual(data, 123)
+                case .UnnamedFields(_, _):
+                    XCTFail()
+                case .NoFields:
+                    XCTFail()
+                }
+            } catch {
+                XCTFail()
+            }
+        }
+    }
+
     /// Verify that we can receive a Result<Vec<>, OpaqueRust> from Rust
     func testSwiftCallRustResultVecUInt32Rust() throws {
         let vec = try! rust_func_return_result_of_vec_u32()

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
@@ -375,10 +375,14 @@ impl BuiltInResult {
             .err_ty
             .to_ffi_compatible_rust_type(swift_bridge_path, types);
         let mut custom_rust_ffi_types = vec![];
+        // TODO: remove allowances when rustc no longer issues dead code warnings for `#[repr(C)]`
+        //  structs or enums: https://github.com/rust-lang/rust/issues/126706
         custom_rust_ffi_types.push(quote! {
             #[repr(C)]
             pub enum #ty {
+                #[allow(unused)]
                 Ok #ok,
+                #[allow(unused)]
                 Err(#err),
             }
         });

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
@@ -375,7 +375,7 @@ impl BuiltInResult {
             .err_ty
             .to_ffi_compatible_rust_type(swift_bridge_path, types);
         let mut custom_rust_ffi_types = vec![];
-        // TODO: remove allowances when rustc no longer issues dead code warnings for `#[repr(C)]`
+        // TODO: remove `#[allow(unused)]` when rustc no longer issues dead code warnings for `#[repr(C)]`
         //  structs or enums: https://github.com/rust-lang/rust/issues/126706
         custom_rust_ffi_types.push(quote! {
             #[repr(C)]

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/result_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/result_codegen_tests.rs
@@ -408,7 +408,8 @@ mod extern_rust_fn_return_result_opaque_rust_type_and_transparent_enum_type {
     }
 
     // In Rust 1.79.0 dead_code warnings are issued for wrapped data in enums in spite of the enum
-    // having `#[repr(C)]`.
+    // having `#[repr(C)]`. `#[allow(unused)]` can be removed following resolution and release of this
+    // issue: https://github.com/rust-lang/rust/issues/126706
     fn expected_rust_tokens() -> ExpectedRustTokens {
         ExpectedRustTokens::Contains(quote! {
             #[repr(C)]
@@ -488,7 +489,9 @@ mod extern_rust_fn_return_result_transparent_enum_type_and_opaque_rust_type {
         }
     }
 
-    // Allows unused to avoid dead_code warnings in Rust 1.79.0 or later.
+    // In Rust 1.79.0 dead_code warnings are issued for wrapped data in enums in spite of the enum
+    // having `#[repr(C)]`. `#[allow(unused)]` can be removed following resolution and release of this
+    // issue: https://github.com/rust-lang/rust/issues/126706
     fn expected_rust_tokens() -> ExpectedRustTokens {
         ExpectedRustTokens::Contains(quote! {
             #[repr(C)]
@@ -565,7 +568,9 @@ mod extern_rust_fn_return_result_unit_type_and_transparent_enum_type {
         }
     }
 
-    // Allows unused to avoid dead_code warnings in Rust 1.79.0 or later.
+    // In Rust 1.79.0 dead_code warnings are issued for wrapped data in enums in spite of the enum
+    // having `#[repr(C)]`. `#[allow(unused)]` can be removed following resolution and release of this
+    // issue: https://github.com/rust-lang/rust/issues/126706
     fn expected_rust_tokens() -> ExpectedRustTokens {
         ExpectedRustTokens::Contains(quote! {
             #[repr(C)]
@@ -638,7 +643,9 @@ mod extern_rust_fn_return_result_tuple_type_and_transparent_enum_type {
         }
     }
 
-    // Allows unused to avoid dead_code warnings in Rust 1.79.0 or later.
+    // In Rust 1.79.0 dead_code warnings are issued for wrapped data in enums in spite of the enum
+    // having `#[repr(C)]`. `#[allow(unused)]` can be removed following resolution and release of this
+    // issue: https://github.com/rust-lang/rust/issues/126706
     fn expected_rust_tokens() -> ExpectedRustTokens {
         ExpectedRustTokens::ContainsMany(vec![
             quote! {

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/result_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/result_codegen_tests.rs
@@ -407,11 +407,15 @@ mod extern_rust_fn_return_result_opaque_rust_type_and_transparent_enum_type {
         }
     }
 
+    // In Rust 1.79.0 dead_code warnings are issued for wrapped data in enums in spite of the enum
+    // having `#[repr(C)]`.
     fn expected_rust_tokens() -> ExpectedRustTokens {
         ExpectedRustTokens::Contains(quote! {
             #[repr(C)]
             pub enum ResultSomeOkTypeAndSomeErrEnum{
+                #[allow(unused)]
                 Ok(*mut super::SomeOkType),
+                #[allow(unused)]
                 Err(__swift_bridge__SomeErrEnum),
             }
 
@@ -484,11 +488,14 @@ mod extern_rust_fn_return_result_transparent_enum_type_and_opaque_rust_type {
         }
     }
 
+    // Allows unused to avoid dead_code warnings in Rust 1.79.0 or later.
     fn expected_rust_tokens() -> ExpectedRustTokens {
         ExpectedRustTokens::Contains(quote! {
             #[repr(C)]
             pub enum ResultSomeOkEnumAndSomeErrType{
+                #[allow(unused)]
                 Ok(__swift_bridge__SomeOkEnum),
+                #[allow(unused)]
                 Err(*mut super::SomeErrType),
             }
 
@@ -558,11 +565,14 @@ mod extern_rust_fn_return_result_unit_type_and_transparent_enum_type {
         }
     }
 
+    // Allows unused to avoid dead_code warnings in Rust 1.79.0 or later.
     fn expected_rust_tokens() -> ExpectedRustTokens {
         ExpectedRustTokens::Contains(quote! {
             #[repr(C)]
             pub enum ResultVoidAndSomeErrEnum{
+                #[allow(unused)]
                 Ok,
+                #[allow(unused)]
                 Err(__swift_bridge__SomeErrEnum),
             }
 
@@ -628,12 +638,15 @@ mod extern_rust_fn_return_result_tuple_type_and_transparent_enum_type {
         }
     }
 
+    // Allows unused to avoid dead_code warnings in Rust 1.79.0 or later.
     fn expected_rust_tokens() -> ExpectedRustTokens {
         ExpectedRustTokens::ContainsMany(vec![
             quote! {
                 #[repr(C)]
                 pub enum ResultTupleI32U32AndSomeErrEnum{
+                    #[allow(unused)]
                     Ok(__swift_bridge__tuple_I32U32),
+                    #[allow(unused)]
                     Err(__swift_bridge__SomeErrEnum),
                 }
             },

--- a/crates/swift-integration-tests/src/result.rs
+++ b/crates/swift-integration-tests/src/result.rs
@@ -38,12 +38,14 @@ mod ffi {
     }
 
     #[swift_bridge(swift_repr = "struct")]
-    struct ResultTestTransparentStruct(pub String);
+    struct ResultTransparentStruct {
+        pub inner: String,
+    }
 
     extern "Rust" {
-        fn rust_func_returns_result_null_transparent_struct(
+        fn rust_func_return_result_null_transparent_struct(
             succeed: bool,
-        ) -> Result<(), ResultTestTransparentStruct>;
+        ) -> Result<(), ResultTransparentStruct>;
     }
 
     enum ResultTransparentEnum {
@@ -146,27 +148,29 @@ fn rust_func_return_result_unit_struct_opaque_rust(
     }
 }
 
-fn rust_func_returns_result_null_transparent_struct(
+fn rust_func_return_result_null_transparent_struct(
     succeed: bool,
-) -> Result<(), ffi::ResultTestTransparentStruct> {
+) -> Result<(), ffi::ResultTransparentStruct> {
     if succeed {
         Ok(())
     } else {
-        Err(ffi::ResultTestTransparentStruct("failed".to_string()))
+        Err(ffi::ResultTransparentStruct {
+            inner: "failed".to_string(),
+        })
     }
 }
 
-impl std::error::Error for ffi::ResultTestTransparentStruct {}
+impl std::error::Error for ffi::ResultTransparentStruct {}
 
-impl std::fmt::Debug for ffi::ResultTestTransparentStruct {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
+impl std::fmt::Debug for ffi::ResultTransparentStruct {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        unreachable!("Debug impl was added to pass `Error: Debug + Display` type checking")
     }
 }
 
-impl std::fmt::Display for ffi::ResultTestTransparentStruct {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+impl std::fmt::Display for ffi::ResultTransparentStruct {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        unreachable!("Display impl was added to pass `Error: Debug + Display` type checking")
     }
 }
 


### PR DESCRIPTION
In Rust 1.79.0, dead code warnings are emitted from enums where the compiler does not infer that wrapped data is used, even when the enum has been annotated with `#[repr(C]`. This warning triggers in `swift-bridge` when defining transparent structs or enums that will be returned in error results.

This appears to be a regression in the `dead_code` rustc lint. Pending upstream fixes to rustc, this change to `swift-bridge` annotates generated result enums with `#[allow(unused)]`.

Fixes #270

```
error: field `0` is never read
   |
1  | #[swift_bridge::bridge]
   | ----------------------- field in this variant
...
3  |     enum ResultTransparentEnum {
   |          ^^^^^^^^^^^^^^^^^^^^^
   |
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
3  |     enum () {
   |          ~~
```

## Example bridge

The following bridge code is the minimal reproduction case:

``` rust
#[swift_bridge::bridge]
mod ffi {
    #[swift_bridge(swift_repr = "struct")]
    struct TransparentErrorStruct(pub String);

    extern "Rust" {
        fn rust_func_returns_result_transparent_struct(
            succeed: bool
        ) -> Result<(), TransparentErrorStruct>;
    }
}

fn rust_func_returns_result_transparent_struct(
    succeed: bool
) -> Result<(), ffi::ResultTestTransparentStruct> {
    if succeed {
        Ok(())
    } else {
        Err(ffi::ResultTestTransparentStruct("failed".to_string()))
    }
}

impl std::error::Error for ffi:: TransparentErrorStruct {}

impl std::fmt::Debug for ffi:: TransparentErrorStruct {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        write!(f, "{}", self)
    }
}

impl std::fmt::Display for ffi:: TransparentErrorStruct {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        write!(f, "{}", self.0)
    }
}
```

