### PR TITLE
Implement Error for RustStringRef

### DIFF
--- a/crates/swift-bridge-build/src/generate_core/rust_string.swift
+++ b/crates/swift-bridge-build/src/generate_core/rust_string.swift
@@ -48,11 +48,6 @@ extension RustStringRef {
     }
 }
 extension RustStringRef: Error {}
-extension RustStringRef: LocalizedError {
-  public var errorDescription: String? {
-    return self.as_str().toString()
-  }
-}
 extension RustString: Vectorizable {
     public static func vecOfSelfNew() -> UnsafeMutableRawPointer {
         __swift_bridge__$Vec_RustString$new()

--- a/crates/swift-bridge-build/src/generate_core/rust_string.swift
+++ b/crates/swift-bridge-build/src/generate_core/rust_string.swift
@@ -47,6 +47,12 @@ extension RustStringRef {
         __swift_bridge__$RustString$trim(ptr)
     }
 }
+extension RustStringRef: Error {}
+extension RustStringRef: LocalizedError {
+  public var errorDescription: String? {
+    return self.as_str().toString()
+  }
+}
 extension RustString: Vectorizable {
     public static func vecOfSelfNew() -> UnsafeMutableRawPointer {
         __swift_bridge__$Vec_RustString$new()


### PR DESCRIPTION
With the latest versions of Swift, using `Result<_, String>` causes two errors:
- `'RustString' is not convertible to 'any Error'`
- `Thrown expression type 'RustString' does not conform to 'Error`
 
The solution to both errors is for `RustStringRef` to declare conformance to the `Error` protocol.

See: [Swift Documentation - Error](https://developer.apple.com/documentation/swift/error)