### PR TITLE
Implement Sendable for `RustString`

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunner.xcodeproj/project.pbxproj
@@ -57,7 +57,7 @@
 		22FD1C562753CB3F00F64281 /* SwiftFnUsesOpaqueRustTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FD1C552753CB3F00F64281 /* SwiftFnUsesOpaqueRustTypeTests.swift */; };
 		C926E4DE294F07AA0027E7E2 /* FunctionAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C926E4DD294F07AA0027E7E2 /* FunctionAttributes.swift */; };
 		C926E4E0294F18C50027E7E2 /* FunctionAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C926E4DF294F18C50027E7E2 /* FunctionAttributeTests.swift */; };
-		DE9444DC2D5241AD007A83A4 /* SendableAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9444DB2D5241A8007A83A4 /* SendableAttributeTests.swift */; };
+		DE9444DC2D5241AD007A83A4 /* SendableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9444DB2D5241A8007A83A4 /* SendableTests.swift */; };
 		DE9444DE2D527C3B007A83A4 /* SendableAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE9444DD2D527C31007A83A4 /* SendableAttribute.swift */; };
 /* End PBXBuildFile section */
 
@@ -128,7 +128,7 @@
 		22FD1C552753CB3F00F64281 /* SwiftFnUsesOpaqueRustTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftFnUsesOpaqueRustTypeTests.swift; sourceTree = "<group>"; };
 		C926E4DD294F07AA0027E7E2 /* FunctionAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionAttributes.swift; sourceTree = "<group>"; };
 		C926E4DF294F18C50027E7E2 /* FunctionAttributeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionAttributeTests.swift; sourceTree = "<group>"; };
-		DE9444DB2D5241A8007A83A4 /* SendableAttributeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendableAttributeTests.swift; sourceTree = "<group>"; };
+		DE9444DB2D5241A8007A83A4 /* SendableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendableTests.swift; sourceTree = "<group>"; };
 		DE9444DD2D527C31007A83A4 /* SendableAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendableAttribute.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -229,7 +229,7 @@
 				225908FB28DA0E320080C737 /* ResultTests.swift */,
 				222A81EA28EB5DF800D4A412 /* PrimitiveTests.swift */,
 				220432EB27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift */,
-				DE9444DB2D5241A8007A83A4 /* SendableAttributeTests.swift */,
+				DE9444DB2D5241A8007A83A4 /* SendableTests.swift */,
 				2202BC0727B2DD1700D43CC4 /* SharedEnumTests.swift */,
 				22BC4BB9294B8CCD0032B8A8 /* SharedEnumAttributeTests.swift */,
 				22C0AD50278ECA9E00A96469 /* SharedStructAttributeTests.swift */,
@@ -431,7 +431,7 @@
 				220432AF274E7BF800BAE645 /* SharedStructTests.swift in Sources */,
 				178F1CD3298E97FB00335AA0 /* ArgumentAttributesTest.swift in Sources */,
 				2289E82C29A879A7009D89D7 /* SingleRepresentationTypeElisionTests.swift in Sources */,
-				DE9444DC2D5241AD007A83A4 /* SendableAttributeTests.swift in Sources */,
+				DE9444DC2D5241AD007A83A4 /* SendableTests.swift in Sources */,
 				220432EC27530AFC00BAE645 /* RustFnUsesOpaqueSwiftTypeTests.swift in Sources */,
 				222A81EB28EB5DF800D4A412 /* PrimitiveTests.swift in Sources */,
 				22553324281DB5FC008A3121 /* GenericTests.rs.swift in Sources */,

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SendableTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SendableTests.swift
@@ -8,11 +8,11 @@
 import XCTest
 @testable import SwiftRustIntegrationTestRunner
 
-/// Tests for the `#[swift_bridge(Sendable)]` attribute.
+/// Tests for Swift's `Sendable` protocol and the `#[swift_bridge(Sendable)]` attribute.
 ///
 /// For the corresponding Rust code, see `crates/swift-integration-tests/src/sendable_attribute.rs`.
 /// For the corresponding codegen tests, see `crates/swift-bridge-ir/src/codegen/codegen_tests/sendable_attribute.rs`.
-class SendableAttributeTests: XCTestCase {
+class SendableTests: XCTestCase {
     /// Verify that we can a Rust type that has the `#[swift_bridge(Sendable)]` attribute gets a `Sendable` protocol implementation.
     func testSendableExternRustType() throws {
         let sendableRustType = SendableRustType()
@@ -20,6 +20,15 @@ class SendableAttributeTests: XCTestCase {
         // Move the type to another thread.
         Thread.detachNewThread {
             let _ = sendableRustType;
+        }
+    }
+
+    /// Verify that we can send a `RustString` to another thread.
+    func testSendableRustString() {
+        let rustString = RustString("hello world")
+
+        Thread.detachNewThread {
+            XCTAssertEqual(rustString.len(), 11)
         }
     }
 }

--- a/book/src/built-in/string/README.md
+++ b/book/src/built-in/string/README.md
@@ -1,35 +1,36 @@
 # Rust `std::string::String` <---> Swift `String`
 
-Rust's `std::string::String` can be passed to Swift as an owned `String`, a referenced `&String` or a mutably referenced `&mut String`.
+Rust's `std::string::String` can be passed to Swift as an owned `String`, a referenced `&String` or a mutably referenced
+`&mut String`.
 
 ```rust
 // Rust
 
 #[swift_bridge::bridge]
 mod ffi {
-	extern "Rust" {
-	    type SomeRustType;
+    extern "Rust" {
+        type SomeRustType;
 
-	    // Becomes a `RustString` when passed to Swift.
-	    fn make_string() -> String;
+        // Becomes a `RustString` when passed to Swift.
+        fn make_string() -> String;
 
-	    // Becomes a `RustStringRef` when passed to Swift.
-	    fn make_ref_string(&self) -> &String;
+        // Becomes a `RustStringRef` when passed to Swift.
+        fn make_ref_string(&self) -> &String;
 
-	    // Becomes a `RustStringRefMut` when passed to Swift.
-	    fn make_ref_mut_string(&mut self) -> &mut String;
+        // Becomes a `RustStringRefMut` when passed to Swift.
+        fn make_ref_mut_string(&mut self) -> &mut String;
 
         // Swift calls this with a `RustString` and
         // Rust receives a `std::string::String`.
-	    fn take_string(string: String);
-	}
+        fn take_string(string: String);
+    }
 
-	extern "Swift" {
-	    type SomeSwiftType;
+    extern "Swift" {
+        type SomeSwiftType;
 
-	    fn make_rust_string() -> String;
-	    fn make_swift_string() -> String;
-	}
+        fn make_rust_string() -> String;
+        fn make_swift_string() -> String;
+    }
 }
 ```
 
@@ -49,11 +50,14 @@ func make_swift_string() -> String {
 
 ## RustString
 
-It is technically possible for us to automatically convert owned Rust `std::string::String`s into Swift `String`s,
-but we do not do this because it would require copying the Rust `std::string::String` bytes to a new `Swift` allocation.
+There is no zero-copy way to construct a Swift `String` from a byte buffer.
 
-This is because there is no way to construct a Swift `String` without copying.
+`swift-bridge` seeks to avoid unnecessary allocations, so when passing a Rust `std::string::String` to Swift we create
+a `RustString` on the Swift side instead of automatically allocating a new Swift `String`.
+Users can then create a Swift `String` themselves by calling the `RustString.toString()` method.
 
-`swift-bridge` seeks to avoid unnecessary allocations, so instead of performing an implicit allocation we pass a `RustString` type from Rust to Swift.
+Since a Rust `std::string::String` is `Send+Sync`, a Swift `RustString` is `Sendable` so long as the swift code does not
+violate Rust's ownership and aliasing rules.
 
-The `RustString`'s `.toString()` method can then be called on the Swift side to get a Swift `String`.
+`RustString`, `RustStringRef` and `RustStringRefMut` implement Swift's `Sendable` protocol.
+This is thread safe so long as users uphold the rules in the [Safety](../../safety/README.md) chapter.

--- a/crates/swift-bridge-build/src/generate_core/rust_string.swift
+++ b/crates/swift-bridge-build/src/generate_core/rust_string.swift
@@ -11,6 +11,25 @@ public class RustString: RustStringRefMut {
         }
     }
 }
+
+/// Tested in:
+///   SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift:
+///  `func testSwiftCallRustReturnsResultString()`
+extension RustString: Error {}
+
+// THREAD SAFETY: `RustString`, `RustStringRef` and `RustStringRefMut` are safe to send across threads as long as the
+// ownership and aliasing rules are followed.
+// This is because the underlying Rust `std::string::String`, `&str` and `&mut str` are all `Send+Sync`.
+// See the `Safety` chapter in the book for more information about memory and thread safety rules.
+//
+// For now we have implemented `Sendable` for `RustString`. If users need `RustStringRef` or `RustStringRefMut` to
+// implement `Sendable` then we can implement those as well.
+//
+// Tested in:
+//  `SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/SendableTests.swift`
+//  `func testSendableRustString()`
+extension RustString: @unchecked Sendable {}
+
 extension RustString {
     public convenience init() {
         self.init(ptr: __swift_bridge__$RustString$new())
@@ -47,9 +66,6 @@ extension RustStringRef {
         __swift_bridge__$RustString$trim(ptr)
     }
 }
-/// exercised in SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift:
-///   - see `func testSwiftCallRustReturnsResultString`
-extension RustStringRef: Error {}
 extension RustString: Vectorizable {
     public static func vecOfSelfNew() -> UnsafeMutableRawPointer {
         __swift_bridge__$Vec_RustString$new()

--- a/crates/swift-bridge-macro/tests/ui/incorrect-argument-type.stderr
+++ b/crates/swift-bridge-macro/tests/ui/incorrect-argument-type.stderr
@@ -5,7 +5,7 @@ error[E0308]: mismatched types
    | ----------------------- arguments to this function are incorrect
 ...
 15 |         fn fn1(arg: &str);
-   |                ^^^^^^^^^ expected `u16`, found `&str`
+   |                ^^^^^^ expected `u16`, found `&str`
    |
 note: function defined here
   --> tests/ui/incorrect-argument-type.rs:24:4

--- a/crates/swift-bridge-macro/tests/ui/incorrect-return-type.stderr
+++ b/crates/swift-bridge-macro/tests/ui/incorrect-return-type.stderr
@@ -8,8 +8,7 @@ error[E0308]: mismatched types
    |  ______________-
 10 | |
 11 | |         #[swift_bridge(rust_name = "some_function")]
-12 | |         fn fn1() -> SomeType;
-   | |_____________________________- expected due to this
+   | |_________- expected due to this
    |
    = note: this error originates in the attribute macro `swift_bridge::bridge` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -25,8 +24,7 @@ error[E0308]: mismatched types
 11 | |         #[swift_bridge(rust_name = "some_function")]
 12 | |         fn fn1() -> SomeType;
 13 | |         #[swift_bridge(rust_name = "another_function")]
-14 | |         fn fn2() -> SomeType;
-   | |_____________________________- expected due to this
+   | |_________- expected due to this
    |
    = note: expected struct `SomeType`
                 found enum `Option<SomeType>`


### PR DESCRIPTION
This commit adds an `@unchecked Sendable` protocol implementation for
the `RustString` class, as well as documentation explaining that this is
thread safe so long as the rules outlined in the book's `Safety` chapter
are upheld.

The following code now compiles:
```swift
let rustString = RustString("hello world")

Thread.detachNewThread {
    XCTAssertEqual(rustString.len(), 11)
}
```