### PR TITLE
Generate Hashable conformance for Copy types

### DIFF
--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OpaqueRustStructTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OpaqueRustStructTests.swift
@@ -136,7 +136,48 @@ class OpaqueRustStructTests: XCTestCase {
             var table: [RustHashableType: String] = [:]
             table[val1] = "hello"
             table[val2] = "world"
-
+            
+            //Should not be overwritten
+            if let element = table[val1] {
+                XCTAssertEqual(element, "hello")
+            }else {
+                XCTFail()
+            }
+            if let element = table[val2] {
+                XCTAssertEqual(element, "world")
+            }else {
+                XCTFail()
+            }
+        }
+    }
+    
+    func testOpaqueRustCopyTypeImplHashable() throws {
+        XCTContext.runActivity(named: "Same hash value"){
+            _ in
+            let val1 = RustCopyHashableType(10)
+            let val2 = RustCopyHashableType(10)
+            
+            var table: [RustCopyHashableType: String] = [:]
+            table[val1] = "hello"
+            table[val2] = "world"
+            
+            //Should be overwritten.
+            if let element = table[val1] {
+                XCTAssertEqual(element, "world")
+            }else {
+                XCTFail()
+            }
+        }
+        
+        XCTContext.runActivity(named: "Not same hash value"){
+            _ in
+            let val1 = RustCopyHashableType(10)
+            let val2 = RustCopyHashableType(100)
+            
+            var table: [RustCopyHashableType: String] = [:]
+            table[val1] = "hello"
+            table[val2] = "world"
+            
             //Should not be overwritten
             if let element = table[val1] {
                 XCTAssertEqual(element, "hello")

--- a/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_c_header.rs
@@ -270,12 +270,6 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                     if ty.attributes.declare_generic {
                         continue;
                     }
-                    if ty.attributes.hashable {
-                        let ty_name = ty.ty_name_ident();
-                        let hash_ty =
-                            format!("uint64_t __swift_bridge__${}$_hash(void* self);", ty_name);
-                        header += &hash_ty;
-                    }
                     let ty_name = ty.to_string();
 
                     if let Some(copy) = ty.attributes.copy {
@@ -332,6 +326,19 @@ typedef struct {option_ffi_name} {{ bool is_some; {ffi_name} val; }} {option_ffi
                         bookkeeping.includes.insert("stdbool.h");
                         header += &equal_ty;
                         header += "\n";
+                    }
+                    if ty.attributes.hashable {
+                        let ty_name = ty.ty_name_ident();
+                        let hash_ty = format!(
+                            "uint64_t __swift_bridge__${ty_name}$_hash({c_ffi_type}* self);",
+                            ty_name = ty_name,
+                            c_ffi_type = if ty.attributes.copy.is_some() {
+                                &ty.ffi_repr_name_string()
+                            } else {
+                                "void"
+                            },
+                        );
+                        header += &hash_ty;
                     }
 
                     // TODO: Support Vec<OpaqueCopyType>. Add codegen tests and then

--- a/crates/swift-integration-tests/build.rs
+++ b/crates/swift-integration-tests/build.rs
@@ -1,11 +1,11 @@
-use std::path::PathBuf;
+use std::{ffi::OsStr, path::PathBuf};
 
 fn main() {
     let out_dir = "../../SwiftRustIntegrationTestRunner/Generated";
     let out_dir = PathBuf::from(out_dir);
 
     let mut bridges = vec![];
-    read_files_recursive(PathBuf::from("src"), &mut bridges);
+    read_files_recursive(PathBuf::from("src"), &mut bridges, OsStr::new("rs"));
 
     for path in &bridges {
         println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
@@ -15,12 +15,12 @@ fn main() {
         .write_all_concatenated(out_dir, env!("CARGO_PKG_NAME"));
 }
 
-fn read_files_recursive(dir: PathBuf, files: &mut Vec<PathBuf>) {
+fn read_files_recursive(dir: PathBuf, files: &mut Vec<PathBuf>, extension: &OsStr) {
     for entry in std::fs::read_dir(dir).unwrap() {
         let path = entry.unwrap().path();
         if path.is_dir() {
-            read_files_recursive(path, files);
-        } else {
+            read_files_recursive(path, files, extension);
+        } else if path.extension() == Some(extension) {
             files.push(path)
         }
     }

--- a/crates/swift-integration-tests/src/opaque_type_attributes/hashable.rs
+++ b/crates/swift-integration-tests/src/opaque_type_attributes/hashable.rs
@@ -6,6 +6,12 @@ mod ffi {
 
         #[swift_bridge(init)]
         fn new(num: isize) -> RustHashableType;
+
+        #[swift_bridge(Copy(4), Hashable, Equatable)]
+        type RustCopyHashableType;
+
+        #[swift_bridge(init)]
+        fn new(num: i32) -> RustCopyHashableType;
     }
 }
 
@@ -15,5 +21,14 @@ pub struct RustHashableType(isize);
 impl RustHashableType {
     fn new(num: isize) -> Self {
         RustHashableType(num)
+    }
+}
+
+#[derive(Clone, Copy, Hash, PartialEq)]
+pub struct RustCopyHashableType(i32);
+
+impl RustCopyHashableType {
+    fn new(num: i32) -> Self {
+        Self(num)
     }
 }


### PR DESCRIPTION
This commit fixes #334, adding support for generating a Hashable conformance for Copy types. 
  
For example, the following is now possible: 
  
```rust
extern "Rust" {
    #[swift_bridge(Copy(8), Equatable, Hashable)]
    type T;
}
``` 