### PR TITLE
Clarify why linking to issues is not enough

### DIFF
--- a/book/src/contributing/pull-requests/README.md
+++ b/book/src/contributing/pull-requests/README.md
@@ -37,3 +37,13 @@ Note that you can not yet return `-> Option<&str>` from Swift.
 This is an uncommon use case, so we're waiting until someone actually
 needs it.
 ````
+
+Producing comprehensive pull request bodies makes it easier for other maintainers to understand
+a changeset. For example, when a new contributor wishes to work on a feature we often point
+them to old commits that addressed a similar feature.
+Having a clear commit title and message makes it easier for the new contributor to understand the commit.
+
+We also reuse the pull requests' examples when producing release notes.
+
+It is insufficient for a pull request to only link to a GitHub issue without also
+including a clear title and body because we want maintainers to be able to easily peruse commits while offline.

--- a/crates/swift-bridge-macro/tests/ui/incorrect-return-type.stderr
+++ b/crates/swift-bridge-macro/tests/ui/incorrect-return-type.stderr
@@ -1,10 +1,10 @@
 error[E0308]: mismatched types
   --> tests/ui/incorrect-return-type.rs:6:1
    |
-6  |   #[swift_bridge::bridge]
+ 6 |   #[swift_bridge::bridge]
    |   ^^^^^^^^^^^^^^^^^^^^^^^ expected `SomeType`, found `&SomeType`
 ...
-9  |           type SomeType;
+ 9 |           type SomeType;
    |  ______________-
 10 | |
 11 | |         #[swift_bridge(rust_name = "some_function")]
@@ -15,10 +15,10 @@ error[E0308]: mismatched types
 error[E0308]: mismatched types
   --> tests/ui/incorrect-return-type.rs:6:1
    |
-6  |   #[swift_bridge::bridge]
+ 6 |   #[swift_bridge::bridge]
    |   ^^^^^^^^^^^^^^^^^^^^^^^ expected `SomeType`, found `Option<SomeType>`
 ...
-9  |           type SomeType;
+ 9 |           type SomeType;
    |  ______________-
 10 | |
 11 | |         #[swift_bridge(rust_name = "some_function")]
@@ -31,5 +31,5 @@ error[E0308]: mismatched types
    = note: this error originates in the attribute macro `swift_bridge::bridge` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using `Option::expect` to unwrap the `Option<SomeType>` value, panicking if the value is an `Option::None`
    |
-6  | #[swift_bridge::bridge].expect("REASON")
+ 6 | #[swift_bridge::bridge].expect("REASON")
    |                        +++++++++++++++++


### PR DESCRIPTION
This commit adds documentation to the internal book explaining why pull
requests should not simply link to existing issues.

The pull request must also include enough information for a maintainer
to understand the change while working offline.
