### PR TITLE
Fix using multiple `Copy + Sendable` types

### DIFF
--- a/crates/swift-bridge-ir/src/codegen/generate_swift.rs
+++ b/crates/swift-bridge-ir/src/codegen/generate_swift.rs
@@ -141,7 +141,7 @@ impl SwiftBridgeModule {
 
                             if ty.attributes.sendable {
                                 let ty_name = ty.ty_name_string();
-                                swift += &format!("extension {ty_name}: @unchecked Sendable {{}}")
+                                swift += &format!("extension {ty_name}: @unchecked Sendable {{}}\n")
                             }
                         }
                         HostLang::Swift => {

--- a/crates/swift-bridge-macro/tests/ui/invalid-copy-attribute.stderr
+++ b/crates/swift-bridge-macro/tests/ui/invalid-copy-attribute.stderr
@@ -7,19 +7,19 @@ error[E0308]: mismatched types
 error[E0277]: the trait bound `DoesNotImplementCopy: Copy` is not satisfied
  --> tests/ui/invalid-copy-attribute.rs:8:14
   |
-8 |         type DoesNotImplementCopy;
-  |              ^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `DoesNotImplementCopy`
-  |
-note: required by a bound in `assert_copy`
- --> $WORKSPACE/src/copy_support.rs
-  |
-  | pub fn assert_copy<T: Copy>() {}
-  |                       ^^^^ required by this bound in `assert_copy`
+ 8 |         type DoesNotImplementCopy;
+   |              ^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `DoesNotImplementCopy`
+   |
+note: required by a bound in `swift_bridge::copy_support::assert_copy`
+  --> $WORKSPACE/src/copy_support.rs
+   |
+ 1 | pub fn assert_copy<T: Copy>() {}
+   |                       ^^^^ required by this bound in `assert_copy`
 help: consider annotating `DoesNotImplementCopy` with `#[derive(Copy)]`
-  |
-15+ #[derive(Copy)]
-16| pub struct DoesNotImplementCopy(u8);
-  |
+   |
+15 + #[derive(Copy)]
+16 | pub struct DoesNotImplementCopy(u8);
+   |
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
  --> tests/ui/invalid-copy-attribute.rs:4:1

--- a/crates/swift-bridge-macro/tests/ui/invalid-copy-attribute.stderr
+++ b/crates/swift-bridge-macro/tests/ui/invalid-copy-attribute.stderr
@@ -5,15 +5,15 @@ error[E0308]: mismatched types
    |              ^^^^^^^^^^^^^^^^^ expected an array with a size of 9, found one with a size of 10
 
 error[E0277]: the trait bound `DoesNotImplementCopy: Copy` is not satisfied
- --> tests/ui/invalid-copy-attribute.rs:8:14
-  |
+  --> tests/ui/invalid-copy-attribute.rs:8:14
+   |
  8 |         type DoesNotImplementCopy;
    |              ^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `DoesNotImplementCopy`
    |
 note: required by a bound in `swift_bridge::copy_support::assert_copy`
   --> $WORKSPACE/src/copy_support.rs
    |
- 1 | pub fn assert_copy<T: Copy>() {}
+   | pub fn assert_copy<T: Copy>() {}
    |                       ^^^^ required by this bound in `assert_copy`
 help: consider annotating `DoesNotImplementCopy` with `#[derive(Copy)]`
    |

--- a/crates/swift-integration-tests/src/sendable_attribute.rs
+++ b/crates/swift-integration-tests/src/sendable_attribute.rs
@@ -55,6 +55,6 @@ const TEST_SENDABLE_SWIFT_TYPE_SEND_SYNC: () = {
 /// causing a compile-time error.
 /// This compile-time error was reported in https://github.com/chinedufn/swift-bridge/issues/335
 #[derive(Copy, Clone)]
-pub struct RustCopySendableOne(u8);
+pub struct RustCopySendableOne(#[allow(unused)] u8);
 #[derive(Copy, Clone)]
-pub struct RustCopySendableTwo(u32);
+pub struct RustCopySendableTwo(#[allow(unused)] u32);

--- a/crates/swift-integration-tests/src/sendable_attribute.rs
+++ b/crates/swift-integration-tests/src/sendable_attribute.rs
@@ -14,6 +14,11 @@ mod ffi {
         // If our code compiles then we know there weren't any duplicate codegen.
         #[swift_bridge(Sendable)]
         type AnotherSendableRustType;
+
+        #[swift_bridge(Copy(1), Sendable)]
+        type RustCopySendableOne;
+        #[swift_bridge(Copy(4), Sendable)]
+        type RustCopySendableTwo;
     }
 
     extern "Swift" {
@@ -45,3 +50,11 @@ const fn assert_send_sync<T: Send + Sync>() {}
 const TEST_SENDABLE_SWIFT_TYPE_SEND_SYNC: () = {
     assert_send_sync::<ffi::SendableSwiftType>();
 };
+
+/// We expose two `#[swift_bridge(Copy(N), Sendable)]` types to confirm that we can do so without
+/// causing a compile-time error.
+/// This compile-time error was reported in https://github.com/chinedufn/swift-bridge/issues/335
+#[derive(Copy, Clone)]
+pub struct RustCopySendableOne(u8);
+#[derive(Copy, Clone)]
+pub struct RustCopySendableTwo(u32);


### PR DESCRIPTION
This commit fixes a bug where creating multiple `#[swift_bridge(Copy(4), Sendable)]`
types would fail to compile.

This was due to a missing newline in the generatod code.

As of this commit, the following will now compile properly:

```rust
#[derive(Clone, Copy)]
struct T1(u32);

#[derive(Clone, Copy)]
struct T2(u32);

#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        #[swift_bridge(Copy(4), Sendable)]
        type T1;
        #[swift_bridge(Copy(4), Sendable)]
        type T2;
    }
}
```

Closes https://github.com/chinedufn/swift-bridge/issues/335