### PR TITLE
fix: wrongly detect as a virtual manifest

### DIFF
--- a/book/src/building/swift-packages/README.md
+++ b/book/src/building/swift-packages/README.md
@@ -18,6 +18,9 @@ mkdir my-rust-lib && cd my-rust-lib
 ```toml
 # Cargo.toml
 
+[package]
+name = "my-rust-lib"
+
 [lib]
 crate-type = ["staticlib"]
 


### PR DESCRIPTION
The `Cargo.toml` file needs a `[package]` section; otherwise, the `[lib]` section is not allowed. See [virtual manifest](https://doc.rust-lang.org/cargo/reference/workspaces.html#virtual-workspace).