### PR TITLE
Add Swift 6 compatibility for async function code generation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,8 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
+        # NOTE: As explained in `README.md`, the minimum supported Swift version is currently `6.0`.
+        #   If supporting `5.0` ever becomes difficult we can consider removing it from the test matrix.
         swift_version: ['5.0', '6.0']
 
     steps:
@@ -64,7 +66,8 @@ jobs:
         with:
           toolchain: stable
 
-      # Xcode 16.2 provides Swift 5.9+ and Swift 6.0
+      # Xcode 16.2 provides Swift 5.9+ and Swift 6.0, which we make use of in the test matrix above.
+      #  If we need to support other versions in the future we can change this Xcode version.
       - name: Set Xcode version
         run: sudo xcode-select -s /Applications/Xcode_16.2.app
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,9 @@ jobs:
   integration-test:
     runs-on: macos-14
     timeout-minutes: 30
+    strategy:
+      matrix:
+        swift_version: ['5.0', '6.0']
 
     steps:
       - uses: actions/checkout@v2
@@ -61,15 +64,15 @@ jobs:
         with:
           toolchain: stable
 
-      # Xcode 16.2 provides Swift 5.9+ which is required for typed throws.
+      # Xcode 16.2 provides Swift 5.9+ and Swift 6.0
       - name: Set Xcode version
         run: sudo xcode-select -s /Applications/Xcode_16.2.app
 
       - name: Add rust targets
         run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
-      - name: Run integration tests
-        run: ./test-swift-rust-integration.sh
+      - name: Run integration tests (Swift ${{ matrix.swift_version }})
+        run: SWIFT_VERSION=${{ matrix.swift_version }} ./test-swift-rust-integration.sh
 
   build-examples:
     runs-on: macos-14

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OpaqueRustStructTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/OpaqueRustStructTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import SwiftRustIntegrationTestRunner
 
+@MainActor
 class OpaqueRustStructTests: XCTestCase {
     
     override func setUpWithError() throws {

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/ResultTests.swift
@@ -7,6 +7,7 @@
 import XCTest
 @testable import SwiftRustIntegrationTestRunner
 
+@MainActor
 class ResultTests: XCTestCase {
     /// Verify that we can pass a Result<String, String> from Swift -> Rust
     func testSwiftCallRustResultString() throws {

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/StringTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/StringTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import SwiftRustIntegrationTestRunner
 
+@MainActor
 class StringTests: XCTestCase {
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.

--- a/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/TupleTests.swift
+++ b/SwiftRustIntegrationTestRunner/SwiftRustIntegrationTestRunnerTests/TupleTests.swift
@@ -11,6 +11,7 @@ import XCTest
 @testable import SwiftRustIntegrationTestRunner
 
 /// Tests tuples
+@MainActor
 final class TupleTest: XCTestCase {
     /// Verify that we can pass and return Rust tuples.
     func testSwiftCallsRustTuples() throws {

--- a/crates/swift-bridge-build/src/generate_core.rs
+++ b/crates/swift-bridge-build/src/generate_core.rs
@@ -72,6 +72,7 @@ fn core_swift() -> String {
 
     core_swift += &generic_freer();
     core_swift += &generic_copy_type_ffi_repr();
+    core_swift += &unchecked_sendable_wrapper();
 
     core_swift
 }
@@ -210,5 +211,16 @@ protocol SwiftBridgeGenericFreer {
 fn generic_copy_type_ffi_repr() -> &'static str {
     r#"
 protocol SwiftBridgeGenericCopyTypeFfiRepr {}
+"#
+}
+
+/// A wrapper type that makes any value Sendable for use in Task closures.
+/// This is used for FFI callbacks that we know are safe to use across Task boundaries.
+fn unchecked_sendable_wrapper() -> &'static str {
+    r#"
+public struct __private__UncheckedSendable<T>: @unchecked Sendable {
+    public let value: T
+    @inlinable public init(_ value: T) { self.value = value }
+}
 "#
 }

--- a/crates/swift-bridge-ir/src/codegen/codegen_tests/async_function.rs
+++ b/crates/swift-bridge-ir/src/codegen/codegen_tests/async_function.rs
@@ -1100,7 +1100,9 @@ mod extern_swift_async_function_no_return {
             r#"
 @_cdecl("__swift_bridge__$some_function")
 func __swift_bridge__some_function (_ callbackWrapper: UnsafeMutableRawPointer, _ callback: @escaping @convention(c) (UnsafeMutableRawPointer) -> Void) {
+    let __callbacks = __private__UncheckedSendable((callbackWrapper, callback))
     Task {
+        let (callbackWrapper, callback) = __callbacks.value
         let _ = await some_function()
         callback(callbackWrapper)
     }
@@ -1176,7 +1178,9 @@ mod extern_swift_async_function_returns_u8 {
             r#"
 @_cdecl("__swift_bridge__$some_function")
 func __swift_bridge__some_function (_ callbackWrapper: UnsafeMutableRawPointer, _ callback: @escaping @convention(c) (UnsafeMutableRawPointer, UInt8) -> Void) {
+    let __callbacks = __private__UncheckedSendable((callbackWrapper, callback))
     Task {
+        let (callbackWrapper, callback) = __callbacks.value
         let result = await some_function()
         callback(callbackWrapper, result)
     }
@@ -1252,7 +1256,9 @@ mod extern_swift_async_function_with_args {
             r#"
 @_cdecl("__swift_bridge__$some_function")
 func __swift_bridge__some_function (_ callbackWrapper: UnsafeMutableRawPointer, _ callback: @escaping @convention(c) (UnsafeMutableRawPointer, UInt8) -> Void, _ arg: UInt32) {
+    let __callbacks = __private__UncheckedSendable((callbackWrapper, callback))
     Task {
+        let (callbackWrapper, callback) = __callbacks.value
         let result = await some_function(arg: arg)
         callback(callbackWrapper, result)
     }
@@ -1338,7 +1344,9 @@ mod extern_swift_async_function_returns_result {
             r#"
 @_cdecl("__swift_bridge__$some_function")
 func __swift_bridge__some_function (_ callbackWrapper: UnsafeMutableRawPointer, _ onSuccess: @escaping @convention(c) (UnsafeMutableRawPointer, UInt32) -> Void, _ onError: @escaping @convention(c) (UnsafeMutableRawPointer, UnsafeMutableRawPointer) -> Void) {
+    let __callbacks = __private__UncheckedSendable((callbackWrapper, onSuccess, onError))
     Task {
+        let (callbackWrapper, onSuccess, onError) = __callbacks.value
         do {
             let result = try await some_function()
             onSuccess(callbackWrapper, result)
@@ -1432,7 +1440,9 @@ mod extern_swift_async_function_returns_result_with_args {
             r#"
 @_cdecl("__swift_bridge__$some_function")
 func __swift_bridge__some_function (_ callbackWrapper: UnsafeMutableRawPointer, _ onSuccess: @escaping @convention(c) (UnsafeMutableRawPointer, UInt32) -> Void, _ onError: @escaping @convention(c) (UnsafeMutableRawPointer, UnsafeMutableRawPointer) -> Void, _ arg: UInt32) {
+    let __callbacks = __private__UncheckedSendable((callbackWrapper, onSuccess, onError))
     Task {
+        let (callbackWrapper, onSuccess, onError) = __callbacks.value
         do {
             let result = try await some_function(arg: arg)
             onSuccess(callbackWrapper, result)
@@ -1524,7 +1534,9 @@ mod extern_swift_async_function_returns_result_void_ok {
             r#"
 @_cdecl("__swift_bridge__$some_function")
 func __swift_bridge__some_function (_ callbackWrapper: UnsafeMutableRawPointer, _ onSuccess: @escaping @convention(c) (UnsafeMutableRawPointer) -> Void, _ onError: @escaping @convention(c) (UnsafeMutableRawPointer, UnsafeMutableRawPointer) -> Void) {
+    let __callbacks = __private__UncheckedSendable((callbackWrapper, onSuccess, onError))
     Task {
+        let (callbackWrapper, onSuccess, onError) = __callbacks.value
         do {
             _ = try await some_function()
             onSuccess(callbackWrapper)
@@ -1617,7 +1629,9 @@ mod extern_swift_async_function_returns_result_void_ok_with_args {
             r#"
 @_cdecl("__swift_bridge__$some_function")
 func __swift_bridge__some_function (_ callbackWrapper: UnsafeMutableRawPointer, _ onSuccess: @escaping @convention(c) (UnsafeMutableRawPointer) -> Void, _ onError: @escaping @convention(c) (UnsafeMutableRawPointer, UnsafeMutableRawPointer) -> Void, _ arg: UInt32) {
+    let __callbacks = __private__UncheckedSendable((callbackWrapper, onSuccess, onError))
     Task {
+        let (callbackWrapper, onSuccess, onError) = __callbacks.value
         do {
             _ = try await some_function(arg: arg)
             onSuccess(callbackWrapper)
@@ -1699,7 +1713,9 @@ mod extern_swift_async_method_with_self {
             r#"
 @_cdecl("__swift_bridge__$SomeType$some_method")
 func __swift_bridge__SomeType_some_method (_ callbackWrapper: UnsafeMutableRawPointer, _ callback: @escaping @convention(c) (UnsafeMutableRawPointer, UInt32) -> Void, _ this: UnsafeMutableRawPointer) {
+    let __captures = __private__UncheckedSendable((callbackWrapper, callback, this))
     Task {
+        let (callbackWrapper, callback, this) = __captures.value
         let result = await Unmanaged<SomeType>.fromOpaque(this).takeUnretainedValue().some_method()
         callback(callbackWrapper, result)
     }
@@ -1776,7 +1792,9 @@ mod extern_swift_async_method_with_self_and_args {
             r#"
 @_cdecl("__swift_bridge__$SomeType$some_method")
 func __swift_bridge__SomeType_some_method (_ callbackWrapper: UnsafeMutableRawPointer, _ callback: @escaping @convention(c) (UnsafeMutableRawPointer, UInt8) -> Void, _ this: UnsafeMutableRawPointer, _ arg1: UInt32, _ arg2: UnsafeMutableRawPointer) {
+    let __captures = __private__UncheckedSendable((callbackWrapper, callback, this))
     Task {
+        let (callbackWrapper, callback, this) = __captures.value
         let result = await Unmanaged<SomeType>.fromOpaque(this).takeUnretainedValue().some_method(arg1: arg1, arg2: RustString(ptr: arg2))
         callback(callbackWrapper, result)
     }
@@ -1863,7 +1881,9 @@ mod extern_swift_async_method_with_self_returns_result {
             r#"
 @_cdecl("__swift_bridge__$SomeType$some_method")
 func __swift_bridge__SomeType_some_method (_ callbackWrapper: UnsafeMutableRawPointer, _ onSuccess: @escaping @convention(c) (UnsafeMutableRawPointer, UInt32) -> Void, _ onError: @escaping @convention(c) (UnsafeMutableRawPointer, UnsafeMutableRawPointer) -> Void, _ this: UnsafeMutableRawPointer, _ arg: UInt32) {
+    let __captures = __private__UncheckedSendable((callbackWrapper, onSuccess, onError, this))
     Task {
+        let (callbackWrapper, onSuccess, onError, this) = __captures.value
         do {
             let result = try await Unmanaged<SomeType>.fromOpaque(this).takeUnretainedValue().some_method(arg: arg)
             onSuccess(callbackWrapper, result)
@@ -1952,7 +1972,9 @@ mod extern_swift_async_method_with_self_returns_result_void_ok {
             r#"
 @_cdecl("__swift_bridge__$SomeType$some_method")
 func __swift_bridge__SomeType_some_method (_ callbackWrapper: UnsafeMutableRawPointer, _ onSuccess: @escaping @convention(c) (UnsafeMutableRawPointer) -> Void, _ onError: @escaping @convention(c) (UnsafeMutableRawPointer, UnsafeMutableRawPointer) -> Void, _ this: UnsafeMutableRawPointer) {
+    let __captures = __private__UncheckedSendable((callbackWrapper, onSuccess, onError, this))
     Task {
+        let (callbackWrapper, onSuccess, onError, this) = __captures.value
         do {
             _ = try await Unmanaged<SomeType>.fromOpaque(this).takeUnretainedValue().some_method()
             onSuccess(callbackWrapper)

--- a/test-swift-rust-integration.sh
+++ b/test-swift-rust-integration.sh
@@ -21,7 +21,15 @@ touch ./Generated/SwiftBridgeCore.{h,swift}
 mkdir -p ./Generated/swift-integration-tests
 touch ./Generated/swift-integration-tests/swift-integration-tests.{h,swift}
 
+# Build settings override (e.g., SWIFT_VERSION=6.0)
+EXTRA_BUILD_SETTINGS=""
+if [ -n "$SWIFT_VERSION" ]; then
+  EXTRA_BUILD_SETTINGS="SWIFT_VERSION=$SWIFT_VERSION"
+  echo "Using Swift version: $SWIFT_VERSION"
+fi
+
 xcodebuild \
   -project SwiftRustIntegrationTestRunner.xcodeproj \
   -scheme SwiftRustIntegrationTestRunner \
-  clean test
+  clean test \
+  $EXTRA_BUILD_SETTINGS


### PR DESCRIPTION
Add Swift 6 strict concurrency compatibility for generated async function code
Add `@MainActor` to test classes using XCTContext.runActivity
Add CI matrix to test with both Swift 5.0 and Swift 6.0