### PR TITLE
Fix typo in `.expect` message for copying `SwiftBridgeCore.h`

### DIFF
--- a/crates/swift-bridge-build/src/package.rs
+++ b/crates/swift-bridge-build/src/package.rs
@@ -142,7 +142,7 @@ fn gen_xcframework(output_dir: &Path, config: &CreatePackageConfig) {
         bridge_dir.join("SwiftBridgeCore.h"),
         &include_dir.join("SwiftBridgeCore.h"),
     )
-    .expect("Couldn't copy SwiftBirdgeCore header file");
+    .expect("Couldn't copy SwiftBridgeCore header file");
     let bridge_project_dir = fs::read_dir(&bridge_dir)
         .expect("Couldn't read generated directory")
         .find_map(|file| {


### PR DESCRIPTION
`SwiftBirdgeCore` -> `SwiftBridgeCore`