### PR TITLE
Support throwing initializers

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
@@ -249,4 +249,27 @@ class ResultTests: XCTestCase {
             XCTAssertEqual(UInt32(i), value.val())
         }
     }
+    
+    /// Verify that we can use throwing initializers defined on the Rust side.
+    func testThrowingInitializers() throws {
+        XCTContext.runActivity(named: "Should fail") {
+            _ in
+            do {
+                let throwingInitializer = try ThrowingInitializer(false)
+            } catch let error as ResultTransparentEnum {
+                if case .NamedField(data: -123) = error {
+                    // This case should pass.
+                } else {
+                    XCTFail()
+                }
+            } catch {
+                XCTFail()
+            }
+        }
+        XCTContext.runActivity(named: "Should succeed") {
+            _ in
+            let throwingInitializer = try! ThrowingInitializer(true)
+            XCTAssertEqual(throwingInitializer.val(), 123)
+        }
+    }
 }

--- a/book/src/bridge-module/functions/README.md
+++ b/book/src/bridge-module/functions/README.md
@@ -66,7 +66,7 @@ do {
 ## Function Attributes
 
 #### #[swift_bridge(init)]
-Used to generate a Swift initializer.
+Used to generate a Swift initializer for Opaque Types.
 
 ```rust
 // Rust

--- a/book/src/bridge-module/functions/README.md
+++ b/book/src/bridge-module/functions/README.md
@@ -65,6 +65,58 @@ do {
 
 ## Function Attributes
 
+#### #[swift_bridge(init)]
+Used to generate a Swift initializer.
+
+```rust
+// Rust
+
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Rust" {
+        type RegularInitializer;
+
+        #[swift_bridge(init)]
+        fn new() -> RegularInitializer;
+    }
+
+    extern "Rust" {
+        type FailableInitializer;
+
+        #[swift_bridge(init)]
+        fn new() -> Option<FailableInitializer>;
+    }
+
+    enum SomeError {
+        case1,
+        case2
+    }
+
+    extern "Rust" {
+        type ThrowingInitializer;
+
+        #[swift_bridge(init)]
+        fn new() -> Result<FailableInitializer, SomeError>;
+    }
+}
+```
+
+```swift
+// Swift
+
+let regularInitializer = RegularInitializer()
+
+if let failableInitializer = FailableInitializer() {
+    // ...
+}
+
+do {
+    let throwingInitializer = try ThrowingInitializer()
+} catch let error {
+    // ...
+}
+```
+
 #### #[swift_bridge(Identifiable)]
 
 Used to generate a Swift `Identifiable` protocol implementation.

--- a/crates/swift-bridge-ir/src/bridged_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type.rs
@@ -411,6 +411,7 @@ pub(crate) enum TypePosition {
     FnReturn(HostLang),
     SharedStructField,
     SwiftCallsRustAsyncOnCompleteReturnTy,
+    ThrowingInit(HostLang),
 }
 
 /// &[T]
@@ -1177,6 +1178,7 @@ impl BridgedType {
                         TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                             unimplemented!()
                         }
+                        TypePosition::ThrowingInit(_) => unimplemented!(),
                     }
                 }
                 StdLibType::Null => "()".to_string(),
@@ -1193,6 +1195,7 @@ impl BridgedType {
                     TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                         unimplemented!()
                     }
+                    TypePosition::ThrowingInit(_) => unimplemented!(),
                 },
                 StdLibType::Vec(ty) => match type_pos {
                     TypePosition::FnArg(func_host_lang, _) => {
@@ -1215,6 +1218,7 @@ impl BridgedType {
                             "UnsafeMutableRawPointer".to_string()
                         }
                     }
+                    TypePosition::ThrowingInit(_) => unimplemented!(),
                     _ => {
                         format!(
                             "RustVec<{}>",
@@ -1243,6 +1247,7 @@ impl BridgedType {
                     TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                         shared_struct.ffi_name_string()
                     }
+                    TypePosition::ThrowingInit(_) => unimplemented!(),
                 }
             }
             BridgedType::Foreign(CustomBridgedType::Shared(SharedType::Enum(shared_enum))) => {
@@ -1259,6 +1264,7 @@ impl BridgedType {
                     TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                         unimplemented!()
                     }
+                    TypePosition::ThrowingInit(_) => unimplemented!(),
                 }
             }
         }
@@ -1567,6 +1573,7 @@ impl BridgedType {
                             TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                                 unimplemented!()
                             }
+                            TypePosition::ThrowingInit(_) => unimplemented!(),
                         },
                         PointerKind::Mut => expression.to_string(),
                     },
@@ -1660,6 +1667,7 @@ impl BridgedType {
                         TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                             unimplemented!()
                         }
+                        TypePosition::ThrowingInit(_) => unimplemented!(),
                     },
                 },
                 StdLibType::Str => match type_pos {
@@ -1677,6 +1685,7 @@ impl BridgedType {
                     TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                         unimplemented!()
                     }
+                    TypePosition::ThrowingInit(_) => unimplemented!(),
                 },
                 StdLibType::Vec(_) => {
                     format!(

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_result.rs
@@ -258,10 +258,9 @@ impl BuiltInResult {
                 TypePosition::ThrowingInit(lang) => {
                     match lang {
                         HostLang::Rust => format!(
-                            "let val = {expression}; switch val.tag {{ case {c_ok_name}: self.init(ptr: val.payload.ok) case {c_err_name}: throw {err_swift_type} default: fatalError() }}",
+                            "let val = {expression}; if val.tag == {c_ok_name} {{ self.init(ptr: val.payload.ok) }} else {{ throw {err_swift_type} }}",
                         expression = expression,
                         c_ok_name = c_ok_name,
-                        c_err_name = c_err_name,
                         err_swift_type = err_swift_type
                     ),
                         HostLang::Swift => todo!(),

--- a/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridgeable_string.rs
@@ -76,6 +76,7 @@ impl BridgeableType for BridgedString {
             TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                 "UnsafeMutableRawPointer?".to_string()
             }
+            TypePosition::ThrowingInit(_) => todo!(),
         }
     }
 
@@ -130,6 +131,7 @@ impl BridgeableType for BridgedString {
             TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                 todo!()
             }
+            TypePosition::ThrowingInit(_) => todo!(),
         }
     }
 
@@ -205,6 +207,7 @@ impl BridgeableType for BridgedString {
             TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                 unimplemented!()
             }
+            TypePosition::ThrowingInit(_) => todo!(),
         }
     }
 
@@ -250,6 +253,7 @@ impl BridgeableType for BridgedString {
             TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                 format!("RustString(ptr: {}!)", expression)
             }
+            TypePosition::ThrowingInit(_) => todo!(),
         }
     }
 

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_opaque_type.rs
@@ -129,6 +129,7 @@ impl BridgeableType for OpaqueForeignType {
                 TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                     unimplemented!()
                 }
+                TypePosition::ThrowingInit(_) => unimplemented!(),
             }
         } else {
             match type_pos {
@@ -146,6 +147,7 @@ impl BridgeableType for OpaqueForeignType {
                 TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                     unimplemented!()
                 }
+                TypePosition::ThrowingInit(_) => unimplemented!(),
             }
         }
     }
@@ -396,6 +398,7 @@ impl BridgeableType for OpaqueForeignType {
                     TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                         unimplemented!()
                     }
+                    TypePosition::ThrowingInit(_) => unimplemented!(),
                 }
             }
         } else {
@@ -420,6 +423,7 @@ impl BridgeableType for OpaqueForeignType {
                 TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                     unimplemented!()
                 }
+                TypePosition::ThrowingInit(_) => unimplemented!(),
             }
         }
     }

--- a/crates/swift-bridge-ir/src/bridged_type/bridged_option.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/bridged_option.rs
@@ -324,6 +324,7 @@ impl BridgedOption {
                     TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                         todo!()
                     }
+                    TypePosition::ThrowingInit(_) => todo!(),
                 },
                 StdLibType::Vec(_) => {
                     format!(
@@ -397,6 +398,7 @@ impl BridgedOption {
             TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => {
                 unimplemented!()
             }
+            TypePosition::ThrowingInit(_) => unimplemented!(),
         }
     }
 

--- a/crates/swift-bridge-ir/src/bridged_type/built_in_tuple.rs
+++ b/crates/swift-bridge-ir/src/bridged_type/built_in_tuple.rs
@@ -135,6 +135,7 @@ impl BridgeableType for BuiltInTuple {
             }
             TypePosition::SharedStructField => todo!(),
             TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => todo!(),
+            TypePosition::ThrowingInit(_) => todo!(),
         }
     }
 
@@ -227,6 +228,7 @@ impl BridgeableType for BuiltInTuple {
             }
             TypePosition::SharedStructField => todo!(),
             TypePosition::SwiftCallsRustAsyncOnCompleteReturnTy => todo!(),
+            TypePosition::ThrowingInit(_) => todo!(),
         }
     }
 

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_rust_type_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_rust_type_codegen_tests.rs
@@ -581,7 +581,7 @@ public class Foo: FooRefMut {
 }
 extension Foo {
     public convenience init() throws {
-        let val = __swift_bridge__$Foo$new(); switch val.tag { case __swift_bridge__$ResultFooAndSomeErrEnum$ResultOk: self.init(ptr: val.payload.ok) case __swift_bridge__$ResultFooAndSomeErrEnum$ResultErr: throw val.payload.err.intoSwiftRepr() default: fatalError() }
+        let val = __swift_bridge__$Foo$new(); if val.tag == __swift_bridge__$ResultFooAndSomeErrEnum$ResultOk { self.init(ptr: val.payload.ok) } else { throw val.payload.err.intoSwiftRepr() }
     }
 }
 "#,

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_rust_type_codegen_tests.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/opaque_rust_type_codegen_tests.rs
@@ -528,7 +528,7 @@ void* __swift_bridge__$Foo$new(void);
     }
 }
 
-/// Verify that we can use a Swift class with a throwing init.
+/// Verify that we can create a Swift class with a throwing init.
 mod extern_rust_class_with_throwing_init {
     use super::*;
 

--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod/function_attributes.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod/function_attributes.rs
@@ -302,6 +302,30 @@ mod tests {
         );
     }
 
+    /// Verify that we can parse an throwing init function.
+    #[test]
+    fn throwing_initializer() {
+        let tokens = quote! {
+            mod foo {
+                extern "Rust" {
+                    type Foo;
+
+                    #[swift_bridge(init)]
+                    fn bar () -> Result<Foo, i32>;
+                }
+            }
+        };
+
+        let module = parse_ok(tokens);
+
+        let func = &module.functions[0];
+        assert!(func.is_swift_initializer);
+        matches!(
+            func.swift_failable_initializer,
+            Some(FailableInitializerType::Throwing)
+        );
+    }
+
     /// Verify that we can parse an init function that takes inputs.
     #[test]
     fn initializer_with_inputs() {

--- a/crates/swift-bridge-ir/src/parse/parse_extern_mod/function_attributes.rs
+++ b/crates/swift-bridge-ir/src/parse/parse_extern_mod/function_attributes.rs
@@ -165,6 +165,7 @@ impl Parse for FunctionAttr {
 #[cfg(test)]
 mod tests {
     use crate::errors::{FunctionAttributeParseError, IdentifiableParseError, ParseError};
+    use crate::parsed_extern_fn::FailableInitializerType;
     use crate::test_utils::{parse_errors, parse_ok};
     use quote::{quote, ToTokens};
 
@@ -295,7 +296,10 @@ mod tests {
 
         let func = &module.functions[0];
         assert!(func.is_swift_initializer);
-        assert!(func.is_swift_failable_initializer);
+        matches!(
+            func.swift_failable_initializer,
+            Some(FailableInitializerType::Option)
+        );
     }
 
     /// Verify that we can parse an init function that takes inputs.

--- a/crates/swift-bridge-ir/src/parsed_extern_fn.rs
+++ b/crates/swift-bridge-ir/src/parsed_extern_fn.rs
@@ -29,6 +29,13 @@ impl SwiftFuncGenerics {
     }
 }
 
+/// Represents different types of Swift's initializers that can fail
+#[derive(Clone)]
+pub(crate) enum FailableInitializerType {
+    Throwing,
+    Option,
+}
+
 /// A method or associated function associated with a type.
 ///
 /// fn bar (&self);
@@ -62,7 +69,7 @@ pub(crate) struct ParsedExternFn {
     /// Whether or not this function is a Swift failable initializer.
     /// For more details, see:
     /// [Swift Documentation - Failable Initializers](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/initialization/#Failable-Initializers)
-    pub is_swift_failable_initializer: bool,
+    pub swift_failable_initializer: Option<FailableInitializerType>,
     /// Whether or not this function should be used for the associated type's Swift
     /// `Identifiable` protocol implementation.
     pub is_swift_identifiable: bool,
@@ -468,7 +475,6 @@ impl ParsedExternFn {
                 }
             })
             .unwrap_or("".to_string());
-
         format!(
             "{}{}${}",
             SWIFT_BRIDGE_PREFIX,

--- a/crates/swift-integration-tests/src/result.rs
+++ b/crates/swift-integration-tests/src/result.rs
@@ -89,6 +89,13 @@ mod ffi {
             succeed: bool,
         ) -> Result<(i32, ResultTestOpaqueRustType, String), ResultTransparentEnum>;
     }
+
+    extern "Rust" {
+        type ThrowingInitializer;
+        #[swift_bridge(init)]
+        fn new(succeed: bool) -> Result<ThrowingInitializer, ResultTransparentEnum>;
+        fn val(&self) -> i32;
+    }
 }
 
 fn rust_func_takes_result_string(arg: Result<String, String>) {
@@ -245,5 +252,22 @@ fn rust_func_return_result_tuple_transparent_enum(
         Ok((123, ResultTestOpaqueRustType::new(123), "hello".to_string()))
     } else {
         Err(ffi::ResultTransparentEnum::NamedField { data: -123 })
+    }
+}
+
+struct ThrowingInitializer {
+    val: i32,
+}
+
+impl ThrowingInitializer {
+    fn new(succeed: bool) -> Result<Self, ffi::ResultTransparentEnum> {
+        if succeed {
+            Ok(ThrowingInitializer { val: 123 })
+        } else {
+            Err(ffi::ResultTransparentEnum::NamedField { data: -123 })
+        }
+    }
+    fn val(&self) -> i32 {
+        self.val
     }
 }


### PR DESCRIPTION
This PR implements throwing initializers. See: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/errorhandling/.

Here's an example of using this feature:

```rust
// Rust
#[swift_bridge::bridge]
mod ffi {
    enum ResultTransparentEnum {
        NamedField { data: i32 },
        UnnamedFields(u8, String),
        NoFields,
    }
    extern "Rust" {
        type ThrowingInitializer;
        #[swift_bridge(init)]
        fn new(succeed: bool) -> Result<ThrowingInitializer, ResultTransparentEnum>;
        fn val(&self) -> i32;
    }
}
```

```swift
// Swift
do {
    let throwingInitializer = try ThrowingInitializer(false)
} catch let error as ResultTransparentEnum {
    //...
} catch {
    //...
}
```