### PR TITLE
Document pull request guidelines

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -35,3 +35,4 @@
     - [Code Generation](./contributing/internal-design/codegen/README.md)
   - [Adding support for a signature](./contributing/adding-support-for-a-signature/README.md)
   - [Adding compile time errors](./contributing/adding-compile-time-errors/README.md)
+  - [Pull Requests](./contributing/pull-requests/README.md)

--- a/book/src/contributing/pull-requests/README.md
+++ b/book/src/contributing/pull-requests/README.md
@@ -1,0 +1,39 @@
+# Pull Requests
+
+Before merging a pull request into the master branch, a maintainer will rebase
+it into a single commit.
+
+The commit's title and body come from the pull request's title and body.
+
+The pull request title serves to summarize the changes. Titles should use 50 or fewer characters.
+
+Pull request bodies should provide a more detailed description of what the pull request has
+achieved.
+When applicable, include a code snippet that demonstrates what the pull request enables.
+
+Here is an example pull request title and body:
+````
+Support Swift Option<String> and Option<&str>
+
+This commit adds support for passing `Option<String>` to and from
+`extern "Swift"` functions, as well as for passing `Option<&str>` to
+extern "Swift" functions.
+
+For example, the following is now possible:
+
+```rust
+#[swift_bridge::bridge]
+mod ffi {
+    extern "Swift" {
+        fn opt_string_function(arg: Option<String>) -> Option<String>;
+
+        fn opt_str_function(arg: Option<&str>);
+    }
+}
+```
+
+Note that you can not yet return `-> Option<&str>` from Swift.
+
+This is an uncommon use case, so we're waiting until someone actually
+needs it.
+````


### PR DESCRIPTION
This commit adds documentation explaining our expectations of pull
request titles and bodies.
