### PR TITLE
Apply input module visibility to output module

### DIFF
--- a/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_rust_tokens.rs
@@ -18,6 +18,7 @@ mod vec;
 impl ToTokens for SwiftBridgeModule {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let mod_name = &self.name;
+        let vis = &self.vis;
         let swift_bridge_path = &self.swift_bridge_path;
 
         let mut extern_rust_fn_tokens = vec![];
@@ -298,7 +299,7 @@ impl ToTokens for SwiftBridgeModule {
         let t = quote! {
             #[allow(non_snake_case)]
             #(#module_attributes)*
-            mod #mod_name {
+            #vis mod #mod_name {
                 #module_inner
             }
         };
@@ -1044,5 +1045,21 @@ mod tests {
             ),
             &expected_fn,
         );
+    }
+
+    /// Verify that we apply the module's visibility to the output.
+    #[test]
+    fn module_visibility() {
+        let start = quote! {
+            pub(super) mod foo {
+            }
+        };
+        let expected = quote! {
+            #[allow(non_snake_case)]
+            pub(super) mod foo {
+            }
+        };
+
+        assert_tokens_eq(&parse_ok(start).to_token_stream(), &expected);
     }
 }

--- a/crates/swift-bridge-ir/src/lib.rs
+++ b/crates/swift-bridge-ir/src/lib.rs
@@ -8,7 +8,7 @@
 #![deny(missing_docs)]
 
 use proc_macro2::Ident;
-use syn::Path;
+use syn::{Path, Visibility};
 
 use crate::bridge_module_attributes::CfgAttr;
 use crate::parse::TypeDeclarations;
@@ -58,6 +58,7 @@ const SWIFT_BRIDGE_PREFIX: &'static str = "__swift_bridge__";
 /// ```
 pub struct SwiftBridgeModule {
     name: Ident,
+    vis: Visibility,
     types: TypeDeclarations,
     functions: Vec<ParsedExternFn>,
     swift_bridge_path: Path,

--- a/crates/swift-bridge-ir/src/parse.rs
+++ b/crates/swift-bridge-ir/src/parse.rs
@@ -57,6 +57,7 @@ impl Parse for SwiftBridgeModuleAndErrors {
 
         if let Ok(item_mod) = input.parse::<ItemMod>() {
             let module_name = item_mod.ident;
+            let vis = item_mod.vis;
 
             let mut functions = vec![];
             let mut type_declarations = TypeDeclarations::default();
@@ -125,6 +126,7 @@ impl Parse for SwiftBridgeModuleAndErrors {
 
             let module = SwiftBridgeModule {
                 name: module_name,
+                vis,
                 types: type_declarations,
                 functions,
                 swift_bridge_path: syn::parse2(quote! { swift_bridge }).unwrap(),


### PR DESCRIPTION
Addresses #252.

Here's an example of using this.

```rust
// enums.rs

#[swift_bridge::bridge]
pub mod ffi {
    enum MyEnum {
        VariantA,
        VariantB,
        VariantC,
    }
}

// lib.rs
mod enums;
use enums::ffi::MyEnum;

#[swift_bridge::bridge]
mod ffi {
  #[swift_bridge(already_declared)]
  enum MyEnum {}

  extern "Rust" {
    fn getEnum() -> MyEnum;
  }
}
```