### PR TITLE
Document Swift String copying

### DIFF
--- a/book/src/built-in/string/README.md
+++ b/book/src/built-in/string/README.md
@@ -1,4 +1,4 @@
-# String <---> String
+# Rust `std::string::String` <---> Swift `String`
 
 Rust's `std::string::String` can be passed to Swift as an owned `String`, a referenced `&String` or a mutably referenced `&mut String`.
 
@@ -49,15 +49,11 @@ func make_swift_string() -> String {
 
 ## RustString
 
-Since both Rust and Swift have their own `String` type, it is technically possible for us to automatically
-convert owned Rust `std::string::String`s into Swift `String`s.
+It is technically possible for us to automatically convert owned Rust `std::string::String`s into Swift `String`s,
+but we do not do this because it would require copying the Rust `std::string::String` bytes to a new `Swift` allocation.
 
-However, we do not do this since Swift does not currently have a way to construct a Swift `String` without copying.
+This is because there is no way to construct a Swift `String` without copying.
 
-This means that if we were to automatically convert from a Rust `std::string::String` to a Swift `String` we would have to create a new
-Swift allocation and copy all of the Rust `std::string::String` bytes to that allocation.
-
-`swift-bridge` seeks to avoid unnecessary allocations, so instead of performing this implicit allocation
-we pass a `RustString` type from Rust to Swift.
+`swift-bridge` seeks to avoid unnecessary allocations, so instead of performing an implicit allocation we pass a `RustString` type from Rust to Swift.
 
 The `RustString`'s `.toString()` method can then be called on the Swift side to get a Swift `String`.


### PR DESCRIPTION
This commit adds documentation explaining that there is is no zero-copy
way to create a Swift `String`.

We also add documentation explaining that the reason the `RustString`
type exists is to avoid the implicit allocation that would be required
if we automatically converted Rust's `std::string::String` to Swift's
`String`.

We also document some potential new attributes that would allow users to
opt into automatically converted from a `Rust std::string::String` to a
Swift String.
